### PR TITLE
The threshold reporter now includes the console reporter output

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -293,6 +293,7 @@ exports.html = function (emitter, options) {
 exports.threshold = function (emitter, options) {
     
     options.dest = {};
+    exports.console(emitter, options);
     exports.coverage(emitter, options);
 
     emitter.on('test', function (test, err) {


### PR DESCRIPTION
This removes the need to have the npm test script call `make test-cov` as they can be combined into a single run.
