### PR TITLE
Make Lab a global

### DIFF
--- a/lib/execute.js
+++ b/lib/execute.js
@@ -8,13 +8,10 @@ var Domain = require('domain');
 var Async = require('async');
 var Reporter = require('./reporter');
 
-// intentionally declared as a global
-Lab = require('./');
-
-
 // Declare internals
 
 var internals = {};
+var Lab = require('./');
 
 
 exports.execute = function () {
@@ -23,17 +20,19 @@ exports.execute = function () {
 
     // Process command line
 
-    var argv = Optimist.usage('Usage: lab [-r reporter] [-o filename] [-t threshold] [-m timeout] [-e NODE_ENV] [-s] [-g global]')
+    var argv = Optimist.usage('Usage: lab [-r reporter] [-o filename] [-t threshold] [-m timeout] [-e NODE_ENV] [-s] [-g global] [-G use_global]')
         .default('r', 'console')
         .default('t', 100)
         .default('m', 2000)
         .default('e', 'test')
         .default('g', true)
+        .default('G', false)
         .argv;
+
+    if (argv.G) global.Lab = Lab;
 
     if (argv.h || argv.help) {
         Optimist.showHelp();
-        delete Lab;
         process.exit(0);
     }
 
@@ -158,8 +157,7 @@ exports.execute = function () {
     function (err) {
 
         var leaks = null;
-        // cleanup our global
-        delete Lab;
+        if (argv.G) delete global.Lab;
         if (options.global) {
             leaks = internals.detectLeaks();
         }


### PR DESCRIPTION
The reason for this is to allow a globally installed lab to run tests. 

As the module works now, if a user were to globally install lab to get the binary in their path and locally install lab in a project to be able to require it in their unit tests, the globally installed lab binary will not work and the user would be forced to run the lab binary from their local installation (i.e. ./node_modules/lab/bin/lab).

To see this for yourself, follow these steps
- create a new directory
- install lab globally `npm i -g lab`
- install lab locally `npm i lab`
- put the following code in test/example.js

``` js
var Lab = require('lab');

Lab.experiment('example', function () {
  Lab.test('does this run?', function (done) {
    Lab.expect(1).to.equal(1);
    done();
  });
});
```
- run the command `lab` and see there are 0 tests completed
- run the command `./node_modules/lab/bin/lab` and see that 1 test is completed

After this pull request, end users would be able to use the lab binary from either a locally or globally installed copy to run their tests. Locally installed copies of lab will continue to work exactly as they do currently, but in addition to that users can omit requiring lab in their tests and use a globally installed binary as well.
