### PR TITLE
Allow code coverage to more than /lib dir

### DIFF
--- a/lib/execute.js
+++ b/lib/execute.js
@@ -37,8 +37,8 @@ exports.execute = function () {
     }
 
     if (['html', 'coverage', 'threshold'].indexOf(argv.r) !== -1) {
-        var currentDir = Path.join(process.cwd(), 'lib').replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
-        var filterPattern = '^' + currentDir + '.*$';
+        var currentDir = process.cwd().replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+        var filterPattern = '^' + currentDir + '\\/((?!node_modules|test).).*$';
         var blanketOptions = {
             pattern: new RegExp(filterPattern, 'i'),
             onlyCwd: true,


### PR DESCRIPTION
Currently lab only provides code coverage through blanket to cwd/lib. Although I know you don't plan on making Lab a test framework for general consumption, allowing flexible folder and file structure is a good thing.

With my changes, it removes the requirement of using the lib folder, and does a negative lookahead check for node_modules and test directories. I have tested the changes with Hapi and Catbox, both of which perform as expected.

Thanks for your consideration.
