### PR TITLE
make argument parsing more verbose

### DIFF
--- a/lib/execute.js
+++ b/lib/execute.js
@@ -20,13 +20,31 @@ exports.execute = function () {
 
     // Process command line
 
-    var argv = Optimist.usage('Usage: lab [-r reporter] [-o filename] [-t threshold] [-m timeout] [-e NODE_ENV] [-s] [-g global] [-G use_global]')
+    var argv = Optimist.usage('Usage: lab [options] [path]')
+        .alias('r', 'reporter')
         .default('r', 'console')
+        .describe('r', 'reporter module [console, html, coverage, threshold]')
+        .alias('t', 'threshold')
         .default('t', 100)
+        .describe('t', 'code coverage threshold in percentage')
+        .alias('m', 'timeout')
         .default('m', 2000)
+        .describe('m', 'timeout for each test in milliseconds')
+        .alias('e', 'environment')
         .default('e', 'test')
+        .describe('e', 'value to set NODE_ENV before tests')
+        .alias('g', 'global-leaks')
         .default('g', true)
+        .describe('g', 'detect global variable leaks')
+        .alias('G', 'use-global')
         .default('G', false)
+        .describe('G', 'export Lab as a global')
+        .alias('s', 'silence')
+        .default('s', false)
+        .describe('s', 'silence test output')
+        .alias('o', 'output')
+        .describe('o', 'file path to write test results')
+        .boolean(['g', 'G', 's'])
         .argv;
 
     if (argv.G) global.Lab = Lab;


### PR DESCRIPTION
This greatly enhances the --help output of the lab binary, as well as allows for long option names (i.e. `--threshold 80`), and correctly parsing boolean flags

It does come with the side effect that to turn off global leak detection, instead of providing `-g 0` as before, you would provide `-g0` (with no space), `--no-g` or `--no-global-leaks`
