### PR TITLE
Fixed branch checking

### DIFF
--- a/lib/execute.js
+++ b/lib/execute.js
@@ -75,7 +75,9 @@ exports.execute = function (skipTraverse) {
         var blanketOptions = {
             pattern: new RegExp(filterPattern, 'i'),
             onlyCwd: true,
-            branchTracking: true
+            "data-cover-flags": {
+                branchTracking: true   
+            }
         };
 
         var blanket = require('blanket')(blanketOptions);


### PR DESCRIPTION
The blanket configuration for branch tracking requires a different configuration. This should fix the branch checking.
