### PR TITLE
update chai dependency, fix deprecation warning in chai

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ internals.titles = [];
 exports.experiments = [internals.current];
 exports.index = {};
 
-Chai.Assertion.includeStack = true;                                     // Show the stack where where the issue occurs
+Chai.config.includeStack = true;                                     // Show the stack where where the issue occurs
 
 
 exports.experiment = exports.describe = function (title, fn) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lab",
   "description": "Test utility",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "author": "Eran Hammer <eran@hueniverse.com> (http://hueniverse.com)",
   "contributors": [],
   "repository": "git://github.com/spumko/lab",
@@ -15,7 +15,7 @@
   "dependencies": {
     "optimist": "0.6.x",
     "blanket": "1.1.x",
-    "chai": "1.9.x",
+    "chai": "^1.9.1",
     "handlebars": "1.2.x",
     "async": "0.2.x",
     "diff": "1.0.x"


### PR DESCRIPTION
Chai published version 1.9.1 today which deprecated setting includeStack on the Assertion property, so we were getting warnings in the console. This fixes that.
