### PR TITLE
fixed failure count so that non-zero exit code is return on test failure

### DIFF
--- a/lib/execute.js
+++ b/lib/execute.js
@@ -192,7 +192,7 @@ exports.execute = function (skipTraverse) {
         ],
         function (err, results) {
 
-            failures += results.failures;
+            failures += results[1];
             if (err) {
                 failures++;
             }


### PR DESCRIPTION
current version of lab returns zero exit code if a test fails
