### PR TITLE
track failure count correctly

### DIFF
--- a/lib/execute.js
+++ b/lib/execute.js
@@ -192,7 +192,7 @@ exports.execute = function (skipTraverse) {
         ],
         function (err, results) {
 
-            failures += results.failures;
+            failures += results[1];
             if (err) {
                 failures++;
             }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lab",
   "description": "Test utility",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "Eran Hammer <eran@hueniverse.com> (http://hueniverse.com)",
   "contributors": [],
   "repository": "git://github.com/spumko/lab",


### PR DESCRIPTION
The `results` passed to the final callback is an array, not an object, so it has no `failures` property. This bug was causing failures to end up being `NaN` and making it so lab never exited with a code other than 0.
