### PR TITLE
Support passing 'done' as async callback

### DIFF
--- a/lib/execute.js
+++ b/lib/execute.js
@@ -482,14 +482,14 @@ internals.protect = function (item, isTimed, callback) {
 
         item.fn.call(null, function (err) {
 
-          var errorFree = err === null || typeof err === 'undefined';
-          if (errorFree) {
-            return finish(null, 'done');
-          }
+            var errorFree = err === null || typeof err === 'undefined';
+            if (errorFree) {
+                return finish(null, 'done');
+            }
 
-          var e = err instanceof Error ? err :
-            new Error('done() called with non-Error first parameter: ' + err);
-          finish(e, 'error');
+            var e = err instanceof Error ? err :
+                new Error('done() called with non-Error first parameter: ' + err);
+            finish(e, 'error');
         });
     });
 };


### PR DESCRIPTION
The done function should operate like a standard node callback where the first parameter is interpreted as a potential error.

This would save keystrokes when testing the happy path for an async function. Here's an example from the supertest docs:

```
Here's an example with mocha, note how you can pass done straight to any of the .expect() calls:

describe('GET /users', function(){
  it('respond with json', function(done){
    request(app)
      .get('/user')
      .set('Accept', 'application/json')
      .expect('Content-Type', /json/)
      .expect(200, done);
  })
})
```
