### PR TITLE
updated double call check on done to provide error to internals.output

### DIFF
--- a/lib/execute.js
+++ b/lib/execute.js
@@ -454,7 +454,7 @@ internals.protect = function (item, isTimed, callback) {
         }
 
         if (cause === 'done' && causes.done) {
-            internals.output('Callback called twice in test:', item.title);
+            internals.output(new Error('Callback called twice in test: ' + item.title));
             return;
         }
 
@@ -495,5 +495,5 @@ internals.protect = function (item, isTimed, callback) {
 
 internals.output = function (err) {
 
-    process.stderr.write(err.message + '\n' + err.stack);
+    process.stderr.write(err.message + '\n' + err.stack + '\n');
 };


### PR DESCRIPTION
When `done` was called twice inside of a test, `undefined` was being printed twice to stderr because internals.output expects an error object and the condition checking for `done` being called twice was providing a string. Thus, the tester has no idea. Ask me how I know... 

I also added an extra carriage return at end of internals.output which keeps output clean when running tests in an automated tool such as [nodemon](https://github.com/remy/nodemon).

Fixes #87
