### PR TITLE
Prints execution time for each test on console

### DIFF
--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -63,7 +63,8 @@ internals.Reporter.prototype.test = function (test) {
         }
         else {
             var symbol = test.skipped || test.todo ? this.colors.magenta('-') : this.colors.green('\u2714');
-            this.print(spacer + symbol + ' ' + this.colors.gray(test.id + ') ' + test.relativeTitle) + '\n');
+            this.print(spacer + symbol + ' ' + this.colors.gray(test.id + ') ' + test.relativeTitle +
+                ' (' + test.duration + ' ms)') + '\n');
         }
     }
 };


### PR DESCRIPTION
 Prints execution time for each test on console when `-v` (verbose) options is passed.
Its good to have execution time for each test. One of the things is it helps in identifying performance issues if any.
