### PR TITLE
Add chai optional message to output

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -45,6 +45,7 @@ internals.colors = function (forceColor) {
         'gray': 90,
         'red': 31,
         'green': 32,
+        'yellow': 33,
         'magenta': 35,
         'redBg': 41,
         'greenBg': 42

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -90,6 +90,7 @@ internals.Reporter.prototype.end = function (notebook) {
     var greenBg = this.colors.greenBg;
     var magenta = this.colors.magenta;
     var gray = this.colors.gray;
+    var yellow = this.colors.yellow;
 
     // Tests
 
@@ -146,6 +147,10 @@ internals.Reporter.prototype.end = function (notebook) {
                             output += lines[l];
                         }
                     }
+                }
+
+                if (message) {
+                    output += '\n\n      ' + yellow(message);
                 }
 
                 output += '\n\n';


### PR DESCRIPTION
I haven't found a good way to split the message when a custom message is set in chai but providing the custom message seems important so here it is.
