### PR TITLE
simplify package.json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ test:
 Alternatively you may want to leverage npm's scripts section of your package.json:
 ```json
 "scripts": {
-    "test": "node ./node_modules/lab/bin/lab"
+    "test": "lab"
   }
 ```
 


### PR DESCRIPTION
Just a quick one-line readme change. Specifying node and the full path is unnecessary when using scripts in package.json. Npm adds the `node_modules/.bin` directory to your path for you, so this way is much much shorter
