### PR TITLE
Add `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+examples
+images
+test
+.travis.yml
+Makefile


### PR DESCRIPTION
Avoid including unnecessary files in the npm package.
This helps to reduce the file size of the package and allows for faster
downloads.
