### PR TITLE
Fix #99: ignore custom globals in leak detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ keep the execution engine as simple as possible, and not try to build an extensi
 - `-g` - only run tests matching the given pattern which is internally compiled to a RegExp.
 - `-G` - export `Lab` as a global. Defaults to disabled. If you enable this, make sure to remove any `require('lab')` lines from your tests.
 - `-i` - only run the test for the given identifier.
+- `-I` - ignore a list of globals for the leak detection (comma separated)
 - `-l` - disables global variable leak detection.
 - `-m` - individual tests timeout in milliseconds, defaults to 2 seconds.
 - `-o` - file to write the report to, otherwise sent to stdout.

--- a/lib/execute.js
+++ b/lib/execute.js
@@ -99,6 +99,9 @@ exports.execute = function (skipTraverse) {
         .describe('v', 'verbose test output')
         .boolean('v')
 
+        .alias('I', 'ignore-globals')
+        .describe('I', 'ignore a list of globals for the leak detection (comma separated)')
+
         .argv;
 
     if (argv.G) {
@@ -171,7 +174,7 @@ exports.execute = function (skipTraverse) {
         var notebook = {
             ms: Date.now() - startTime,
             tests: report.tests,
-            leaks: !argv.l ? Leaks.detect() : undefined,
+            leaks: !argv.l ? Leaks.detect(argv.I ? argv.I.trim().split(',') : []) : undefined,
             coverage: testCoverage ? Coverage.analyze(report.tests) : undefined
         };
 

--- a/lib/leaks.js
+++ b/lib/leaks.js
@@ -6,7 +6,7 @@
 var internals = {};
 
 
-exports.detect = function () {
+exports.detect = function (customGlobals) {
 
     var leaks = [];
     var knownGlobals = [
@@ -22,6 +22,12 @@ exports.detect = function () {
         global,
         constructor
     ];
+
+    customGlobals.forEach(function(custom) {
+        if (global[custom]) {
+            knownGlobals.push(global[custom]);
+        }
+    });
 
     if (global.gc) {
         knownGlobals.push(global.gc);


### PR DESCRIPTION
Not sure about the CLI argument name but otherwise this works.
