### PR TITLE
Display Test duration once completed (even with errors)

### DIFF
--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -99,9 +99,9 @@ internals.Reporter.prototype.end = function (notebook) {
         return !!test.err;
     });
 
-    var output = ' ';
+    var output = 'Test duration: ' + notebook.ms + ' ms\n\n';
     if (!failures.length) {
-        output += green(notebook.tests.length + ' tests complete') + ' (' + notebook.ms + ' ms)\n\n';
+        output += green(notebook.tests.length + ' tests complete') + '\n\n';
     }
     else {
         output += red(failures.length + ' of ' + notebook.tests.length + ' tests failed:') + '\n\n';


### PR DESCRIPTION
In case when even a single test fails duration is not printed on console. 
This PR prints the duration before the success/failure result is printed. 
