### PR TITLE
Repeat failure count at end of errors listing.

### DIFF
--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -183,6 +183,7 @@ internals.Reporter.prototype.end = function (notebook) {
             output += '\n';
         }
 
+        output += red(failures.length + ' of ' + notebook.tests.length + ' tests failed:') + '\n\n';
         output += '\n';
     }
 


### PR DESCRIPTION
Use case: We have some covered code and introduce a feature we know will cause regression errors. We run lab under `nodemon` and want to burn down the error count as we fix the regressions.

This is just a minimally invasive fix, 'editor inheritance' of the existing failure count report.
