### PR TITLE
Default to test environment

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -22,7 +22,7 @@ internals.defaults = {
     // coverageExclude: ['node_modules', 'test'],
     colors: null,                                   // true, false, null (based on tty)
     dry: false,
-    environment: null,
+    environment: 'test',
     // flat: false,
     grep: null,
     ids: [],

--- a/test/cli.js
+++ b/test/cli.js
@@ -70,7 +70,7 @@ describe('CLI', function () {
 
             expect(code).to.equal(0);
             expect(signal).to.not.exist;
-            expect(output).to.contain('8 tests complete');
+            expect(output).to.contain('9 tests complete');
             done();
         });
     });
@@ -313,6 +313,30 @@ describe('CLI', function () {
             expect(signal).to.not.exist;
             expect(output).to.contain('2 tests complete');
             expect(output).to.contain('Coverage: 0.00%');
+            done();
+        });
+    });
+
+    it('defaults NODE_ENV environment variable to test', function (done) {
+
+        var cli = ChildProcess.spawn('node', [labPath, 'test/cli/environment.js']);
+        var output = '';
+
+        cli.stdout.on('data', function (data) {
+
+            output += data;
+        });
+
+        cli.stderr.on('data', function (data) {
+
+            expect(data).to.not.exist;
+        });
+
+        cli.on('close', function (code, signal) {
+
+            expect(code).to.equal(0);
+            expect(signal).to.not.exist;
+            expect(output).to.contain('1 tests complete');
             done();
         });
     });

--- a/test/cli/environment.js
+++ b/test/cli/environment.js
@@ -1,0 +1,22 @@
+// Load modules
+
+var _Lab = require('../../test_runner');
+
+
+// Test shortcuts
+
+var lab = exports.lab = _Lab.script();
+var describe = lab.describe;
+var it = lab.it;
+var expect = _Lab.expect;
+
+var env = process.env.NODE_ENV;
+
+describe('Test CLI', function () {
+
+    it('Node Environment defaults to test', function (done) {
+
+        expect(env).to.equal('test');
+        done();
+    });
+});

--- a/test/runner.js
+++ b/test/runner.js
@@ -44,6 +44,52 @@ describe('Runner', function () {
         });
     });
 
+    it('won\'t set the environment when passing null', { parallel: false }, function (done) {
+
+        var orig = process.env.NODE_ENV;
+
+        var script = Lab.script();
+        script.experiment('test', function () {
+
+            script.test('works', function (finished) {
+
+                Lab.expect(process.env.NODE_ENV).to.equal(orig);
+                process.env.NODE_ENV = orig;
+                finished();
+            });
+        });
+
+        Lab.execute(script, { environment: null }, null, function (err, notebook) {
+
+            expect(notebook.tests).to.have.length(1);
+            expect(notebook.failures).to.equal(0);
+            done();
+        });
+    });
+
+    it('the environment defaults to test', { parallel: false }, function (done) {
+
+        var orig = process.env.NODE_ENV;
+
+        var script = Lab.script();
+        script.experiment('test', function () {
+
+            script.test('works', function (finished) {
+
+                Lab.expect(process.env.NODE_ENV).to.equal('test');
+                process.env.NODE_ENV = orig;
+                finished();
+            });
+        });
+
+        Lab.execute(script, {}, null, function (err, notebook) {
+
+            expect(notebook.tests).to.have.length(1);
+            expect(notebook.failures).to.equal(0);
+            done();
+        });
+    });
+
     it('filters on ids', function (done) {
 
         var script = Lab.script();


### PR DESCRIPTION
Closes #148

This was a regression from the previous version of lab where it defaulted to 'test': https://github.com/hapijs/lab/blob/9d90c29c66932b3f0f0d973f02d1eadfd663c497/lib/execute.js#L120
