### PR TITLE
Add lines covered and not covered to the CC report

### DIFF
--- a/lib/reporters/html/report.html
+++ b/lib/reporters/html/report.html
@@ -164,9 +164,19 @@
         color: #b6b6b6;
     }
 
-    .stats .hits,
-    .stats .misses {
-        display: none;
+    .stats .hits::before {
+        content: '(';
+        color: #b6b6b6;
+    }
+
+    .stats .hits::after {
+        content: ' Covered';
+        color: #b6b6b6;
+    }
+
+    .stats .misses::after {
+        content: ' Not Covered)';
+        color: #b6b6b6;
     }
 
     .high {


### PR DESCRIPTION
This PR updated the HTML CC report to visually show the lines covered and not covered overall and on a per file bases.

For example:

![screenshot 2014-08-23 00 34 42](https://cloud.githubusercontent.com/assets/1672480/4019947/2838f344-2a98-11e4-9e4f-69517809f189.png)
