### PR TITLE
Support multiple tests from the command line.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -211,7 +211,7 @@ internals.options = function () {
     }
 
     var options = {
-        paths: argv._ ? [argv._] : ['test']
+        paths: argv._ ? [].concat(argv._) : ['test']
     };
 
     var keys = ['coverage', 'colors', 'dry', 'environment', 'flat', 'grep', 'globals', 'timeout', 'parallel', 'reporter', 'threshold'];

--- a/test/cli.js
+++ b/test/cli.js
@@ -50,6 +50,30 @@ describe('CLI', function () {
         });
     });
 
+    it('runs multiple tests from the command line', function (done) {
+
+        var cli = ChildProcess.spawn('node', [labPath, 'test/cli/simple.js', 'test/cli/simple2.js', '-m', '2000']);
+        var output = '';
+
+        cli.stdout.on('data', function (data) {
+
+            output += data;
+        });
+
+        cli.stderr.on('data', function (data) {
+
+            expect(data).to.not.exist;
+        });
+
+        cli.on('close', function (code, signal) {
+
+            expect(code).to.equal(0);
+            expect(signal).to.not.exist;
+            expect(output).to.contain('4 tests complete');
+            done();
+        });
+    });
+
     it('runs a directory of tests from the command line', function (done) {
 
         var cli = ChildProcess.spawn('node', [labPath, 'test/cli']);


### PR DESCRIPTION
It seems that support for multiple test files specified on the command line was lost in the [switch from optimist to bossy](https://github.com/hapijs/lab/commit/f5e42d8bb3123f3ade95bac521b81e266d9df7a8). Without this feature, tools like [gulp-lab](https://github.com/otodockal/gulp-lab) are broken. This change adds a test case for this scenario and restore the ability to specify multiple test scripts from the command line.
