### PR TITLE
Fix #209: omit undefined options

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -216,7 +216,7 @@ internals.options = function () {
 
     var keys = ['coverage', 'colors', 'dry', 'environment', 'flat', 'grep', 'globals', 'timeout', 'parallel', 'reporter', 'threshold'];
     for (var i = 0, il = keys.length; i < il; ++i) {
-        if (argv.hasOwnProperty(keys[i])) {
+        if (argv.hasOwnProperty(keys[i]) && argv[keys[i]] !== undefined) {
             options[keys[i]] = argv[keys[i]];
         }
     }


### PR DESCRIPTION
Undefined options out of bossy are all set to `undefined`, just checking for `hasOwnProperty` is not enough.
Since everything was defined, all timeouts were overridden to `undefined`, so nothing was waiting for the tests to finish, hence the even loop was dry, which caused the #209 premature exit.
Hope that was clear :)
