### PR TITLE
Handle uncaught exceptions in test deps.

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -187,6 +187,28 @@ internals.executeExperiments = function (experiments, state, skip, callback) {
 };
 
 
+internals.run = function (item, finish) {
+
+    var onError = function (err) {
+
+        finish(err, 'error');
+    };
+
+    var domain = Domain.createDomain();
+    domain.on('error', onError);
+
+    setImmediate(function () {
+
+        domain.enter();
+        item.fn.call(null, function (err) {
+
+            domain.exit();
+            finish(err, 'done');
+        });
+    });
+};
+
+
 internals.executeDeps = function (deps, state, callback) {
 
     if (!deps) {
@@ -211,7 +233,7 @@ internals.executeDeps = function (deps, state, callback) {
             }, timeout);
         }
 
-        dep.fn.call(null, finish);
+        internals.run(dep, finish);
     }, callback);
 };
 
@@ -373,23 +395,7 @@ internals.protect = function (item, state, callback) {
         }, ms);
     }
 
-    var onError = function (err) {
-
-        finish(err, 'error');
-    };
-
-    var domain = Domain.createDomain();
-    domain.on('error', onError);
-
-    setImmediate(function () {
-
-        domain.enter();
-        item.fn.call(null, function (err) {
-
-            domain.exit();
-            finish(err, 'done');
-        });
-    });
+    internals.run(item, finish);
 };
 
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -277,6 +277,39 @@ describe('Runner', function () {
         });
     });
 
+    it('fails on uncaught exception in before', function (done) {
+
+        var steps = [];
+        var script = Lab.script({ schedule: false });
+        script.experiment('test', function () {
+
+            script.before(function () {
+
+                steps.push('before');
+                throw new Error('oops');
+            });
+
+            script.test('works', function (finished) {
+
+                steps.push('test');
+                finished();
+            });
+
+            script.after(function (finished) {
+
+                steps.push('after');
+                finished();
+            });
+        });
+
+        Lab.execute(script, null, null, function (err, notebook) {
+
+            expect(notebook.tests[0].err).to.equal('\'before\' action failed');
+            expect(steps).to.deep.equal(['before']);
+            done();
+        });
+    });
+
     it('skips tests on failed beforeEach', function (done) {
 
         var steps = [];


### PR DESCRIPTION
Uncaught exceptions in test deps cause the test runner to exit unexpectedly without an explanation of what failed. This change causes test deps to be executed in their own domains so that uncaught exceptions can be reported as test failures (including a failure message).
