### PR TITLE
Add Map, Set, and WeakSet to the Harmony globals and improve testing

### DIFF
--- a/lib/leaks.js
+++ b/lib/leaks.js
@@ -51,7 +51,6 @@ exports.detect = function (customGlobals) {
         undefined: true,
         Date: true,
         SyntaxError: true,
-        WeakSet: true,
         String: true,
         eval: true,
         parseFloat: true,
@@ -93,8 +92,20 @@ exports.detect = function (customGlobals) {
         whitelist.Symbol = true;
     }
 
+    if (global.Map) {
+        whitelist.Map = true;
+    }
+
     if (global.WeakMap) {
         whitelist.WeakMap = true;
+    }
+
+    if (global.Set) {
+        whitelist.Set = true;
+    }
+
+    if (global.WeakSet) {
+        whitelist.WeakSet = true;
     }
 
     if (global.DTRACE_HTTP_SERVER_RESPONSE) {


### PR DESCRIPTION
The `Map` and `Set` Harmony globals were not being tracked at all. Also moved `WeakSet` with the other Harmony globals. Modified the tests to not overwrite existing globals with 1 and then delete them. Tested on stable, latest, and 0.12 development branch.
