### PR TITLE
[CLI] Skip scripts which export null

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -88,6 +88,11 @@ internals.traverse = function (paths, options) {
             global._labScriptRun = false;
             file = Path.resolve(file);
             var pkg = require(file);
+
+            if (!pkg) {
+                return;
+            }
+
             if (pkg.lab &&
                 pkg.lab._root) {
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -537,6 +537,28 @@ describe('CLI', function () {
         });
     });
 
+    it('ignores scripts which export null', function (done) {
+
+        var cli = ChildProcess.spawn('node', [labPath, 'test/cli_no_exports/nullExports.js']);
+        var output = '';
+
+        cli.stdout.on('data', function (data) {
+
+            output += data;
+        });
+
+        cli.stderr.on('data', function (data) {
+
+            expect(data).to.not.exist();
+        });
+
+        cli.once('close', function (code, signal) {
+            expect(code).to.equal(0);
+            expect(signal).to.not.exist();
+            done();
+        });
+    });
+
     it('displays error message when an unknown reporter is specified', function (done) {
 
         var cli = ChildProcess.spawn('node', [labPath, '-r', 'unknown']);

--- a/test/cli.js
+++ b/test/cli.js
@@ -553,6 +553,7 @@ describe('CLI', function () {
         });
 
         cli.once('close', function (code, signal) {
+            
             expect(code).to.equal(0);
             expect(signal).to.not.exist();
             expect(output).to.contain('0 tests complete');

--- a/test/cli.js
+++ b/test/cli.js
@@ -555,6 +555,7 @@ describe('CLI', function () {
         cli.once('close', function (code, signal) {
             expect(code).to.equal(0);
             expect(signal).to.not.exist();
+            expect(output).to.contain('0 tests complete');
             done();
         });
     });

--- a/test/cli_no_exports/nullExports.js
+++ b/test/cli_no_exports/nullExports.js
@@ -1,0 +1,3 @@
+module.exports = (function() {
+	// Do nothing
+});


### PR DESCRIPTION
When a script inside the test folder exports null, lab throws at line 91 of `lib/cli.js`