### PR TITLE
Avoid double timeout on before/after

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -224,23 +224,8 @@ internals.executeDeps = function (deps, state, callback) {
 
     Items.serial(deps, function (dep, next) {
 
-        var finish = function (err) {
-
-            clearTimeout(timeoutId);
-            next(err);
-        };
-
-        var timeout = dep.options.timeout || state.options['context-timeout'];
-        if (timeout) {
-            var timeoutId = setTimeout(function () {
-
-                var error = new Error('Timed out (' + timeout + 'ms) - ' + dep.title);
-                error.timeout = true;
-                finish(error);
-            }, timeout);
-        }
-
-        internals.protect(dep, state, finish);
+        dep.options.timeout = dep.options.timeout || state.options['context-timeout'];
+        internals.protect(dep, state, next);
     }, callback);
 };
 
@@ -396,7 +381,7 @@ internals.protect = function (item, state, callback) {
     if (ms) {
         var timeoutId = setTimeout(function () {
 
-            var error = new Error('Timed out (' + ms + 'ms)');
+            var error = new Error('Timed out (' + ms + 'ms) - ' + item.title);
             error.timeout = true;
             finish(error, 'timeout');
         }, ms);

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -278,7 +278,7 @@ describe('Reporter', function () {
                     expect(err).to.not.exist();
                     expect(code).to.equal(1);
                     var result = output.replace(/\/[\/\w]+\.js\:\d+\:\d+/g, '<trace>');
-                    expect(result).to.match(/^\n  \n  x\n\nFailed tests:\n\n  1\) test works:\n\n      Timed out \(\d+ms\)\n\n\n\n1 of 1 tests failed\nTest duration: \d+ ms\nNo global variable leaks detected\n\n$/);
+                    expect(result).to.match(/^\n  \n  x\n\nFailed tests:\n\n  1\) test works:\n\n      Timed out \(\d+ms\) - test works\n\n\n\n1 of 1 tests failed\nTest duration: \d+ ms\nNo global variable leaks detected\n\n$/);
                     done();
                 });
             });


### PR DESCRIPTION
Since you introduced internals.protect for before/after, that extra timeout is not needed, it even causes weird failures.
