### PR TITLE
make linter pluggable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ global manipulation. Our goal with **lab** is to keep the execution engine as si
 - `-i`, `--id` - only run the test for the given identifier (or identifiers range).
 - `-I`, `--ignore` - ignore a list of globals for the leak detection (comma separated)
 - `-l`, `--leaks` - disables global variable leak detection.
-- `-L`, `--lint` - run linting rules using `eslint`.  Disabled by default.
+- `-L`, `--lint` - run linting rules using linter.  Disabled by default.
 - `-m`, `--timeout` - individual tests timeout in milliseconds (zero disables timeout). Defaults to 2 seconds.
 - `-M`, `--context-timeout` - default timeouts for before, after, beforeEach and afterEach in milliseconds. Disabled by default.
+- `-n`, `--linter` - specify linting program; default is `eslint`.
 - `-o`, `--output` - file to write the report to, otherwise sent to stdout.
 - `-p`, `--parallel` - sets parallel execution as default test option. Defaults to serial execution.
 - `-r`, `--reporter` - the reporter used to generate the test results. Defaults to `console`. Options are:

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -178,6 +178,13 @@ internals.options = function () {
             type: 'boolean',
             description: 'enable linting'
         },
+        linter: {
+            alias: 'n',
+            type: 'string',
+            description: 'linter to use',
+            default: 'eslint',
+            valid: ['eslint', 'jslint']
+        },
         timeout: {
             alias: 'm',
             type: 'number',
@@ -244,7 +251,7 @@ internals.options = function () {
         require('./').assertions = options.assert;
     }
 
-    var keys = ['coverage', 'colors', 'dry', 'environment', 'flat', 'grep', 'globals', 'timeout', 'parallel', 'reporter', 'threshold', 'context-timeout', 'sourcemaps', 'lint'];
+    var keys = ['coverage', 'colors', 'dry', 'environment', 'flat', 'grep', 'globals', 'timeout', 'parallel', 'reporter', 'threshold', 'context-timeout', 'sourcemaps', 'lint', 'linter'];
     for (var i = 0, il = keys.length; i < il; ++i) {
         if (argv.hasOwnProperty(keys[i]) && argv[keys[i]] !== undefined) {
             options[keys[i]] = argv[keys[i]];

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -5,15 +5,20 @@ var ChildProcess = require('child_process');
 
 // Declare internals
 
-var internals = {};
+var internals = {
+    linters: {
+        eslint: __dirname + '/linters/eslint/index.js',
+        jslint: __dirname + '/linters/jslint/index.js'
+    }
+};
 
 
 exports.lint = function (settings, callback) {
 
-    var child = ChildProcess.fork(__dirname + '/linters/eslint/index.js', { cwd: settings.lintingPath });
+    var child = ChildProcess.fork(internals.linters[settings.linter],
+                                  { cwd: settings.lintingPath });
     child.once('message', function (message) {
-
         child.kill();
-        return callback(null, { eslint: message });
+        return callback(null, { lint: message });
     });
 };

--- a/lib/linters/jslint/index.js
+++ b/lib/linters/jslint/index.js
@@ -10,6 +10,7 @@ var Nodejslint = require('jslint');
 var internals = {};
 
 var formatErrors = function (error) {
+
     return {
         line: error.line,
         severity: 'ERROR',
@@ -18,10 +19,11 @@ var formatErrors = function (error) {
 };
 
 var formatFile = function (file) {
-  return {
-    filename: file[0],
-    errors: file[1].map(formatErrors)
-  };
+
+    return {
+        filename: file[0],
+        errors: file[1].map(formatErrors)
+    };
 };
 
 exports.lint = function () {
@@ -34,8 +36,8 @@ exports.lint = function () {
         },
         collector: true
     }, function (err, report) {
-        var formatted = report.map(formatFile);
 
+        var formatted = report.map(formatFile);
         process.send(formatted);
     });
 };

--- a/lib/linters/jslint/index.js
+++ b/lib/linters/jslint/index.js
@@ -1,0 +1,43 @@
+// Load modules
+
+var Fs = require('fs');
+var Path = require('path');
+var Nodejslint = require('jslint');
+
+
+// Declare internals
+
+var internals = {};
+
+var formatErrors = function (error) {
+    return {
+        line: error.line,
+        severity: 'ERROR',
+        message: error.reason
+    };
+};
+
+var formatFile = function (file) {
+  return {
+    filename: file[0],
+    errors: file[1].map(formatErrors)
+  };
+};
+
+exports.lint = function () {
+
+    // synchronously lint
+    Nodejslint.runMain({
+        edition: 'latest',
+        argv: {
+            remain: ['**/*.js']
+        },
+        collector: true
+    }, function (err, report) {
+        var formatted = report.map(formatFile);
+
+        process.send(formatted);
+    });
+};
+
+exports.lint();

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -276,7 +276,7 @@ internals.Reporter.prototype.end = function (notebook) {
         output += 'Linting results:';
 
         var hasErrors = false;
-        lint.eslint.forEach(function (entry) {
+        lint.lint.forEach(function (entry) {
 
             // Don't show anything if there aren't issues
             if (!entry.errors || !entry.errors.length) {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "eslint": "0.8.x",
     "hoek": "2.x.x"
   },
+  "optionalDependencies": {
+    "jslint": "0.7.x"
+  },
   "devDependencies": {
     "code": "1.x.x"
   },

--- a/test/lint/jslint/basic/fail.js
+++ b/test/lint/jslint/basic/fail.js
@@ -1,0 +1,12 @@
+// Load modules
+
+
+// Declare internals
+
+var internals = {};
+
+
+exports.method = function (value) {
+
+	return value
+};

--- a/test/lint/jslint/clean/success.js
+++ b/test/lint/jslint/clean/success.js
@@ -1,0 +1,14 @@
+'use strict';
+
+// Load modules
+
+
+// Declare internals
+
+var internals = {};
+
+
+exports.method = function (value) {
+
+    return value;
+};

--- a/test/lint/jslint/with_config/fail.js
+++ b/test/lint/jslint/with_config/fail.js
@@ -1,0 +1,12 @@
+// Load modules
+
+
+// Declare internals
+
+var internals = {};
+
+
+exports.method = function (value) {
+
+	return value++;
+};

--- a/test/lint/jslint/with_config/jslint.conf
+++ b/test/lint/jslint/with_config/jslint.conf
@@ -1,0 +1,3 @@
+{
+  "plusplus": true
+}

--- a/test/linters.js
+++ b/test/linters.js
@@ -13,16 +13,16 @@ var describe = lab.describe;
 var it = lab.it;
 var expect = Code.expect;
 
-describe('Linters', function () {
+describe('Linters - eslint', function () {
 
     it('should lint files in a folder', function (done) {
 
         var path = Path.join(__dirname, 'lint', 'eslint', 'basic');
-        Linters.lint({ lintingPath: path }, function (err, result) {
+        Linters.lint({ lintingPath: path, linter: 'eslint' }, function (err, result) {
 
-            expect(result).to.include('eslint');
+            expect(result).to.include('lint');
 
-            var eslintResults = result.eslint;
+            var eslintResults = result.lint;
             expect(eslintResults).to.have.length(1);
 
             var checkedFile = eslintResults[0];
@@ -39,11 +39,11 @@ describe('Linters', function () {
     it('should use local configuration files', function (done) {
 
         var path = Path.join(__dirname, 'lint', 'eslint', 'with_config');
-        Linters.lint({ lintingPath: path }, function (err, result) {
+        Linters.lint({ lintingPath: path, linter: 'eslint' }, function (err, result) {
 
-            expect(result).to.include('eslint');
+            expect(result).to.include('lint');
 
-            var eslintResults = result.eslint;
+            var eslintResults = result.lint;
             expect(eslintResults).to.have.length(1);
 
             var checkedFile = eslintResults[0];
@@ -57,14 +57,74 @@ describe('Linters', function () {
     it('displays success message if no issues found', function (done) {
 
         var path = Path.join(__dirname, 'lint', 'eslint', 'clean');
-        Linters.lint({ lintingPath: path }, function (err, result) {
+        Linters.lint({ lintingPath: path, linter: 'eslint' }, function (err, result) {
 
-            expect(result.eslint).to.exist();
+            expect(result.lint).to.exist();
 
-            var eslintResults = result.eslint;
+            var eslintResults = result.lint;
             expect(eslintResults).to.have.length(1);
 
             var checkedFile = eslintResults[0];
+            expect(checkedFile.errors.length).to.equal(0);
+
+            done();
+        });
+    });
+});
+
+describe('Linters - jslint', function () {
+    it('should lint files in a folder', function (done) {
+
+        var path = Path.join(__dirname, 'lint', 'jslint', 'basic');
+        Linters.lint({ lintingPath: path, linter: 'jslint' }, function (err, result) {
+
+            expect(result).to.include('lint');
+
+            var jslintResults = result.lint;
+            expect(jslintResults).to.have.length(1);
+
+            var checkedFile = jslintResults[0];
+            expect(checkedFile).to.include({ filename: 'fail.js' });
+            expect(checkedFile.errors).to.deep.include(
+                { line: 11, severity: 'ERROR', message: 'Use spaces, not tabs.' },
+                { line: 11, severity: 'ERROR', message: 'Missing \'use strict\' statement.' },
+                { line: 11, severity: 'ERROR', message: 'Expected \';\' and instead saw \'}\'.' }
+            );
+
+            done();
+        });
+    });
+
+    it('should use local configuration files', function (done) {
+
+        var path = Path.join(__dirname, 'lint', 'jslint', 'with_config');
+        Linters.lint({ lintingPath: path, linter: 'jslint' }, function (err, result) {
+
+            expect(result).to.include('lint');
+
+            var jslintResults = result.lint;
+            expect(jslintResults).to.have.length(1);
+
+            var checkedFile = jslintResults[0];
+            expect(checkedFile).to.include({ filename: 'fail.js' });
+            expect(checkedFile.errors).to.deep.include({ line: 11, severity: 'ERROR', message: 'Use spaces, not tabs.' },
+                                                       { line: 11, severity: 'ERROR', message: 'Missing \'use strict\' statement.' });
+            expect(checkedFile.errors).to.not.deep.include({ line: 11, severity: 'ERROR', message: 'Unexpected \'++\'.' });
+            done();
+        });
+    });
+
+    it('displays success message if no issues found', function (done) {
+
+        var path = Path.join(__dirname, 'lint', 'jslint', 'clean');
+        Linters.lint({ lintingPath: path, linter: 'jslint' }, function (err, result) {
+
+            expect(result.lint).to.exist();
+
+            var jslintResults = result.lint;
+            expect(jslintResults).to.have.length(1);
+
+            var checkedFile = jslintResults[0];
             expect(checkedFile.errors.length).to.equal(0);
 
             done();

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -695,7 +695,7 @@ describe('Reporter', function () {
             var notebook = {
                 tests: [],
                 lint: {
-                    'eslint': [
+                    'lint': [
                         {
                             filename: 'test.js',
                             errors: [
@@ -723,7 +723,7 @@ describe('Reporter', function () {
             var notebook = {
                 tests: [],
                 lint: {
-                    'eslint': [
+                    'lint': [
                         {
                             filename: 'test.js',
                             errors: []
@@ -745,7 +745,7 @@ describe('Reporter', function () {
             var notebook = {
                 tests: [],
                 lint: {
-                    'eslint': [
+                    'lint': [
                         {
                             filename: 'test.js',
                             errors: null

--- a/test/runner.js
+++ b/test/runner.js
@@ -426,7 +426,7 @@ describe('Runner', function () {
             });
         });
 
-        Lab.report(script, { output: false, lint: 'eslint', lintingPath: 'test/lint' }, function (err, code, output) {
+        Lab.report(script, { output: false, lint: true, linter: 'eslint', lintingPath: 'test/lint' }, function (err, code, output) {
 
             expect(code).to.equal(0);
             expect(output).to.contain(['eslint/', 'semi']);


### PR DESCRIPTION
initial work: jslint runs but writes to stdout instead of returning data
update tests to use -L, -n to specify linter
style: remove dangling comma
spacing and intentation
rename linter output to "lint" from "eslint"
implement runner; add tests, fixtures for jslint
restore newlines
hoist helper functions
add jslint (w/version) as optional dependency