### PR TITLE
Properly support sourcemaps when using the transform option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ global manipulation. Our goal with **lab** is to keep the execution engine as si
 - `-s`, `--silence` - silence test output, defaults to false.
 - `-S`, `--sourcemaps` - enables sourcemap support for stack traces and code coverage, disabled by default.
 - `-t`, `--threshold` - minimum code test coverage percentage (sets `-c`), defaults to 100%.
-- `-T`, `--transform` - javascript file that exports an array of objects ie. `[ { ext: ".js", transform: function (content) { ... } } ]`. Note that if you use this option with -c (--coverage), then you must generate sourcemaps and pass sourcemaps option to get proper line numbers.
+- `-T`, `--transform` - javascript file that exports an array of objects ie. `[ { ext: ".js", transform: function (content, filename) { ... } } ]`. Note that if you use this option with -c (--coverage), then you must generate sourcemaps and pass sourcemaps option to get proper line numbers.
 - `-v`, `--verbose` - verbose test output, defaults to false.
 - `-a`, `--assert` - name of assert library to use.
 
@@ -205,9 +205,9 @@ To use source transforms, you must specify a file that tells Lab how to do the t
 var Babel = require('babel-core');
 
 module.exports = [
-  {ext: '.js', transform: function (content) {
+  {ext: '.js', transform: function (content, filename) {
 
-    var result = Babel.transform(content, { sourceMap: 'inline', ast: false});
+    var result = Babel.transform(content, { sourceMap: 'inline', filename: filename, sourceFileName: filename });
       return result.code;
   }}
 ];

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -38,7 +38,7 @@ exports.run = function () {
 
         if (settings.transform) {
             sourceMapOptions = {
-                retrieveFile: settings.coverage ? Coverage.retrieveFile : Transform.retrieveFile
+                retrieveFile: Transform.retrieveFile
             };
         }
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -34,7 +34,15 @@ exports.run = function () {
     }
 
     if (settings.sourcemaps) {
-        require('source-map-support').install();
+        var sourceMapOptions = {};
+
+        if (settings.transform) {
+            sourceMapOptions = {
+                retrieveFile: settings.coverage ? Coverage.retrieveFile : Transform.retrieveFile
+            };
+        }
+
+        require('source-map-support').install(sourceMapOptions);
     }
 
     var scripts = internals.traverse(settings.paths, settings);
@@ -224,14 +232,14 @@ internals.options = function () {
             description: 'silence test output'
         },
         sourcemaps: {
-            short: 'S',
+            alias: ['S', 'sourcemaps'],
             type: 'boolean',
             description: 'enable support for sourcemaps'
         },
         transform: {
             alias: ['T', 'transform'],
             type: 'string',
-            description: 'javascript file that exports an array of objects ie. [ { ext: ".js", transform: function (content) { ... } } ]'
+            description: 'javascript file that exports an array of objects ie. [ { ext: ".js", transform: function (content, filename) { ... } } ]'
         },
         threshold: {
             alias: 't',
@@ -296,7 +304,7 @@ internals.options = function () {
     if (options.transform) {
         var transform = require(Path.resolve(options.transform));
 
-        Hoek.assert(Array.isArray(transform), 'transform module must export an array of objects {ext: ".js", transform: null or function (content)}');
+        Hoek.assert(Array.isArray(transform), 'transform module must export an array of objects {ext: ".js", transform: null or function (content, filename)}');
 
         options.transform = transform;
     }

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -14,6 +14,7 @@ var sourceMapSupport = require('source-map-support');
 // Declare internals
 
 var internals = {
+    fileCache: {},
     origLoader: require.extensions['.js'],
     patterns: [],
     sources: {},
@@ -33,7 +34,9 @@ internals.transform = function (filename, content) {
         }
     });
 
-    return (typeof transform === 'function') ? transform(content) : content;
+    var relativeFilename = filename.substr(process.cwd().length + 1);
+    internals.fileCache[relativeFilename] = (typeof transform === 'function') ? transform(content, relativeFilename) : content;
+    return internals.fileCache[relativeFilename];
 };
 
 
@@ -49,6 +52,24 @@ internals.prime = function (extension) {
 
         return internals.origLoader(localModule, filename);
     };
+};
+
+
+exports.retrieveFile = function (path) {
+
+    if (internals.fileCache[path]) {
+        return internals.fileCache[path];
+    }
+
+    var contents = null;
+    try {
+        contents = Fs.readFileSync(path, 'utf8');
+    } catch (e) {
+        contents = null;
+    }
+    internals.fileCache[path] = contents;
+
+    return contents;
 };
 
 

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -64,9 +64,11 @@ exports.retrieveFile = function (path) {
     var contents = null;
     try {
         contents = Fs.readFileSync(path, 'utf8');
-    } catch (e) {
+    }
+    catch (e) {
         contents = null;
     }
+
     internals.fileCache[path] = contents;
 
     return contents;

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -9,12 +9,12 @@ var Fs = require('fs');
 var Path = require('path');
 var Esprima = require('esprima');
 var sourceMapSupport = require('source-map-support');
+var Transform = require('./transform');
 
 
 // Declare internals
 
 var internals = {
-    fileCache: {},
     origLoader: require.extensions['.js'],
     patterns: [],
     sources: {},
@@ -35,8 +35,8 @@ internals.transform = function (filename, content) {
     });
 
     var relativeFilename = filename.substr(process.cwd().length + 1);
-    internals.fileCache[relativeFilename] = (typeof transform === 'function') ? transform(content, relativeFilename) : content;
-    return internals.fileCache[relativeFilename];
+    Transform.fileCache[relativeFilename] = (typeof transform === 'function') ? transform(content, relativeFilename) : content;
+    return Transform.fileCache[relativeFilename];
 };
 
 
@@ -53,27 +53,6 @@ internals.prime = function (extension) {
         return internals.origLoader(localModule, filename);
     };
 };
-
-
-exports.retrieveFile = function (path) {
-
-    if (internals.fileCache[path]) {
-        return internals.fileCache[path];
-    }
-
-    var contents = null;
-    try {
-        contents = Fs.readFileSync(path, 'utf8');
-    }
-    catch (e) {
-        contents = null;
-    }
-
-    internals.fileCache[path] = contents;
-
-    return contents;
-};
-
 
 exports.instrument = function (options) {
 

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -4,9 +4,7 @@ var Fs = require('fs');
 
 // Declare internals
 
-var internals = {
-    fileCache: {}
-};
+var internals = {};
 
 internals.prime = function (extension, transform) {
 
@@ -17,11 +15,13 @@ internals.prime = function (extension, transform) {
 
         src = (typeof transform === 'function') ? transform(src, relativeFilename) : src;
 
-        internals.fileCache[relativeFilename] = src;
+        exports.fileCache[relativeFilename] = src;
 
         localModule._compile(src, filename);
     };
 };
+
+exports.fileCache = {};
 
 exports.install = function (settings) {
 
@@ -33,8 +33,8 @@ exports.install = function (settings) {
 
 exports.retrieveFile = function (path) {
 
-    if (internals.fileCache[path]) {
-        return internals.fileCache[path];
+    if (exports.fileCache[path]) {
+        return exports.fileCache[path];
     }
 
     var contents = null;
@@ -45,7 +45,7 @@ exports.retrieveFile = function (path) {
         contents = null;
     }
 
-    internals.fileCache[path] = contents;
+    exports.fileCache[path] = contents;
 
     return contents;
 };

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -8,28 +8,28 @@ var internals = {
     fileCache: {}
 };
 
+internals.prime = function (extension, transform) {
+
+    require.extensions[extension] = function (localModule, filename) {
+
+        var src = Fs.readFileSync(filename, 'utf8');
+        var relativeFilename = filename.substr(process.cwd().length + 1);
+
+        src = (typeof transform === 'function') ? transform(src, relativeFilename) : src;
+
+        internals.fileCache[relativeFilename] = src;
+
+        localModule._compile(src, filename);
+    };
+};
 
 exports.install = function (settings) {
 
     settings.transform.forEach(function (transform) {
 
-        require.extensions[transform.ext] = function (module, filename) {
-
-            var src = Fs.readFileSync(filename);
-
-            var relativeFilename = filename.substr(process.cwd().length + 1);
-
-            if (typeof transform.transform === 'function') {
-                src = transform.transform(src, relativeFilename);
-            }
-
-            internals.fileCache[relativeFilename] = src;
-
-            module._compile(src, filename);
-        };
+        internals.prime(transform.ext, transform.transform);
     });
 };
-
 
 exports.retrieveFile = function (path) {
 

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -40,9 +40,11 @@ exports.retrieveFile = function (path) {
     var contents = null;
     try {
         contents = Fs.readFileSync(path, 'utf8');
-    } catch (e) {
+    }
+    catch (e) {
         contents = null;
     }
+
     internals.fileCache[path] = contents;
 
     return contents;

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -4,7 +4,9 @@ var Fs = require('fs');
 
 // Declare internals
 
-var internals = {};
+var internals = {
+    fileCache: {}
+};
 
 
 exports.install = function (settings) {
@@ -15,11 +17,33 @@ exports.install = function (settings) {
 
             var src = Fs.readFileSync(filename);
 
+            var relativeFilename = filename.substr(process.cwd().length + 1);
+
             if (typeof transform.transform === 'function') {
-                src = transform.transform(src);
+                src = transform.transform(src, relativeFilename);
             }
+
+            internals.fileCache[relativeFilename] = src;
 
             module._compile(src, filename);
         };
     });
+};
+
+
+exports.retrieveFile = function (path) {
+
+    if (internals.fileCache[path]) {
+        return internals.fileCache[path];
+    }
+
+    var contents = null;
+    try {
+        contents = Fs.readFileSync(path, 'utf8');
+    } catch (e) {
+        contents = null;
+    }
+    internals.fileCache[path] = contents;
+
+    return contents;
 };

--- a/test/transform.js
+++ b/test/transform.js
@@ -59,20 +59,6 @@ describe('Transform', function () {
         done();
     });
 
-    it('unit tests coverage.retrieveFile', function (done) {
-
-        var content = Lab.coverage.retrieveFile('test/transform/exclude/lab-noexport.js');
-        expect(content).to.contain('// no code');
-
-        content = Lab.coverage.retrieveFile('test/transform/exclude/lab-noexport.js');
-        expect(content).to.contain('// no code');
-
-        content = Lab.coverage.retrieveFile('doesnotexist');
-        expect(content).to.equal(null);
-
-        done();
-    });
-
     it('unit tests transform.retrieveFile', function (done) {
 
         var content = Transform.retrieveFile('test/transform/exclude/lab-noexport.js');

--- a/test/transform.js
+++ b/test/transform.js
@@ -1,14 +1,31 @@
 // Load modules
 
+var Os = require('os');
 var Path = require('path');
 var Code = require('code');
 var _Lab = require('../test_runner');
 var Lab = require('../');
+var Transform = require('../lib/transform');
 
 
 // Declare internals
 
-var internals = {};
+var internals = {
+    transform: [
+        { ext: '.new', transform: function (content, filename) {
+
+            return content.replace('!NOCOMPILE!', 'value = value ');
+        }},
+        { ext: '.inl', transform: function (content, filename) {
+
+            if (Buffer.isBuffer(content)) {
+                content = content.toString();
+            }
+            return content.concat(Os.EOL).concat('//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIkB0cmFjZXVyL2dlbmVyYXRlZC9UZW1wbGF0ZVBhcnNlci8xIiwiLi93aGlsZS5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiO0FBQUEsQUFBSSxFQUFBLENBQUEsWUFBVyxVQUFvQixDQUFDO0FDS3BDLEFBQUksRUFBQSxDQUFBLFNBQVEsRUFBSSxHQUFDLENBQUM7QUFHbEIsTUFBTSxPQUFPLEVBQUksVUFBVSxLQUFJLENBQUc7QUFFOUIsUUFBTSxLQUFJLENBQUc7QUFDVCxRQUFJLEVBQUksTUFBSSxDQUFDO0VBQ2pCO0FBQUEsQUFFQSxPQUFPLE1BQUksQ0FBQztBQUNoQixDQUFDIiwic291cmNlc0NvbnRlbnQiOlsidmFyIF9fbW9kdWxlTmFtZSA9ICRfX3BsYWNlaG9sZGVyX18wOyIsIi8vIExvYWQgbW9kdWxlc1xuXG5cbi8vIERlY2xhcmUgaW50ZXJuYWxzXG5cbnZhciBpbnRlcm5hbHMgPSB7fTtcblxuXG5leHBvcnRzLm1ldGhvZCA9IGZ1bmN0aW9uICh2YWx1ZSkge1xuXG4gICAgd2hpbGUodmFsdWUpIHtcbiAgICAgICAgdmFsdWUgPSBmYWxzZTtcbiAgICB9XG5cbiAgICByZXR1cm4gdmFsdWU7XG59O1xuIl19').concat(Os.EOL);
+        }},
+        { ext: '.js', transform: null }
+    ]
+};
 
 
 // Test shortcuts
@@ -20,15 +37,7 @@ var expect = Code.expect;
 
 describe('Transform', function () {
 
-    Lab.coverage.instrument({ coveragePath: Path.join(__dirname, './transform/'), coverageExclude: 'exclude', 
-        transform: [
-            { ext: '.new', transform: function (content) {
-
-                return content.replace('!NOCOMPILE!', 'value = value ');
-            }},
-            { ext: '.js', transform: null }
-        ]
-    });
+    Lab.coverage.instrument({ coveragePath: Path.join(__dirname, './transform/'), coverageExclude: 'exclude', transform: internals.transform });
 
     it('instruments and measures coverage', function (done) {
 
@@ -47,6 +56,66 @@ describe('Transform', function () {
 
         var cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'transform/basic') });
         expect(cov.percent).to.equal(100);
+        done();
+    });
+
+    it('unit tests coverage.retrieveFile', function (done) {
+
+        var content = Lab.coverage.retrieveFile('test/transform/exclude/lab-noexport.js');
+        expect(content).to.contain('// no code');
+
+        content = Lab.coverage.retrieveFile('test/transform/exclude/lab-noexport.js');
+        expect(content).to.contain('// no code');
+
+        content = Lab.coverage.retrieveFile('doesnotexist');
+        expect(content).to.equal(null);
+
+        done();
+    });
+
+    it('unit tests transform.retrieveFile', function (done) {
+
+        var content = Transform.retrieveFile('test/transform/exclude/lab-noexport.js');
+        expect(content).to.contain('// no code');
+
+        content = Transform.retrieveFile('test/transform/exclude/lab-noexport.js');
+        expect(content).to.contain('// no code');
+
+        content = Transform.retrieveFile('doesnotexist');
+        expect(content).to.equal(null);
+
+        done();
+    });
+});
+
+describe('Transform.install', function () {
+
+    lab.before(function (done) {
+
+        internals.js = require.extensions['.js'];
+        internals['new'] = require.extensions['.new'];
+        internals.inl = require.extensions['.inl'];
+        done();
+    });
+
+    lab.after(function (done) {
+
+        require.extensions['.js'] = internals.js;
+        require.extensions['.new'] = internals['new'];
+        require.extensions['.inl'] = internals.inl;
+        done();
+    });
+
+    it('works correctly', function (done) {
+
+        Transform.install({ transform: internals.transform });
+
+        var Test = require('./transform/sourcemaps');
+        expect(Test.method(false)).to.equal(false);
+
+        var Test2 = require('./transform/exclude/transform-basic');
+        expect(Test2.method()).to.equal(1);
+
         done();
     });
 });

--- a/test/transform/exclude/transform-basic.js
+++ b/test/transform/exclude/transform-basic.js
@@ -1,0 +1,3 @@
+module.exports.method = function () {
+	return 1;
+};

--- a/test/transform/sourcemaps.inl
+++ b/test/transform/sourcemaps.inl
@@ -1,0 +1,9 @@
+"use strict";
+var __moduleName = "while";
+var internals = {};
+exports.method = function(value) {
+  while (value) {
+    value = false;
+  }
+  return value;
+};


### PR DESCRIPTION
Multiple changes:
 1) Fix the command line sourcemaps option to use alias so we can finally call it with -S and --sourcemaps as documented in README
 2) Pass filename to the exported transform method (2nd parameter) so it is backwards compatible. Sourcemaps do need that information to generate nice output.
 3) Sourcemaps are now transparently handled when using transforms. It was broken before but I did not realize as my transforms always gave me 1 to 1 mappings.

Issues:
- Testability: Unfortunately, to get code coverage for (3), I need to "install" an option to source-map-support module and I cannot do so in a way that can be undone or clean with the way things are done right now. Doing so, in tests, breaks Lab reporting.
- I can definitely write tests that will cover the the lines of code (by invoking the cli directly as in cli.js) but we will not get code coverage reports for that.

Question:
- When Lab crashes, is there a way to see the stack trace. It really likes to eat its own errors...

I apologize for the sourcemap support :(