### PR TITLE
Support custom reporters - closes #216 & closes #309

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ global manipulation. Our goal with **lab** is to keep the execution engine as si
     - `tap` - TAP protocol report.
     - `lcov` - output to [lcov](http://ltp.sourceforge.net/coverage/lcov/geninfo.1.php) format.
     - `clover` - output results in [Clover XML](https://confluence.atlassian.com/display/CLOVER) format.
+    - [Custom Reporters](#custom-reporters) - See Below
 - `-s`, `--silence` - silence test output, defaults to false.
 - `-S`, `--sourcemaps` - enables sourcemap support for stack traces and code coverage, disabled by default.
 - `-t`, `--threshold` - minimum code test coverage percentage (sets `-c`), defaults to 100%.
@@ -262,6 +263,16 @@ file to figure out where coverage is lacking.
 ```bash
 $ npm test
 ```
+
+## Custom Reporters
+
+If the value passed for `reporter` isn't included with Lab, it is loaded from the filesystem.
+If the string starts with a period (`'./custom-reporter'`), it will be loaded relative to the current working directory.
+If it doesn't start with a period (`'custom-reporter'`), it will be loaded from the `node_modules` directory, just like any module installed using `npm install`.
+
+Reporters must be a class with the following methods: `start`, `test` and `end`. `options` are passed to the class constructor upon initialization.
+
+See the [json reporter](lib/reporters/json.js) for an good starting point.
 
 ## Acknowledgements
 

--- a/lib/reporters/index.js
+++ b/lib/reporters/index.js
@@ -4,7 +4,6 @@ var Fs = require('fs');
 var Path = require('path');
 var Mkdirp = require('mkdirp');
 
-
 // Declare internals
 
 var internals = {};
@@ -20,10 +19,18 @@ internals.protos = {
     tap: require('./tap')
 };
 
+internals.requireReporter = function (reporter) {
+
+    if (reporter[0] === '.') {
+        return require(Path.join(process.cwd(), reporter));
+    }
+
+    return require(reporter);
+};
 
 exports.generate = function (options) {
 
-    var Proto = internals.protos[options.reporter];
+    var Proto = internals.protos[options.reporter] || internals.requireReporter(options.reporter);
     var reporter = new Proto(options);
 
     var dest;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "jslint": "0.7.x"
   },
   "devDependencies": {
-    "code": "1.x.x"
+    "code": "1.x.x",
+    "lab-event-reporter": "1.x.x"
   },
   "bin": {
     "lab": "./bin/lab"

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -1313,4 +1313,47 @@ describe('Reporter', function () {
             done();
         });
     });
+
+    describe('custom reporters', function () {
+
+        it('requires a custom reporter relatively if starts with .', function (done) {
+
+            var reporter = './node_modules/lab-event-reporter/index.js';
+
+            var script = Lab.script();
+            script.experiment('test', function () {
+
+                script.test('works', function (finished) {
+
+                    finished();
+                });
+            });
+
+            Lab.report(script, { reporter: reporter }, function (err, code, output) {
+
+                expect(err).to.not.exist();
+                done();
+            });
+        });
+
+        it('requires a custom reporter from node_modules if not starting with .', function (done) {
+
+            var reporter = 'lab-event-reporter';
+
+            var script = Lab.script();
+            script.experiment('test', function () {
+
+                script.test('works', function (finished) {
+
+                    finished();
+                });
+            });
+
+            Lab.report(script, { reporter: reporter }, function (err, code, output) {
+
+                expect(err).to.not.exist();
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
The implementation I went with is: if a string passed to the `reporter` option doesn't exist in the `internals.proto` map, just attempt to require it.  I also added simple logic for relative vs npm-installed reporters.