### PR TITLE
Allow --lint-options to be passed to configure linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ global manipulation. Our goal with **lab** is to keep the execution engine as si
 - `-m`, `--timeout` - individual tests timeout in milliseconds (zero disables timeout). Defaults to 2 seconds.
 - `-M`, `--context-timeout` - default timeouts for before, after, beforeEach and afterEach in milliseconds. Disabled by default.
 - `-n`, `--linter` - specify linting program; default is `eslint`.
+- `--lint-options` - specify options to pass to linting program. It must be a string that is JSON.parse(able).
 - `-o`, `--output` - file to write the report to, otherwise sent to stdout.
 - `-p`, `--parallel` - sets parallel execution as default test option. Defaults to serial execution.
 - `-r`, `--reporter` - the reporter used to generate the test results. Defaults to `console`. Options are:

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -196,6 +196,10 @@ internals.options = function () {
             default: 'eslint',
             valid: ['eslint', 'jslint']
         },
+        'lint-options': {
+            type: 'string',
+            description: 'specify options to pass to linting program. It must be a string that is JSON.parse(able).'
+        },
         timeout: {
             alias: 'm',
             type: 'number',
@@ -267,7 +271,7 @@ internals.options = function () {
         require('./').assertions = options.assert;
     }
 
-    var keys = ['coverage', 'colors', 'dry', 'debug', 'environment', 'flat', 'grep', 'globals', 'timeout', 'parallel', 'reporter', 'threshold', 'context-timeout', 'sourcemaps', 'lint', 'linter', 'transform'];
+    var keys = ['coverage', 'colors', 'dry', 'debug', 'environment', 'flat', 'grep', 'globals', 'timeout', 'parallel', 'reporter', 'threshold', 'context-timeout', 'sourcemaps', 'lint', 'linter', 'transform', 'lint-options'];
     for (var i = 0, il = keys.length; i < il; ++i) {
         if (argv.hasOwnProperty(keys[i]) && argv[keys[i]] !== undefined) {
             options[keys[i]] = argv[keys[i]];

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -16,6 +16,7 @@ var internals = {
 exports.lint = function (settings, callback) {
 
     var child = ChildProcess.fork(internals.linters[settings.linter],
+                                  settings['lint-options'] ? [ settings['lint-options'] ] : [],
                                   { cwd: settings.lintingPath });
     child.once('message', function (message) {
         child.kill();

--- a/lib/linters/eslint/index.js
+++ b/lib/linters/eslint/index.js
@@ -1,6 +1,7 @@
 var Fs = require('fs');
 var Path = require('path');
 var Eslint = require('eslint');
+var Hoek = require('hoek');
 
 // Declare internals
 
@@ -14,12 +15,18 @@ exports.lint = function () {
         useEslintrc: true
     };
 
+    var options = process.argv[2] ? JSON.parse(process.argv[2]) : undefined;
+
     if (!Fs.existsSync('.eslintrc')) {
         configuration.configFile = Path.join(__dirname, '.eslintrc');
     }
 
     if (!Fs.existsSync('.eslintignore')) {
         configuration.ignorePath = Path.join(__dirname, '.eslintignore');
+    }
+
+    if (options) {
+        Hoek.merge(configuration, options, true, false);
     }
 
     var engine = new Eslint.CLIEngine(configuration);

--- a/lib/linters/jslint/index.js
+++ b/lib/linters/jslint/index.js
@@ -2,6 +2,7 @@
 
 var Fs = require('fs');
 var Path = require('path');
+var Hoek = require('hoek');
 var Nodejslint = require('jslint');
 
 
@@ -28,14 +29,22 @@ var formatFile = function (file) {
 
 exports.lint = function () {
 
-    // synchronously lint
-    Nodejslint.runMain({
+    var configuration = {
         edition: 'latest',
         argv: {
             remain: ['**/*.js']
         },
         collector: true
-    }, function (err, report) {
+    };
+
+    var options = process.argv[2] ? JSON.parse(process.argv[2]) : undefined;
+
+    if (options) {
+        Hoek.merge(configuration, options, true, false);
+    }
+
+    // synchronously lint
+    Nodejslint.runMain(configuration, function (err, report) {
 
         var formatted = report.map(formatFile);
         process.send(formatted);

--- a/test/linters.js
+++ b/test/linters.js
@@ -70,6 +70,21 @@ describe('Linters - eslint', function () {
             done();
         });
     });
+
+    it('should pass options and not find any files', function (done) {
+
+        var lintOptions = JSON.stringify({ extensions: ['.jsx'] });
+        var path = Path.join(__dirname, 'lint', 'eslint', 'basic');
+        Linters.lint({ lintingPath: path, linter: 'eslint', 'lint-options': lintOptions }, function (err, result) {
+
+            expect(result).to.include('lint');
+
+            var eslintResults = result.lint;
+            expect(eslintResults).to.have.length(0);
+
+            done();
+        });
+    });
 });
 
 describe('Linters - jslint', function () {
@@ -126,6 +141,21 @@ describe('Linters - jslint', function () {
 
             var checkedFile = jslintResults[0];
             expect(checkedFile.errors.length).to.equal(0);
+
+            done();
+        });
+    });
+
+    it('should pass options and not find any files', function (done) {
+
+        var lintOptions = JSON.stringify({ argv: { remain: ['**/*.jsx'] } });
+        var path = Path.join(__dirname, 'lint', 'jslint', 'basic');
+        Linters.lint({ lintingPath: path, linter: 'jslint', 'lint-options': lintOptions }, function (err, result) {
+
+            expect(result).to.include('lint');
+
+            var jslintResults = result.lint;
+            expect(jslintResults).to.have.length(0);
 
             done();
         });


### PR DESCRIPTION
Pass --lint-options with a JSON.parse(able) string. The options will be Hoek.merged with the configuration object in jslint or eslint. Now you can configure the linting program how you please and override or add to the defaults at your own peril.