### PR TITLE
Fix EventEmitter bug

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -154,6 +154,10 @@ internals.executeExperiments = function (experiments, state, skip, callback) {
 
     Items.serial(experiments, function (experiment, nextExperiment) {
 
+        // Create a new domains context for this level of experiments, keep the old ones to restore them when finishing
+        var previousDomains = state.domains;
+        state.domains = [];
+
         var skipExperiment = skip || experiment.options.skip;
         var steps = [
             function (next) {
@@ -202,6 +206,9 @@ internals.executeExperiments = function (experiments, state, skip, callback) {
             item(next);
         },
         function (err, results) {
+
+            // Restore the domains we had before
+            state.domains = previousDomains;
 
             if (err) {
                 state.report.errors.push(err);
@@ -336,8 +343,7 @@ internals.executeTests = function (experiment, state, skip, callback) {
         });
     };
 
-    Items.serial(serial, execute,
-    function (err) {
+    Items.serial(serial, execute, function (err) {
 
         Items.parallel(parallel, execute, function () {
 
@@ -363,20 +369,44 @@ internals.collectDeps = function (experiment, key) {
 internals.protect = function (item, state, callback) {
 
     var isFirst = true;
+
+    var activeDomain = Domain.active;
+
+    // We need to keep a reference to the list of domains at the time of the call since those will change with nested
+    // experiments.
+    var domains = state.domains;
+
     var finish = function (err, cause) {
 
         if (!isFirst) {
-            state.report.errors.push(new Error('Multiple callbacks or thrown errors received in test: ' + item.title + ' (' + cause + ')'));
+            var message = 'Multiple callbacks or thrown errors received in test "' + item.title + '" (' + cause + ')';
+
+            if (err && !/^Multiple callbacks/.test(err.message)) {
+                err.message = message + ': ' + err.message;
+            }
+            else {
+                err = new Error(message);
+            }
+
+            state.report.errors.push(err);
             return;
         }
 
-        domain.exit();
         isFirst = false;
         clearTimeout(timeoutId);
-        setImmediate(function () {
+
+        var immed = setImmediate(function () {
 
             return callback(err);
         });
+
+        /* $lab:coverage:off$ */
+        if (activeDomain) {
+            // The previously active domain need to be used here in case the callback throws.
+            // This is of course only valid if lab itself is ran in a domain, which is the case for its own tests.
+            activeDomain.add(immed);
+        }
+        /* $lab:coverage:on$ */
     };
 
     var ms = item.options.timeout !== undefined ? item.options.timeout : state.options.timeout;
@@ -389,7 +419,13 @@ internals.protect = function (item, state, callback) {
         }, ms);
     }
 
-    var onError = function (err) {
+    var onError = function (err, isForward) {
+
+        // 1. Do not forward what's already a forward.
+        // 2. Only errors that reach before*/after* are worth forwarding, otherwise we know where they came from.
+        if (!isForward && item.id === undefined) {
+            internals.forwardError(err, domain, domains);
+        }
 
         if (state.options.debug) {
             state.report.errors.push(err);
@@ -399,7 +435,9 @@ internals.protect = function (item, state, callback) {
     };
 
     var domain = Domain.createDomain();
+    domain.title = item.title;
     domain.on('error', onError);
+    domains.push(domain);
 
     setImmediate(function () {
 
@@ -408,7 +446,19 @@ internals.protect = function (item, state, callback) {
 
             finish(err, 'done');
         });
+        domain.exit();
     });
+};
+
+
+internals.forwardError = function (err, sourceDomain, targetDomains) {
+
+    for (var s = 0, sl = targetDomains.length; s < sl; ++s) {
+        var d = targetDomains[s];
+        if (d !== sourceDomain) {
+            d.emit('error', err, true); // Add true to mark this as a forward.
+        }
+    }
 };
 
 


### PR DESCRIPTION
@geek I finally managed to reproduce the bug reliably !

So basically the explanation is the domain of the beforeEach captures the event emitter that's created, and if it crashes in the context of the test, the error is not caught by the `protect` of the test but by the one of beforeEach.

I have an idea how to fix it but that's gonna be weird : we should transfer the list of `domain.members` from the beforeEach to the new domain of the test.
What do you think ?