### PR TITLE
[DEP] eslint 0.14 to 0.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "items": "1.x.x",
     "diff": "1.x.x",
     "source-map-support": "0.2.x",
-    "eslint": "0.14.x",
+    "eslint": "0.17.x",
     "hoek": "2.x.x",
     "mkdirp": "0.5.x"
   },


### PR DESCRIPTION
Closes #326 

New rule added not sure if needed http://eslint.org/docs/rules/space-before-function-parentheses.html
General info about the change can be found in the 0.15 release notes [here](http://eslint.org/blog/2015/02/eslint-0.15.0-released/)