### PR TITLE
Replace esprima with espree

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -7,7 +7,7 @@
 
 var Fs = require('fs');
 var Path = require('path');
-var Esprima = require('esprima');
+var Espree = require('espree');
 var sourceMapSupport = require('source-map-support');
 
 
@@ -203,7 +203,7 @@ internals.instrument = function (filename) {
 
     // Parse tree
 
-    var tree = Esprima.parse(content, { loc: true, comment: true, range: true });
+    var tree = Espree.parse(content, { loc: true, comment: true, range: true });
 
     // Process comments
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "bossy": "1.x.x",
-    "esprima": "1.x.x",
+    "espree": "2.x.x",
     "handlebars": "2.x.x",
     "items": "1.x.x",
     "diff": "1.x.x",


### PR DESCRIPTION
Provides support for ES6 features such as generators.

Suggested in #332