### PR TITLE
Fix HTML reporter when using live-transformed code

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -236,7 +236,8 @@ internals.instrument = function (filename) {
 
     // Store original source
 
-    internals.sources[filename] = file.replace(/(\r\n|\n|\r)/gm, '\n').split('\n');
+    var transformedFile = content.replace(/\/\/\#(.*)$/, '');
+    internals.sources[filename] = transformedFile.replace(/(\r\n|\n|\r)/gm, '\n').split('\n');
 
     // Setup global report container
                                                         // $lab:coverage:off$


### PR DESCRIPTION
This will allow the HTML reporter (and others) to display the transformed code. The display now makes much more sense, and the right lines are highlighted.

@jedireza raised this earlier this week along.
@romeovs raised it too in issue #338 but this does not fix 338. Though it does fix the weird line numbers (line 1 being repeated) raised later on!

![screen shot 2015-04-09 at 9 38 23 pm](https://cloud.githubusercontent.com/assets/5972411/7081982/ccedbee8-df00-11e4-87a8-b0dcdf14c651.png)

Before, it would have highlighted an irrelevant line like so
![screen shot 2015-04-09 at 9 40 48 pm](https://cloud.githubusercontent.com/assets/5972411/7082003/2b394030-df01-11e4-9e0f-519dba806830.png)
