### PR TITLE
Handle Promises returned by tests

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -442,10 +442,13 @@ internals.protect = function (item, state, callback) {
     setImmediate(function () {
 
         domain.enter();
-        item.fn.call(null, function (err) {
-
+        var fn = function (err) {
             finish(err, 'done');
-        });
+        };
+        var thenable = item.fn.call(null, fn);
+        if (thenable && typeof thenable.then === 'function') {
+            thenable.then(fn.bind(undefined, null), fn);
+        }
         domain.exit();
     });
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "devDependencies": {
     "code": "1.x.x",
-    "lab-event-reporter": "1.x.x"
+    "lab-event-reporter": "1.x.x",
+    "promise": "^6.1.0"
   },
   "bin": {
     "lab": "./bin/lab"

--- a/test/runner.js
+++ b/test/runner.js
@@ -439,6 +439,10 @@ describe('Runner', function () {
     });
 
     it('can handle thenables', function (done) {
+        if (typeof Promise === 'undefined') {
+          var Promise = require('promise');
+        }
+
         var script = Lab.script();
         script.experiment('test', function () {
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -438,6 +438,27 @@ describe('Runner', function () {
         });
     });
 
+    it('can handle thenables', function (done) {
+
+        var script = Lab.script();
+        script.experiment('test', function () {
+
+            script.test('1', function () {
+                return Promise.fulfill('done');
+            });
+
+            script.test('1', function () {
+                return Promise.reject(new Error('sample reason'));
+            });
+        });
+
+        Lab.report(script, { output: false }, function (err, code, output) {
+
+            expect(code).to.equal(1);
+            done();
+        });
+    });
+
     it('uses provided linter', function (done) {
 
         var script = Lab.script();

--- a/test/runner.js
+++ b/test/runner.js
@@ -439,22 +439,37 @@ describe('Runner', function () {
     });
 
     it('can handle thenables', function (done) {
-
         var script = Lab.script();
         script.experiment('test', function () {
 
-            script.test('1', function () {
-                return Promise.fulfill('done');
+            script.test('1', function (done) {
+                return Promise.resolve('done');
             });
 
-            script.test('1', function () {
-                return Promise.reject(new Error('sample reason'));
+            script.test('2', function (done) {
+                return Promise.reject(new Error('Promise Error'))
             });
+
+            script.test('3', function (done) {
+              return {
+                then: function (ok, ko) {
+                  ok('done')
+                }
+              }
+            })
+
+            script.test('4', function (done) {
+              return {
+                then: function (ok, ko) {
+                  ko(new Error('Thenable Error'))
+                }
+              }
+            })
         });
 
         Lab.report(script, { output: false }, function (err, code, output) {
-
             expect(code).to.equal(1);
+            console.log(output)
             done();
         });
     });


### PR DESCRIPTION
Feature requested by issue #79

It does not expect a full fledged Promise, only a *thenable* since it is the most barebone Promise implementation. Every Promise is a thenable, not every thenable is a Promise, but a Promise can handle a thenable.

sample use case:

```js

lab.experiment('Thenable', function () {
    lab.test(function () {
        return new Promise(function () {
            // This Exception will be caught by the Promise 
            throw new Error('Meaningful Exception');
        });
    });
});

lab.experiment('Thenable', function () {
    lab.test(function () {
        return Promise.all([
            Promise.fulfill('one'),
            Promise.fulfill('two'),
            'three'
        ]);
    });
});


lab.experiment('Thenable', function () {
    lab.test(function () {
        return Promise.all([
            Promise.fulfill('one'),
            Promise.reject(new Error('Something went terribly wrong'))
        ]);
    });
});

```