### PR TITLE
Add filename to compilation errors.

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -22,16 +22,33 @@ var internals = {
 
 internals.prime = function (extension) {
 
+    var attemptCompile = function (fn, filename) {
+        try {
+            return fn();
+        } catch (err) {
+            if (/^Line/.test(err.message)) {
+                err.message = filename + ' - ' + err.message;
+            }
+            throw err;
+        }
+    };
+
     require.extensions[extension] = function (localModule, filename) {
 
         for (var i = 0, il = internals.patterns.length; i < il; ++i) {
             if (internals.patterns[i].test(filename.replace(/\\/g, '/'))) {
-                return localModule._compile(internals.instrument(filename), filename);
+                return attemptCompile(function () {
+
+                    return localModule._compile(internals.instrument(filename), filename);
+                }, filename);
             }
         }
 
         var src = Fs.readFileSync(filename, 'utf8');
-        return localModule._compile(Transform.transform(filename, src), filename);
+        return attemptCompile(function () {
+
+            return localModule._compile(Transform.transform(filename, src), filename);
+        }, filename);
     };
 };
 


### PR DESCRIPTION
With the new espree, my compilation is failing. It probably won't solve it but at least it shows the file on which it's failing.