### PR TITLE
Added two eslint rules to lab to enforce the hapi code style.

### DIFF
--- a/lib/linters/eslint/.eslintrc
+++ b/lib/linters/eslint/.eslintrc
@@ -58,6 +58,8 @@
         "no-new-wrappers": 2,
         "no-comma-dangle": 2,
         "no-sparse-arrays": 2,
-        "no-ex-assign": 2
+        "no-ex-assign": 2,
+        "space-before-function-paren": 2,
+        "func-style": [2, "expression"]
     }
 }

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -17,7 +17,7 @@ exports = module.exports = internals.Reporter = function (options) {
     this.counter = 0;
 };
 
-internals.Reporter.prototype.insertYAMLBlock = function(test) {
+internals.Reporter.prototype.insertYAMLBlock = function (test) {
 
     this.report('  ---\n');
     this.report('  duration_ms: ' + test.duration + '\n');


### PR DESCRIPTION
Force functions to be defined by assignment and not by declaration, as well as enforce spacing after function name.