### PR TITLE
Fix #351. Add message about threshold and npm error message.

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,8 @@ $ npm install -g lab
 
 Note that `npm test` will execute **lab** with the `-t 100` option which will require 100% code coverage. Change or remove
 this option if you just cannot be bothered with producing quality code. Run `npm run test-cov-html` and check the `coverage.html`
-file to figure out where coverage is lacking.
+file to figure out where coverage is lacking. When coverage is below the threshold, the CLI with exit with code `1` and will result
+in an npm Error message.
 
 - Run your tests with
 


### PR DESCRIPTION
Addresses the `npm ERR! Exit status 1` error message. 

Not certain if this is the right place or if there should be a troubleshooting section. 

Hard return to maintain apparent line wrapping.