### PR TITLE
Change afterEaches to run in more natural order

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -357,11 +357,14 @@ internals.collectDeps = function (experiment, key) {
 
     var set = [];
 
+    // if we are looking at afterEaches, we want to run our parent's blocks before ours (unshift onto front)
+    var arrayAddFn = key === 'afterEaches' ? Array.prototype.unshift : Array.prototype.push;
+
     if (experiment.parent) {
-        set = set.concat(internals.collectDeps(experiment.parent, key));
+        arrayAddFn.apply(set, internals.collectDeps(experiment.parent, key));
     }
 
-    set = set.concat(experiment[key] || []);
+    arrayAddFn.apply(set, experiment[key] || []);
     return set;
 };
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -332,6 +332,83 @@ describe('Runner', function () {
         });
     });
 
+    it('runs afterEaches in nested experiments from inside, out (by experiments)', function (done) {
+
+        var steps = [];
+        var script = Lab.script({ schedule: false });
+        script.experiment('test', function () {
+
+            script.beforeEach(function (finished) {
+
+                steps.push('outer beforeEach');
+                finished();
+            });
+
+            script.afterEach(function (finished) {
+
+                steps.push('outer afterEach 1');
+                finished();
+            });
+
+            script.test('first works', function (finished) {
+
+                steps.push('first test');
+                finished();
+            });
+
+            script.experiment('inner test', function () {
+
+                script.beforeEach(function (finished) {
+
+                    steps.push('inner beforeEach');
+                    finished();
+                });
+
+                script.afterEach(function (finished) {
+
+                    steps.push('inner afterEach 1');
+                    finished();
+                });
+
+                script.test('works', function (finished) {
+
+                    steps.push('second test');
+                    finished();
+                });
+
+                script.afterEach(function (finished) {
+
+                    steps.push('inner afterEach 2');
+                    finished();
+                });
+            });
+
+            script.afterEach(function (finished) {
+
+                steps.push('outer afterEach 2');
+                finished();
+            });
+        });
+
+        Lab.execute(script, null, null, function (err, notebook) {
+
+            expect(steps).to.deep.equal([
+              'outer beforeEach',
+              'first test',
+              'outer afterEach 1',
+              'outer afterEach 2',
+              'outer beforeEach',
+              'inner beforeEach',
+              'second test',
+              'inner afterEach 1',
+              'inner afterEach 2',
+              'outer afterEach 1',
+              'outer afterEach 2'
+            ]);
+            done();
+        });
+    });
+
     it('executes in parallel', function (done) {
 
         var steps = [];


### PR DESCRIPTION
This fixes #357. In order to have afterEaches run in a more natural order (closest to the test first and out through the experiments), this prepends the afterEaches to the returned set as it finds them. The blocks are then run in a more natural order. As a side note: this still is running them in the order they are defined in the experiments.

A test has been added in the suite for this change, but to specifically show the test displayed in the issue, the output with this branch is as follows:

```
$ lab test.js
outer: before
inner: before
outer: beforeEach
inner: beforeEach
test.
inner: afterEach # inner afterEach is now before outer
outer: afterEach
inner: after     # inner after is still before outer after
outer: after
```