### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,5 @@
     "test": "./bin/_lab -fL -t 100 -m 3000 --lint-errors-threshold 0 --lint-warnings-threshold 0",
     "test-cov-html": "./bin/_lab -fL -r html -m 3000 -o coverage.html --lint-errors-threshold 0 --lint-warnings-threshold 0"
   },
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "http://github.com/hapijs/lab/raw/master/LICENSE"
-    }
-  ]
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/