### PR TITLE
Linting update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 
 node_js:

--- a/lib/linters/eslint/.eslintrc
+++ b/lib/linters/eslint/.eslintrc
@@ -61,6 +61,8 @@
         "no-ex-assign": 2,
         "indent": [2, 4],
         "space-before-function-paren": 2,
-        "func-style": [2, "expression"]
+        "func-style": [2, "expression"],
+        "lines-around-comment": [2, { "beforeLineComment": true, "afterLineComment": false, "beforeBlockComment": false, "afterBlockComment": false }],
+        "object-curly-spacing": [2, "always"]
     }
 }

--- a/lib/linters/jslint/index.js
+++ b/lib/linters/jslint/index.js
@@ -15,7 +15,7 @@ var formatErrors = function (error) {
     return {
         line: error.line,
         severity: 'ERROR',
-        message: error.reason
+        message: error.message
     };
 };
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -25,14 +25,17 @@ Error.stackTraceLimit = Infinity;                   // Set Error stack size
 
 
 internals.defaults = {
+
     // assert: { incomplete(), count() },
     coverage: false,
+
     // coveragePath: process.cwd(),
     // coverageExclude: ['node_modules', 'test'],
     colors: null,                                   // true, false, null (based on tty)
     dry: false,
     debug: false,
     environment: 'test',
+
     // flat: false,
     grep: null,
     ids: [],
@@ -43,6 +46,7 @@ internals.defaults = {
     parallel: false,
     progress: 1,
     reporter: 'console',
+
     // schedule: true,
     threshold: 0
 };
@@ -405,6 +409,7 @@ internals.protect = function (item, state, callback) {
 
         /* $lab:coverage:off$ */
         if (activeDomain) {
+
             // The previously active domain need to be used here in case the callback throws.
             // This is of course only valid if lab itself is ran in a domain, which is the case for its own tests.
             activeDomain.add(immed);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "items": "1.x.x",
     "diff": "1.x.x",
     "source-map-support": "0.2.x",
-    "eslint": "0.21.x",
+    "eslint": "0.22.x",
     "hoek": "2.x.x",
     "mkdirp": "0.5.x"
   },

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "items": "1.x.x",
     "diff": "1.x.x",
     "source-map-support": "0.2.x",
-    "eslint": "0.19.x",
+    "eslint": "0.21.x",
     "hoek": "2.x.x",
     "mkdirp": "0.5.x"
   },
   "optionalDependencies": {
-    "jslint": "0.8.x"
+    "jslint": "0.9.x"
   },
   "devDependencies": {
     "code": "1.x.x",
@@ -33,8 +33,8 @@
     "lab": "./bin/lab"
   },
   "scripts": {
-    "test": "./bin/_lab -fL -t 100 -m 3000 --lint-errors-threshold 0 --lint-warnings-threshold 0",
-    "test-cov-html": "./bin/_lab -fL -r html -m 3000 -o coverage.html --lint-errors-threshold 0 --lint-warnings-threshold 0"
+    "test": "./bin/_lab -fL -t 100 -m 3000",
+    "test-cov-html": "./bin/_lab -fL -r html -m 3000 -o coverage.html"
   },
   "licenses": [
     {

--- a/test/cli.js
+++ b/test/cli.js
@@ -641,6 +641,7 @@ describe('CLI', function () {
             Fs.unlinkSync(outputPath);
         }
         catch (err) {
+
             // Error is ok here
         }
 

--- a/test/lint/jslint/clean/success.js
+++ b/test/lint/jslint/clean/success.js
@@ -5,8 +5,6 @@
 
 // Declare internals
 
-var internals = {};
-
 
 exports.method = function (value) {
 

--- a/test/lint/jslint/with_config/fail.js
+++ b/test/lint/jslint/with_config/fail.js
@@ -8,5 +8,10 @@ var internals = {};
 
 exports.method = function (value) {
 
-	return value++;
+    var myString = 'x';
+    var myObject = {
+        x: 10
+    };
+    value = eval('myObject.' + myString);
+    return value;
 };

--- a/test/lint/jslint/with_config/jslint.conf
+++ b/test/lint/jslint/with_config/jslint.conf
@@ -1,3 +1,3 @@
 {
-  "plusplus": true
+  "eval": true
 }

--- a/test/linters.js
+++ b/test/linters.js
@@ -13,6 +13,7 @@ var describe = lab.describe;
 var it = lab.it;
 var expect = Code.expect;
 
+
 describe('Linters - eslint', function () {
 
     it('should lint files in a folder', function (done) {
@@ -48,7 +49,8 @@ describe('Linters - eslint', function () {
 
             var checkedFile = eslintResults[0];
             expect(checkedFile).to.include({ filename: 'fail.js' });
-            expect(checkedFile.errors).to.deep.include({ line: 12, severity: 'ERROR', message: 'eol-last - Newline required at end of file but not found.' });
+            expect(checkedFile.errors).to.deep.include([
+                { line: 12, severity: 'ERROR', message: 'eol-last - Newline required at end of file but not found.' }]);
             expect(checkedFile.errors).to.not.deep.include({ line: 6, severity: 'ERROR', message: 'no-unused-vars - internals is defined but never used' });
             done();
         });
@@ -101,12 +103,12 @@ describe('Linters - jslint', function () {
 
             var checkedFile = jslintResults[0];
             expect(checkedFile).to.include({ filename: 'fail.js' });
-            expect(checkedFile.errors).to.deep.include(
+            expect(checkedFile.errors).to.deep.include([
                 { line: 10, severity: 'ERROR', message: 'Use spaces, not tabs.' },
                 { line: 10, severity: 'ERROR', message: 'Expected \'use strict\' before \'return\'.' },
                 { line: 11, severity: 'ERROR', message: 'Expected \';\' and instead saw \'}\'.' },
                 { line: 11, severity: 'ERROR', message: 'Stopping.' }
-            );
+            ]);
 
             done();
         });
@@ -124,12 +126,12 @@ describe('Linters - jslint', function () {
 
             var checkedFile = jslintResults[0];
             expect(checkedFile).to.include({ filename: 'fail.js' });
-            expect(checkedFile.errors).to.deep.include(
+            expect(checkedFile.errors).to.deep.include([
                 { line: 5, severity: 'ERROR', message: 'Unused \'internals\'.' },
-                { line: 10, severity: 'ERROR', message: 'Use spaces, not tabs.' },
-                { line: 11, severity: 'ERROR', message: 'Expected \'use strict\' before \'return\'.' }
-            );
-            expect(checkedFile.errors).to.not.deep.include({ line: 10, severity: 'ERROR', message: 'Unexpected \'++\'.' });
+                { line: 10, severity: 'ERROR', message: 'Expected \'use strict\' before \'var\'.' },
+                { line: 11, severity: 'ERROR', message: 'Unused \'myObject\'.' }
+            ]);
+            expect(checkedFile.errors).to.not.deep.include({ line: 14, severity: 'ERROR', message: 'Unexpected \'eval\'.' });
             done();
         });
     });

--- a/test/linters.js
+++ b/test/linters.js
@@ -102,9 +102,10 @@ describe('Linters - jslint', function () {
             var checkedFile = jslintResults[0];
             expect(checkedFile).to.include({ filename: 'fail.js' });
             expect(checkedFile.errors).to.deep.include(
-                { line: 11, severity: 'ERROR', message: 'Use spaces, not tabs.' },
-                { line: 11, severity: 'ERROR', message: 'Missing \'use strict\' statement.' },
-                { line: 11, severity: 'ERROR', message: 'Expected \';\' and instead saw \'}\'.' }
+                { line: 10, severity: 'ERROR', message: 'Use spaces, not tabs.' },
+                { line: 10, severity: 'ERROR', message: 'Expected \'use strict\' before \'return\'.' },
+                { line: 11, severity: 'ERROR', message: 'Expected \';\' and instead saw \'}\'.' },
+                { line: 11, severity: 'ERROR', message: 'Stopping.' }
             );
 
             done();
@@ -123,9 +124,12 @@ describe('Linters - jslint', function () {
 
             var checkedFile = jslintResults[0];
             expect(checkedFile).to.include({ filename: 'fail.js' });
-            expect(checkedFile.errors).to.deep.include({ line: 11, severity: 'ERROR', message: 'Use spaces, not tabs.' },
-                                                       { line: 11, severity: 'ERROR', message: 'Missing \'use strict\' statement.' });
-            expect(checkedFile.errors).to.not.deep.include({ line: 11, severity: 'ERROR', message: 'Unexpected \'++\'.' });
+            expect(checkedFile.errors).to.deep.include(
+                { line: 5, severity: 'ERROR', message: 'Unused \'internals\'.' },
+                { line: 10, severity: 'ERROR', message: 'Use spaces, not tabs.' },
+                { line: 11, severity: 'ERROR', message: 'Expected \'use strict\' before \'return\'.' }
+            );
+            expect(checkedFile.errors).to.not.deep.include({ line: 10, severity: 'ERROR', message: 'Unexpected \'++\'.' });
             done();
         });
     });

--- a/test/runner.js
+++ b/test/runner.js
@@ -757,6 +757,7 @@ describe('Runner', function () {
                 });
 
                 setTimeout(done, 100);
+
                 // done();
             });
 
@@ -818,6 +819,7 @@ describe('Runner', function () {
                 });
 
                 setTimeout(done, 100);
+
                 // done();
             });
 

--- a/test/transform.js
+++ b/test/transform.js
@@ -12,17 +12,21 @@ var Transform = require('../lib/transform');
 
 var internals = {
     transform: [
-        { ext: '.new', transform: function (content, filename) {
+        {
+            ext: '.new', transform: function (content, filename) {
 
-            return content.replace('!NOCOMPILE!', 'value = value ');
-        }},
-        { ext: '.inl', transform: function (content, filename) {
-
-            if (Buffer.isBuffer(content)) {
-                content = content.toString();
+                return content.replace('!NOCOMPILE!', 'value = value ');
             }
-            return content.concat(Os.EOL).concat('//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIkB0cmFjZXVyL2dlbmVyYXRlZC9UZW1wbGF0ZVBhcnNlci8xIiwiLi93aGlsZS5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiO0FBQUEsQUFBSSxFQUFBLENBQUEsWUFBVyxVQUFvQixDQUFDO0FDS3BDLEFBQUksRUFBQSxDQUFBLFNBQVEsRUFBSSxHQUFDLENBQUM7QUFHbEIsTUFBTSxPQUFPLEVBQUksVUFBVSxLQUFJLENBQUc7QUFFOUIsUUFBTSxLQUFJLENBQUc7QUFDVCxRQUFJLEVBQUksTUFBSSxDQUFDO0VBQ2pCO0FBQUEsQUFFQSxPQUFPLE1BQUksQ0FBQztBQUNoQixDQUFDIiwic291cmNlc0NvbnRlbnQiOlsidmFyIF9fbW9kdWxlTmFtZSA9ICRfX3BsYWNlaG9sZGVyX18wOyIsIi8vIExvYWQgbW9kdWxlc1xuXG5cbi8vIERlY2xhcmUgaW50ZXJuYWxzXG5cbnZhciBpbnRlcm5hbHMgPSB7fTtcblxuXG5leHBvcnRzLm1ldGhvZCA9IGZ1bmN0aW9uICh2YWx1ZSkge1xuXG4gICAgd2hpbGUodmFsdWUpIHtcbiAgICAgICAgdmFsdWUgPSBmYWxzZTtcbiAgICB9XG5cbiAgICByZXR1cm4gdmFsdWU7XG59O1xuIl19').concat(Os.EOL);
-        }},
+        },
+        {
+            ext: '.inl', transform: function (content, filename) {
+
+                if (Buffer.isBuffer(content)) {
+                    content = content.toString();
+                }
+                return content.concat(Os.EOL).concat('//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIkB0cmFjZXVyL2dlbmVyYXRlZC9UZW1wbGF0ZVBhcnNlci8xIiwiLi93aGlsZS5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiO0FBQUEsQUFBSSxFQUFBLENBQUEsWUFBVyxVQUFvQixDQUFDO0FDS3BDLEFBQUksRUFBQSxDQUFBLFNBQVEsRUFBSSxHQUFDLENBQUM7QUFHbEIsTUFBTSxPQUFPLEVBQUksVUFBVSxLQUFJLENBQUc7QUFFOUIsUUFBTSxLQUFJLENBQUc7QUFDVCxRQUFJLEVBQUksTUFBSSxDQUFDO0VBQ2pCO0FBQUEsQUFFQSxPQUFPLE1BQUksQ0FBQztBQUNoQixDQUFDIiwic291cmNlc0NvbnRlbnQiOlsidmFyIF9fbW9kdWxlTmFtZSA9ICRfX3BsYWNlaG9sZGVyX18wOyIsIi8vIExvYWQgbW9kdWxlc1xuXG5cbi8vIERlY2xhcmUgaW50ZXJuYWxzXG5cbnZhciBpbnRlcm5hbHMgPSB7fTtcblxuXG5leHBvcnRzLm1ldGhvZCA9IGZ1bmN0aW9uICh2YWx1ZSkge1xuXG4gICAgd2hpbGUodmFsdWUpIHtcbiAgICAgICAgdmFsdWUgPSBmYWxzZTtcbiAgICB9XG5cbiAgICByZXR1cm4gdmFsdWU7XG59O1xuIl19').concat(Os.EOL);
+            }
+        },
         { ext: '.js', transform: null }
     ]
 };


### PR DESCRIPTION
* updates eslint to 0.22.x
    * added `lines-around-comment` and `object-curly-spacing` rules
* updates jslint to 0.9.x
* removed linting thresholds because they are default now
* linting test are more strict
* added container based travis as per https://github.com/hapijs/contrib/issues/30