### PR TITLE
added extra rule (to make wreck pass linting)

### DIFF
--- a/lib/linters/eslint/.eslintrc
+++ b/lib/linters/eslint/.eslintrc
@@ -20,6 +20,7 @@
         "no-unused-expressions": 0,
         "no-regex-spaces": 0,
         "no-shadow": 0,
+        "no-catch-shadow": 0,
         "global-strict": 0,
         "handle-callback-err": 0,
         "no-lonely-if": 0,


### PR DESCRIPTION
prevents wreck build (https://travis-ci.org/hapijs/wreck/builds/64105510) from failing and the rule should only be used when supporting <IE8