### PR TITLE
Enforce capitalization of imported module variable names

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -8,7 +8,7 @@
 var Fs = require('fs');
 var Path = require('path');
 var Espree = require('espree');
-var sourceMapSupport = require('source-map-support');
+var SourceMapSupport = require('source-map-support');
 var Transform = require('./transform');
 
 
@@ -363,7 +363,7 @@ internals.addSourceMapsInformation = function (ret, num) {
         line: num,
         column: 0
     };
-    var originalPosition = sourceMapSupport.mapSourcePosition(position);
+    var originalPosition = SourceMapSupport.mapSourcePosition(position);
     var source = ret.source[num];
 
     if (position !== originalPosition) {

--- a/lib/linters/eslint/.eslintrc
+++ b/lib/linters/eslint/.eslintrc
@@ -25,6 +25,7 @@
         "no-lonely-if": 0,
         "space-in-brackets": 0,
         "brace-style": 0,
+        "hapi/hapi-capitalize-modules": [1, "global-scope-only"],
         "hapi/hapi-scope-start": 1,
         "dot-notation": 1,
         "eol-last": 1,


### PR DESCRIPTION
Per the style guide:

> Use uppercase variable names for imported modules