### PR TITLE
updated eslint to 0.23.x from 0.22.x

### DIFF
--- a/lib/linters/eslint/.eslintrc
+++ b/lib/linters/eslint/.eslintrc
@@ -66,6 +66,7 @@
         "indent": [2, 4],
         "space-before-function-paren": 2,
         "func-style": [2, "expression"],
-        "object-curly-spacing": [2, "always"]
+        "object-curly-spacing": [2, "always"],
+        "spaced-comment": [2, "always",{"markers":[","]}]
     }
 }


### PR DESCRIPTION
 Another eslint, another PR (until v1 :P)

* updated eslint to 0.23
* added space after comment rule, except when followed by `,` to allow comments for optional function params like `function (title /*, options, fn */)`