### PR TITLE
enable code coverage support with ES6

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -208,7 +208,20 @@ internals.instrument = function (filename) {
 
     // Parse tree
 
-    var tree = Espree.parse(content, { loc: true, comment: true, range: true });
+    var tree = Espree.parse(content, {
+        loc: true,
+        comment: true,
+        range: true,
+        ecmaFeatures: {
+            blockBindings: true,
+            arrowFunctions: true,
+            templateStrings: true,
+            generators: true,
+            forOf: true,
+            binaryLiterals: true,
+            octalLiterals: true
+        }
+    });
 
     // Process comments
 


### PR DESCRIPTION
features enabled
====
+ [x] arrowFunctions
+ [x] templateStrings
+ [x] blockBindings
+ [x] generators
+ [x] forOf
+ [x] binaryLiterals
+ [x] octalLiterals

There are additional options that could be enabled as well: https://github.com/eslint/espree#usage but I have elected to enable the ones I use most heavily and supported under iojs or node12; I'm unsure what, if any, negative consequence there may be to enabling them all by default.

This PR resolves issues raised at https://github.com/hapijs/lab/issues/358#issuecomment-103936194