### PR TITLE
Update to eslint 0.24.x and add array bracket spacing linting rule

### DIFF
--- a/lib/lint.js
+++ b/lib/lint.js
@@ -16,7 +16,7 @@ var internals = {
 exports.lint = function (settings, callback) {
 
     var child = ChildProcess.fork(internals.linters[settings.linter],
-                                  settings['lint-options'] ? [ settings['lint-options'] ] : [],
+                                  settings['lint-options'] ? [settings['lint-options']] : [],
                                   { cwd: settings.lintingPath });
     child.once('message', function (message) {
 

--- a/lib/linters/eslint/.eslintrc
+++ b/lib/linters/eslint/.eslintrc
@@ -29,6 +29,7 @@
         "hapi/no-shadow-relaxed": [1, { "ignore": ["err", "done"] }],
         "hapi/hapi-capitalize-modules": [1, "global-scope-only"],
         "hapi/hapi-scope-start": 1,
+        "array-bracket-spacing": 1,
         "dot-notation": 1,
         "eol-last": 1,
         "camelcase": 1,

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -6,7 +6,7 @@ var Fs = require('fs');
 
 var internals = {
     fileCache: {},
-    transforms: [ { ext: '.js', transform: null } ]
+    transforms: [{ ext: '.js', transform: null }]
 };
 
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "items": "1.x.x",
     "diff": "1.x.x",
     "source-map-support": "0.3.x",
-    "eslint": "0.22.x",
+    "eslint": "0.24.x",
     "hoek": "2.x.x",
     "mkdirp": "0.5.x"
   },


### PR DESCRIPTION
ESLint 0.24.0 was recently released. It includes a new rule, `array-bracket-spacing`, that is relevant to this part of the style guide:

`No space after [ and before ] in inlined arrays`