### PR TITLE
Test Reporters: Removing constraints and allowing multiple reporters

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -238,7 +238,7 @@ internals.options = function () {
             type: 'string',
             description: 'reporter type [console, html, json, tap, lcov, clover, junit]',
             default: 'console',
-            valid: ['console', 'html', 'json', 'tap', 'lcov', 'clover', 'junit']
+            multiple: true
         },
         silence: {
             alias: 's',


### PR DESCRIPTION
- removed constraints to allow use of custom reporters either through `./local_mod` or node modules folder like `some_reporter`
- added multiple to be true to allow `-r html -r console` etc