### PR TITLE
enable more es6 features for Espree

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -219,7 +219,9 @@ internals.instrument = function (filename) {
             generators: true,
             forOf: true,
             binaryLiterals: true,
-            octalLiterals: true
+            octalLiterals: true,
+            classes: true,
+            objectLiteralShorthandProperties: true
         }
     });
 


### PR DESCRIPTION
This PR enables classes and object literal shorthand properties in Espree. Without these turned on code coverage fails when testing code that uses these features.