### PR TITLE
Fix exit code when multiple reporters encounter a failure

### DIFF
--- a/lib/reporters/multiple.js
+++ b/lib/reporters/multiple.js
@@ -91,9 +91,14 @@ internals.Reporter.prototype.finalizeSingle = function (key, callback) {
         self._results.err = self._results.err || err;
         self._results.code[key] = code;
         self._results.output[key] = output;
+        self._results.processCode = self._results.processCode || code;
 
         if (self._results.count === Object.keys(self._reporters).length) {
-            callback(self._results.err, self._results.code, self._results.output);
+            if (callback) {
+                return callback(self._results.err, self._results.code, self._results.output);
+            }
+
+            process.exit(self._results.processCode);
         }
     };
 };

--- a/test/cli.js
+++ b/test/cli.js
@@ -120,6 +120,48 @@ describe('CLI', function () {
         });
     });
 
+    it('exits with code 1 when function returns error with multiple reporters', function (done) {
+
+        var cli = ChildProcess.spawn('node', [labPath, 'test/cli_failure/failure.js', '-r', 'console', '-r', 'lcov']);
+        var outData = '';
+        var errData = '';
+
+        cli.stdout.on('data', function (data) {
+
+            outData += data;
+        });
+
+        cli.stderr.on('data', function (data) {
+
+            errData += data;
+        });
+
+        cli.once('close', function (code) {
+
+            expect(code).to.not.equal(0);
+            done();
+        });
+    });
+
+    it('runs tests with multiple reporters', function (done) {
+
+        var cli = ChildProcess.spawn('node', [labPath, 'test/cli', '-r', 'console', '-r', 'lcov']);
+        var outData = '';
+
+        cli.stdout.on('data', function (data) {
+
+            outData += data;
+        });
+
+        cli.once('close', function (code, signal) {
+
+            expect(code).to.equal(0);
+            expect(signal).to.not.exist();
+            expect(outData).to.contain('10 tests complete');
+            done();
+        });
+    });
+
     it('displays a domain\'s error stack (-D)', function (done) {
 
         var cli = ChildProcess.spawn('node', [labPath, 'test/cli_throws/debug.js', '--debug']);

--- a/test/cli_error/failure.js
+++ b/test/cli_error/failure.js
@@ -1,0 +1,26 @@
+// Load modules
+
+var Code = require('code');
+var _Lab = require('../../test_runner');
+
+
+// Declare internals
+
+var internals = {};
+
+
+// Test shortcuts
+
+var lab = exports.lab = _Lab.script();
+var describe = lab.describe;
+var it = lab.it;
+var expect = Code.expect;
+
+
+describe('Test CLI', function () {
+
+    it('handles failure', function (done) {
+
+        done(new Error('fail'));
+    });
+});


### PR DESCRIPTION
Closes #393 .

We need to open a new issue, however, when a test throws an exception, since I still have not figured out how to solve it. 