### PR TITLE
Revert "Handle Promises returned by tests"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 // Load modules
 
 var Hoek = require('hoek');
-var Espree = require('espree');
 var Coverage = require('./coverage');
 var Leaks = require('./leaks');
 var Runner = require('./runner');
@@ -217,22 +216,7 @@ internals.test = function (title /*, options, fn */) {
     var fn = arguments.length === 3 ? arguments[2] : arguments[1];
 
     if (fn) {
-        var returns = false;
-
-        if (fn.length === 0) {
-            // create an AST with espree
-            var ast = Espree.parse('(' + fn.toString() + ')');
-            // ugly way to reach the function's BlockStatement
-            ast = ast.body.pop().expression.body.body;
-
-            var x = ast.length - 1;
-            while (!returns && x >= 0) {
-                returns = ast[x].type === 'ReturnStatement';
-                x--;
-            }
-        }
-
-        Hoek.assert(fn.length === 1 || returns, 'Function for test "' + title + '" should take exactly one argument or return a Promise');
+        Hoek.assert(fn.length === 1, 'Function for test "' + title + '" should take exactly one argument');
     }
 
     var settings = Utils.mergeOptions(this._current.options, options, ['only']);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -450,17 +450,10 @@ internals.protect = function (item, state, callback) {
     setImmediate(function () {
 
         domain.enter();
-
-        var fn = function (err) {
+        item.fn.call(null, function (err) {
 
             finish(err, 'done');
-        };
-
-        var thenable = item.fn.call(null, fn);
-        if (thenable && typeof thenable.then === 'function') {
-            thenable.then(fn.bind(undefined, null), fn);
-        }
-
+        });
         domain.exit();
     });
 };

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   },
   "devDependencies": {
     "code": "1.x.x",
-    "lab-event-reporter": "1.x.x",
-    "promise": "6.x.x"
+    "lab-event-reporter": "1.x.x"
   },
   "bin": {
     "lab": "./bin/lab"

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,5 @@
 // Load modules
 
-var Promise = require('promise');
 var Code = require('code');
 var _Lab = require('../test_runner');
 var Lab = require('../');
@@ -776,16 +775,13 @@ describe('Lab', function () {
 
         expect(function () {
 
-            script.test('a', function () {});
-        }).to.throw('Function for test "a" should take exactly one argument or return a Promise');
+            script.test('a');
+        }).not.to.throw();
 
         expect(function () {
 
-            script.test('a', function () {
-
-                return Promise.resolve();
-            });
-        }).not.to.throw();
+            script.test('a', function () {});
+        }).to.throw('Function for test "a" should take exactly one argument');
 
         ['before', 'beforeEach', 'after', 'afterEach'].forEach(function (fn) {
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -539,55 +539,6 @@ describe('Runner', function () {
         });
     });
 
-    it('can handle thenables', function (done) {
-
-        if (typeof Promise === 'undefined') {
-            var Promise = require('promise');
-        }
-
-        var script = Lab.script();
-        script.experiment('test', function () {
-
-            script.test('1', function (done) {
-
-                return Promise.resolve('done');
-            });
-
-            script.test('2', function (done) {
-
-                return Promise.reject(new Error('Promise Error'));
-            });
-
-            script.test('3', function (done) {
-
-                return {
-                    then: function (ok, ko) {
-
-                        ok('done');
-                    }
-                };
-            });
-
-            script.test('4', function (done) {
-
-                return {
-                    then: function (ok, ko) {
-
-                        ko(new Error('Thenable Error'));
-                    }
-                };
-            });
-        });
-
-        Lab.report(script, { output: false }, function (err, code, output) {
-
-            expect(code).to.equal(1);
-            expect(output).to.contain('Promise Error');
-            expect(output).to.contain('Thenable Error');
-            done();
-        });
-    });
-
     it('uses provided linter', function (done) {
 
         var script = Lab.script();


### PR DESCRIPTION
Reverts hapijs/lab#342

I started down this path, but supporting promises like this complicates the test functions.  Instead of allowing a return of a done/then statement a Promise can work with the done passed to the test and resolve it when the promise is done.  

We aren't doing anything at the moment to prevent promise support, but adding support for the `return { then }` isn't something I want to support at this time.

Thanks for your patience and effort in this solution.