### PR TITLE
Fix stack traces when using transforms

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -66,8 +66,10 @@ exports.transform = function (filename, content) {
 
 exports.retrieveFile = function (path) {
 
-    if (internals.fileCache[path]) {
-        return internals.fileCache[path];
+    var cwd = process.cwd();
+    var cacheKey = path.indexOf(cwd) === 0 ? path.substr(cwd.length + 1) : path;
+    if (internals.fileCache[cacheKey]) {
+        return internals.fileCache[cacheKey];
     }
 
     var contents = null;

--- a/test/transform.js
+++ b/test/transform.js
@@ -76,6 +76,19 @@ describe('Transform', function () {
 
         done();
     });
+
+    it('should return transformed file through for relative (cwd-rooted) and absolute paths', function (done) {
+
+        require('./transform/basic-transform'); // prime the cache
+
+        var rel = Transform.retrieveFile('test/transform/basic-transform.new');
+        expect(rel).to.not.contain('!NOCOMPILE!');
+
+        var abs = Transform.retrieveFile(process.cwd() + '/test/transform/basic-transform.new');
+        expect(abs).to.not.contain('!NOCOMPILE!');
+
+        done();
+    });
 });
 
 describe('Transform.install', function () {


### PR DESCRIPTION
In my environment, source-map-support is calling Transform.retrieveFile with absolute path, but cache of transformed sources uses relative path keys.