### PR TITLE
Show invisible tokens on stringify

### DIFF
--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -83,6 +83,29 @@ internals.spacer = function (length) {
 };
 
 
+internals.stringifyReplacer = function (key, value) {
+
+    // Show usually invisible values from JSON.stringify in a different way,
+    // follow the bracket format of json-stringify-safe.
+
+    if (value === undefined) {
+        return '[undefined]';
+    }
+
+    if (typeof value === 'function') {
+        return '[' + value.toString() + ']';
+    }
+
+    /* $lab:coverage:off$ */ // There is no way to cover that in node 0.10
+    if (typeof value === 'symbol') {
+        return '[' + value.toString() + ']';
+    }
+    /* $lab:coverage:on$ */
+
+    return value;
+};
+
+
 internals.Reporter.prototype.end = function (notebook) {
 
     if (this.settings.progress) {
@@ -144,8 +167,8 @@ internals.Reporter.prototype.end = function (notebook) {
             if (test.err.actual !== undefined &&
                 test.err.expected !== undefined) {
 
-                var actual = StringifySafe(test.err.actual, null, 2);
-                var expected = StringifySafe(test.err.expected, null, 2);
+                var actual = StringifySafe(test.err.actual, internals.stringifyReplacer, 2);
+                var expected = StringifySafe(test.err.expected, internals.stringifyReplacer, 2);
 
                 output += '      ' + redBg('actual') + ' ' + greenBg('expected') + '\n\n      ';
 

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -944,6 +944,36 @@ describe('Reporter', function () {
                 done();
             });
         });
+
+        it('reports with undefined values', function (done) {
+
+            var script = Lab.script();
+            script.experiment('test', function () {
+
+                script.test('works', function (finished) {
+
+                    var err = new Error('Fail');
+                    err.actual = { a: 1 };
+                    err.expected = {
+                        a: 1,
+                        b: undefined,
+                        c: function () {
+
+                            return 'foo';
+                        }
+                    };
+                    throw err;
+                });
+            });
+
+            Lab.report(script, { reporter: 'console', colors: false }, function (err, code, output) {
+
+                expect(err).not.to.exist();
+                var result = output.replace(/at.*\.js\:\d+\:\d+\)?/g, 'at <trace>');
+                expect(result).to.match(/^\n  \n  x\n\nFailed tests:\n\n  1\) test works:\n\n      actual expected\n\n      {\n        "a": 1,\n        "b": "\[undefined\]",\n        "c": "\[function \(\) \{\\n\\n\s+return 'foo';\\n\s+\}\]"\n      }\n\n      Fail\n\n(?:      at <trace>\n)+\n\n1 of 1 tests failed\nTest duration: \d+ ms\nNo global variable leaks detected\n\n$/);
+                done();
+            });
+        });
     });
 
     describe('json', function () {


### PR DESCRIPTION
My team is constantly having problems with deep equals that show diffs without the hidden parts, it's very hard to debug, so this is one possible solution.