### PR TITLE
Updated eslint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "bossy": "1.x.x",
     "diff": "1.x.x",
-    "eslint": "1.0.x",
+    "eslint": "1.x.x",
     "eslint-config-hapi": "1.x.x",
     "eslint-plugin-hapi": "1.x.x",
     "espree": "2.x.x",


### PR DESCRIPTION
I noticed a problem when integrating with CodeClimate. My CodeClimate eslint results were different to my Hapi Lab eslint results. When running eslint directly from the commandline I also got different results than with Hapy lab.

It turns out that it was just that a bug with the eslint in memory linter which has already been fixed - but Hapi Lab is fixed to eslint `1.0.x`.

I have updated the dependencies to `1.x.x` which matches more closely with the other dependencies. Lab now reports exactly the same results as the eslint commandline! 