### PR TITLE
Update to eslint-config-hapi@2.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "bossy": "1.x.x",
     "diff": "1.x.x",
     "eslint": "1.x.x",
-    "eslint-config-hapi": "1.x.x",
+    "eslint-config-hapi": "2.x.x",
     "eslint-plugin-hapi": "1.x.x",
     "espree": "2.x.x",
     "handlebars": "3.x.x",


### PR DESCRIPTION
This release contains proper linting for `switch-case` statements (with tests to help prevent regressions). I bumped the major version because existing lint jobs that depended on the old behavior would begin failing. I'll leave it up to you to sort out how you want to version lab. Verified that this closes #434.

UPDATE: Released v2.0.1. Closes #437