### PR TITLE
Update insecure dependencies (eslint, handlebars)

### DIFF
--- a/lib/reporters/html/report.html
+++ b/lib/reporters/html/report.html
@@ -497,7 +497,7 @@
                                 <td class="line">{{@key}}</td>
                                 <td class="hits">{{this.percent}}</td>
                                 <td class="source">{{#each this.chunks}}{{#if this.miss}}<div class="miss {{this.miss}}">{{this.source}}</div>{{else}}<div>{{this.source}}</div>{{/if}}{{/each}}</td>
-                                {{#if ../../../sourcemaps}}
+                                {{#if ../sourcemaps}}
                                     <td class="sourcemaps file">{{this.originalFilename}}</td>
                                     <td class="sourcemaps line">{{this.originalLine}}</td>
                                 {{/if}}
@@ -507,7 +507,7 @@
                                 <td class="line">{{@key}}</td>
                                 <td class="hits">{{this.percent}}</td>
                                 <td class="source">{{this.source}}</td>
-                                {{#if ../../../sourcemaps}}
+                                {{#if ../sourcemaps}}
                                     <td class="sourcemaps file">{{this.originalFilename}}</td>
                                     <td class="sourcemaps line">{{this.originalLine}}</td>
                                 {{/if}}
@@ -518,7 +518,7 @@
                             <td class="line">{{@key}}</td>
                             <td class="hits">{{hits this.hits}}</td>
                             <td class="source">{{this.source}}</td>
-                            {{#if ../../sourcemaps}}
+                            {{#if ../sourcemaps}}
                                 <td class="sourcemaps file">{{this.originalFilename}}</td>
                                 <td class="sourcemaps line">{{this.originalLine}}</td>
                             {{/if}}

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
   "dependencies": {
     "bossy": "1.x.x",
     "diff": "1.x.x",
-    "eslint": "1.3.x",
+    "eslint": "1.4.x",
     "eslint-config-hapi": "2.x.x",
     "eslint-plugin-hapi": "1.x.x",
     "espree": "2.x.x",
-    "handlebars": "3.x.x",
+    "handlebars": "4.x.x",
     "hoek": "2.x.x",
     "items": "1.x.x",
     "json-stringify-safe": "5.x.x",

--- a/test/linters.js
+++ b/test/linters.js
@@ -27,7 +27,7 @@ describe('Linters - eslint', function () {
             expect(eslintResults).to.have.length(1);
 
             var checkedFile = eslintResults[0];
-            expect(checkedFile).to.include({ filename: 'fail.js' });
+            expect(checkedFile).to.include({ filename: Path.join(path, 'fail.js') });
             expect(checkedFile.errors).to.deep.include([
                 { line: 11, severity: 'ERROR', message: 'semi - Missing semicolon.' },
                 { line: 12, severity: 'WARNING', message: 'eol-last - Newline required at end of file but not found.' }
@@ -48,7 +48,7 @@ describe('Linters - eslint', function () {
             expect(eslintResults).to.have.length(1);
 
             var checkedFile = eslintResults[0];
-            expect(checkedFile).to.include({ filename: 'fail.js' });
+            expect(checkedFile).to.include({ filename: Path.join(path, 'fail.js') });
             expect(checkedFile.errors).to.deep.include([
                 { line: 12, severity: 'ERROR', message: 'eol-last - Newline required at end of file but not found.' }]);
             expect(checkedFile.errors).to.not.deep.include({ line: 6, severity: 'ERROR', message: 'no-unused-vars - internals is defined but never used' });


### PR DESCRIPTION
handlebars@3.0.3 (also used in eslint @1.3.1) requires uglify-js@2.3.6, a
vulnerable version, see https://nodesecurity.io/advisories/module/uglify-js

This commit also addresses the changes introduced with the update of
both packages:

- eslint: Return the complete path of the linted file
  (see test/linters.js#30,51)
- handlebars: Depthed paths are now conditionally pushed on to the stack.
  (see https://github.com/wycats/handlebars.js/issues/1028)