### PR TITLE
-V/--version flag to show version

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ global manipulation. Our goal with **lab** is to keep the execution engine as si
 - `-t`, `--threshold` - minimum code test coverage percentage (sets `-c`), defaults to 100%.
 - `-T`, `--transform` - javascript file that exports an array of objects ie. `[ { ext: ".js", transform: function (content, filename) { ... } } ]`. Note that if you use this option with -c (--coverage), then you must generate sourcemaps and pass sourcemaps option to get proper line numbers.
 - `-v`, `--verbose` - verbose test output, defaults to false.
+- `-V`, `--version` - display lab version information.
 
 ## Usage
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -5,6 +5,7 @@ var Path = require('path');
 var Bossy = require('bossy');
 var Hoek = require('hoek');
 var Coverage = require('./coverage');
+var Pkg = require('../package.json');
 var Runner = require('./runner');
 var Transform = require('./transform');
 var Utils = require('./utils');
@@ -276,6 +277,11 @@ internals.options = function () {
             alias: 'v',
             type: 'boolean',
             description: 'verbose test output'
+        },
+        version: {
+            alias: 'V',
+            type: 'boolean',
+            description: 'version information'
         }
     };
 
@@ -289,6 +295,11 @@ internals.options = function () {
 
     if (argv.help) {
         console.log(Bossy.usage(definition, 'lab [options] [path]'));
+        process.exit(0);
+    }
+
+    if (argv.version) {
+        console.log(Pkg.version);
         process.exit(0);
     }
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -5,6 +5,7 @@ var Fs = require('fs');
 var Path = require('path');
 var Code = require('code');
 var Lab = require('../');
+var Pkg = require('../package.json');
 var _Lab = require('../test_runner');
 
 
@@ -262,6 +263,25 @@ describe('CLI', function () {
             expect(code).to.equal(0);
             expect(signal).to.not.exist();
             expect(output).to.contain('Usage: lab [options] [path]');
+            done();
+        });
+    });
+
+    it('shows the version (-V)', function (done) {
+
+        var cli = ChildProcess.spawn('node', [labPath, '-V']);
+        var output = '';
+
+        cli.stdout.on('data', function (data) {
+
+            output += data;
+        });
+
+        cli.once('close', function (code, signal) {
+
+            expect(code).to.equal(0);
+            expect(signal).to.not.exist();
+            expect(output).to.contain(Pkg.version);
             done();
         });
     });


### PR DESCRIPTION
CLI tools generally have a `--version` flag to print out version. Lab should too. 

I've caught myself running --version a number of times to see if I have the latest installed.

