### PR TITLE
Update to eslint-config-hapi@3.x.x

### DIFF
--- a/lib/linters/jslint/index.js
+++ b/lib/linters/jslint/index.js
@@ -1,7 +1,5 @@
 // Load modules
 
-var Fs = require('fs');
-var Path = require('path');
 var Hoek = require('hoek');
 var Nodejslint = require('jslint');
 

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -118,7 +118,6 @@ internals.Reporter.prototype.end = function (notebook) {
     var redBg = this.colors.redBg;
     var green = this.colors.green;
     var greenBg = this.colors.greenBg;
-    var magenta = this.colors.magenta;
     var gray = this.colors.gray;
     var yellow = this.colors.yellow;
 

--- a/lib/reporters/multiple.js
+++ b/lib/reporters/multiple.js
@@ -1,6 +1,5 @@
 // Load modules
 
-var Path = require('path');
 var Hoek = require('hoek');
 var Reporters = require('./index');
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "bossy": "1.x.x",
     "diff": "2.x.x",
     "eslint": "1.5.x",
-    "eslint-config-hapi": "2.x.x",
+    "eslint-config-hapi": "3.x.x",
     "eslint-plugin-hapi": "1.x.x",
     "espree": "2.x.x",
     "handlebars": "4.x.x",

--- a/test/lint/eslint/shadow-res/fail.js
+++ b/test/lint/eslint/shadow-res/fail.js
@@ -14,6 +14,8 @@ exports.method = function (value) {
 
             return value;
         };
+
+        return inner;
     };
 
     top();

--- a/test/lint/eslint/shadow/success.js
+++ b/test/lint/eslint/shadow/success.js
@@ -14,6 +14,8 @@ exports.method = function (value) {
 
             return value;
         };
+
+        return inner;
     };
 
     top();


### PR DESCRIPTION
This turns on the ESLint rule `no-unused-vars`. All variables must be used, with the exception of `internals` and function arguments, otherwise a linting warning is created.