### PR TITLE
Add objectLiteralShorthandMethods to supported ES6 features

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -221,7 +221,8 @@ internals.instrument = function (filename) {
             binaryLiterals: true,
             octalLiterals: true,
             classes: true,
-            objectLiteralShorthandProperties: true
+            objectLiteralShorthandProperties: true,
+            objectLiteralShorthandMethods: true
         }
     });
 


### PR DESCRIPTION
It's confusing that shorthand properties are enabled, but methods aren't.