### PR TITLE
Fix error forwarding using active domain

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -429,12 +429,13 @@ internals.protect = function (item, state, callback) {
         }, ms);
     }
 
-    var onError = function (err, isForward) {
+    var onError = function (err) {
+        // 1. EventEmitters can emit errors in the domain which they are created.
+        // 2. If the error domain does not match the active domain forward the error to the active domain
+        var activeDomain = Domain.active;
 
-        // 1. Do not forward what's already a forward.
-        // 2. Only errors that reach before*/after* are worth forwarding, otherwise we know where they came from.
-        if (!isForward && item.id === undefined) {
-            internals.forwardError(err, domain, domains);
+        if (activeDomain && domain !== activeDomain) {
+            return activeDomain.emit('error', err);
         }
 
         if (state.options.debug) {
@@ -458,17 +459,6 @@ internals.protect = function (item, state, callback) {
         });
         domain.exit();
     });
-};
-
-
-internals.forwardError = function (err, sourceDomain, targetDomains) {
-
-    for (var s = 0, sl = targetDomains.length; s < sl; ++s) {
-        var d = targetDomains[s];
-        if (d !== sourceDomain) {
-            d.emit('error', err, true); // Add true to mark this as a forward.
-        }
-    }
 };
 
 


### PR DESCRIPTION
#### Example of Problem
```js
var Lab = require('lab')
var lab = exports.lab = Lab.script()
var before = lab.before
var beforeEach = lab.beforeEach
var through2 = require('through2')

var describe = lab.describe
var it = lab.it

describe('example', function () {
  var ctx
  describe('error emitted in beforeEach', function () {
    before(function (done) {
      ctx = {}
      ctx.stream = through2()
      done()
    })
    beforeEach(function (done) {
      emitErr()
      done()
    })

    it('should error', function (done) {
      done()
    })
  })

  describe('error emitted in test', function () {
    before(function (done) {
      ctx = {}
      ctx.stream = through2()
      done()
    })
    beforeEach(function (done) {
      done()
    })

    it('should error', function (done) {
      emitErr()
    })
  })
  function emitErr () {
    ctx.stream.emit('error')
  }
})
```

#### Lab incorrectly prints error locations
```bash

  xx

Test script errors:

Multiple callbacks or thrown errors received in test "Before example error emitted in beforeEach" (error): Uncaught, unspecified "error" event.
      at DestroyableTransform.emit (events.js:66:23)
      at emitErr (/Users/tjmehta/Developer/+lab/lab-test/lab-master/test-master.js:43:16)
      at /Users/tjmehta/Developer/+lab/lab-test/lab-master/test-master.js:19:7
      at processImmediate [as _immediateCallback] (timers.js:354:15)

Multiple callbacks or thrown errors received in test "Before each example error emitted in beforeEach" (done)
      at /Users/tjmehta/Developer/+lab/lab-test/lab-master/test-master.js:20:7
      at processImmediate [as _immediateCallback] (timers.js:354:15)

Multiple callbacks or thrown errors received in test "Before example error emitted in beforeEach" (error): Uncaught, unspecified "error" event.
      at DestroyableTransform.emit (events.js:66:23)
      at emitErr (/Users/tjmehta/Developer/+lab/lab-test/lab-master/test-master.js:43:16)
      at /Users/tjmehta/Developer/+lab/lab-test/lab-master/test-master.js:19:7
      at processImmediate [as _immediateCallback] (timers.js:354:15)

Multiple callbacks or thrown errors received in test "Before each example error emitted in test" (error): Uncaught, unspecified "error" event.
      at DestroyableTransform.emit (events.js:66:23)
      at emitErr (/Users/tjmehta/Developer/+lab/lab-test/lab-master/test-master.js:43:16)
      at /Users/tjmehta/Developer/+lab/lab-test/lab-master/test-master.js:39:7
      at processImmediate [as _immediateCallback] (timers.js:354:15)

Multiple callbacks or thrown errors received in test "Before example error emitted in test" (error)
      at Domain.emit (events.js:95:17)
      at DestroyableTransform.emit (events.js:70:21)
      at emitErr (/Users/tjmehta/Developer/+lab/lab-test/lab-master/test-master.js:43:16)
      at /Users/tjmehta/Developer/+lab/lab-test/lab-master/test-master.js:39:7
      at processImmediate [as _immediateCallback] (timers.js:354:15)

There were 5 test script error(s).

Failed tests:

  1) example error emitted in beforeEach should error:




  2) example error emitted in test should error:

      Multiple callbacks or thrown errors received in test "Before each example error emitted in test" (error): Uncaught, unspecified "error" event.

      at DestroyableTransform.emit (events.js:66:23)
      at emitErr (/Users/tjmehta/Developer/+lab/lab-test/lab-master/test-master.js:43:16)
      at /Users/tjmehta/Developer/+lab/lab-test/lab-master/test-master.js:39:7
      at Object._onImmediate (/Users/tjmehta/Developer/+lab/lab-test/lab-master/node_modules/lab/lib/runner.js:455:17)
      at processImmediate [as _immediateCallback] (timers.js:354:15)


2 of 2 tests failed
Test duration: 6 ms
No global variable leaks detected
```

#### Lab w/ this fix prints errors correctly
```bash

  xx

Test script errors:

Multiple callbacks or thrown errors received in test "Before each example error emitted in beforeEach" (done)
      at /Users/tjmehta/Developer/+lab/lab-test/lab-tjmehta/test-tjmehta.js:20:7
      at processImmediate [as _immediateCallback] (timers.js:354:15)

Uncaught, unspecified "error" event.
      at DestroyableTransform.emit (events.js:66:23)
      at emitErr (/Users/tjmehta/Developer/+lab/lab-test/lab-tjmehta/test-tjmehta.js:43:16)
      at /Users/tjmehta/Developer/+lab/lab-test/lab-tjmehta/test-tjmehta.js:19:7
      at processImmediate [as _immediateCallback] (timers.js:354:15)

There were 2 test script error(s).

Failed tests:

  1) example error emitted in beforeEach should error:




  2) example error emitted in test should error:

      Uncaught, unspecified "error" event.

      at DestroyableTransform.emit (events.js:66:23)
      at emitErr (/Users/tjmehta/Developer/+lab/lab-test/lab-tjmehta/test-tjmehta.js:43:16)
      at /Users/tjmehta/Developer/+lab/lab-test/lab-tjmehta/test-tjmehta.js:39:7
      at Object._onImmediate (/Users/tjmehta/Developer/+lab/lab-test/lab-tjmehta/node_modules/lab/lib/runner.js:456:17)
      at processImmediate [as _immediateCallback] (timers.js:354:15)


2 of 2 tests failed
Test duration: 6 ms
No global variable leaks detected
```

