### PR TITLE
Improved emitter err handling using EmitterDomain, removed forwardError

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,6 +1,7 @@
 // Load modules
 
 var Domain = require('domain');
+var EmitterDomain = require('emitter-domain');
 var Items = require('items');
 var Reporters = require('./reporters');
 var Coverage = require('./coverage');
@@ -14,7 +15,10 @@ var Date = global.Date;
 var setTimeout = global.setTimeout;
 var clearTimeout = global.clearTimeout;
 var setImmediate = global.setImmediate;
-
+// emitter domains support more traceable event emitter error handling
+// they require wrapped event emitter methods to provide advanced behavior
+// wrap them here in case any tests modify EventEmitter
+EmitterDomain.wrapEventEmitterMethods();
 
 // Declare internals
 
@@ -429,13 +433,7 @@ internals.protect = function (item, state, callback) {
         }, ms);
     }
 
-    var onError = function (err, isForward) {
-
-        // 1. Do not forward what's already a forward.
-        // 2. Only errors that reach before*/after* are worth forwarding, otherwise we know where they came from.
-        if (!isForward && item.id === undefined) {
-            internals.forwardError(err, domain, domains);
-        }
+    var onError = function (err) {
 
         if (state.options.debug) {
             state.report.errors.push(err);
@@ -444,7 +442,7 @@ internals.protect = function (item, state, callback) {
         finish(err, 'error');
     };
 
-    var domain = Domain.createDomain();
+    var domain = EmitterDomain.createDomain();
     domain.title = item.title;
     domain.on('error', onError);
     domains.push(domain);
@@ -458,17 +456,6 @@ internals.protect = function (item, state, callback) {
         });
         domain.exit();
     });
-};
-
-
-internals.forwardError = function (err, sourceDomain, targetDomains) {
-
-    for (var s = 0, sl = targetDomains.length; s < sl; ++s) {
-        var d = targetDomains[s];
-        if (d !== sourceDomain) {
-            d.emit('error', err, true); // Add true to mark this as a forward.
-        }
-    }
 };
 
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "bossy": "1.x.x",
     "diff": "2.x.x",
+    "emitter-domain": "^1.0.1",
     "eslint": "1.5.x",
     "eslint-config-hapi": "3.x.x",
     "eslint-plugin-hapi": "1.x.x",


### PR DESCRIPTION
Using EmitterDomain we are able to determine the exact `before`, `beforeEach`, `test`, etc where an EventEmitter error occurs. Including both errors that occur in event handlers or emitted errors.

Continuing discussion from #463