### PR TITLE
Add context as an alias to script.experiment.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,6 +67,7 @@ exports.script = function (options) {
     script.experiment.skip = internals.skip(script, 'experiment');
     script.experiment.only = internals.only(script, 'experiment');
     script.describe = script.experiment;
+    script.context = script.experiment;
     script.suite = script.experiment;
 
     script.test = internals.test.bind(script);


### PR DESCRIPTION
Add context as an alias to script.experiment to improve organization of tests. This pattern is often seen in other BDD interfaces (see: mochajs.org and vowsjs.org).