### PR TITLE
Do not add tracking code before "var" in "for(var x of xs)"

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -162,7 +162,7 @@ internals.instrument = function (filename) {
         ];
 
         if (trackedTypes.indexOf(node.type) !== -1 &&
-            (node.type !== 'VariableDeclaration' || (node.parent.type !== 'ForStatement' && node.parent.type !== 'ForInStatement')) &&
+            (node.type !== 'VariableDeclaration' || (node.parent.type !== 'ForStatement' && node.parent.type !== 'ForInStatement'  && node.parent.type !== 'ForOfStatement')) &&
             (node.type !== 'ExpressionStatement' || node.expression.value !== 'use strict') &&
             node.parent.type !== 'LabeledStatement') {
 

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -49,10 +49,10 @@ describe('Coverage', function () {
         Test.method(1, 2, 3);
 
         var cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/partial') });
-        expect(Math.floor(cov.percent)).to.equal(59);
-        expect(cov.sloc).to.equal(47);
+        expect(Math.floor(cov.percent)).to.equal(62);
+        expect(cov.sloc).to.equal(51);
         expect(cov.misses).to.equal(19);
-        expect(cov.hits).to.equal(28);
+        expect(cov.hits).to.equal(32);
         done();
     });
 

--- a/test/coverage/partial.js
+++ b/test/coverage/partial.js
@@ -59,6 +59,10 @@ exports.method = function (a, b, c) {
     for (var k in j) {
         ++l;
     }
+    
+    for (var o of j) {      
+        ++l;
+    }
 
     var m = (a ? b : c) || (c ? d : e);
 


### PR DESCRIPTION
Fixes #470 

Do not add tracking code before `var` in `for(var x of xs)`
This occurs when this is true:
```javascript
node.type == "VariableDeclaration"
node.parent.type == "ForOfStatement"
```

This PR includes new code in `partial.js` (as this was where I found `for(var x in xs)`) which is used in a test in `coverage.js`. 
I hope this was the correct place to add it.