### PR TITLE
Add objectLiteralShorthandMethods to supported ES6 features

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -223,6 +223,7 @@ internals.instrument = function (filename) {
             binaryLiterals: true,
             octalLiterals: true,
             classes: true,
+            objectLiteralComputedProperties: true,
             objectLiteralShorthandProperties: true,
             objectLiteralShorthandMethods: true
         }


### PR DESCRIPTION
Fixes issue #491.