### PR TITLE
fix diff text visibility for console reporter

### DIFF
--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -339,7 +339,7 @@ internals.color = function (name, code, enabled) {
 
             return color + text + '\u001b[0m';
         };
-    } 
+    }
     else if (enabled) {
         const color = '\u001b[' + code + 'm';
         return function (text) {

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -333,16 +333,14 @@ internals.Reporter.prototype.end = function (notebook) {
 
 internals.color = function (name, code, enabled) {
 
-    if (enabled && !Array.isArray(code)) {
-        const color = '\u001b[' + code + 'm';
+    if (enabled && Array.isArray(code)) {
+        const color = '\u001b[' + code[0] + ';' + code[1] + 'm';
         return function (text) {
 
             return color + text + '\u001b[0m';
         };
-    }
-
-    if (enabled && Array.isArray(code)) {
-        const color = '\u001b[' + code[0] + ';' + code[1] + 'm';
+    } else if (enabled) {
+        const color = '\u001b[' + code + 'm';
         return function (text) {
 
             return color + text + '\u001b[0m';

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -371,7 +371,7 @@ internals.colors = function (enabled) {
         'magenta': 35,
         'redBg': 41,
         'greenBg': 42,
-        'whiteRedBg': [255, 41],
+        'whiteRedBg': [37, 41],
         'blackGreenBg': [30, 42]
     };
 

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -339,7 +339,8 @@ internals.color = function (name, code, enabled) {
 
             return color + text + '\u001b[0m';
         };
-    } else if (enabled) {
+    } 
+    else if (enabled) {
         const color = '\u001b[' + code + 'm';
         return function (text) {
 

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -117,9 +117,7 @@ internals.Reporter.prototype.end = function (notebook) {
     // Colors
 
     const red = this.colors.red;
-    const redBg = this.colors.redBg;
     const green = this.colors.green;
-    const greenBg = this.colors.greenBg;
     const gray = this.colors.gray;
     const yellow = this.colors.yellow;
     const whiteRedBg = this.colors.whiteRedBg;

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -122,6 +122,8 @@ internals.Reporter.prototype.end = function (notebook) {
     const greenBg = this.colors.greenBg;
     const gray = this.colors.gray;
     const yellow = this.colors.yellow;
+    const whiteRedBg = this.colors.whiteRedBg;
+    const blackGreenBg = this.colors.blackGreenBg;
 
     // Tests
 
@@ -171,7 +173,7 @@ internals.Reporter.prototype.end = function (notebook) {
                 const actual = StringifySafe(test.err.actual, internals.stringifyReplacer, 2);
                 const expected = StringifySafe(test.err.expected, internals.stringifyReplacer, 2);
 
-                output += '      ' + redBg('actual') + ' ' + greenBg('expected') + '\n\n      ';
+                output += '      ' + whiteRedBg('actual') + ' ' + blackGreenBg('expected') + '\n\n      ';
 
                 const comparison = Diff.diffWords(actual, expected);
                 for (let j = 0; j < comparison.length; ++j) {
@@ -184,7 +186,7 @@ internals.Reporter.prototype.end = function (notebook) {
                         }
 
                         if (item.added || item.removed) {
-                            output += item.added ? greenBg(lines[k]) : redBg(lines[k]);
+                            output += item.added ? blackGreenBg(lines[k]) : whiteRedBg(lines[k]);
                         }
                         else {
                             output += lines[k];
@@ -333,8 +335,16 @@ internals.Reporter.prototype.end = function (notebook) {
 
 internals.color = function (name, code, enabled) {
 
-    if (enabled) {
+    if (enabled && !Array.isArray(code)) {
         const color = '\u001b[' + code + 'm';
+        return function (text) {
+
+            return color + text + '\u001b[0m';
+        };
+    }
+
+    if (enabled && Array.isArray(code)) {
+        const color = '\u001b[' + code[0] + ';' + code[1] + 'm';
         return function (text) {
 
             return color + text + '\u001b[0m';
@@ -362,7 +372,9 @@ internals.colors = function (enabled) {
         'yellow': 33,
         'magenta': 35,
         'redBg': 41,
-        'greenBg': 42
+        'greenBg': 42,
+        'whiteRedBg': [255, 41],
+        'blackGreenBg': [30, 42]
     };
 
     const colors = {};


### PR DESCRIPTION
Modified internals.color to accept an array of color codes and added new color codes to the internals.colors method as well.

See: [#493] (https://github.com/hapijs/lab/issues/493)
