### PR TITLE
Fix eslint configuration file format support.

### DIFF
--- a/lib/linters/eslint/.eslintrc
+++ b/lib/linters/eslint/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": "eslint-config-hapi"
-}

--- a/lib/linters/eslint/.eslintrc.js
+++ b/lib/linters/eslint/.eslintrc.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+    'extends': 'eslint-config-hapi'
+};

--- a/lib/linters/eslint/index.js
+++ b/lib/linters/eslint/index.js
@@ -21,7 +21,11 @@ exports.lint = function () {
 
     const options = process.argv[2] ? JSON.parse(process.argv[2]) : undefined;
 
-    if (!Fs.existsSync('.eslintrc')) {
+    if (!Fs.existsSync('.eslintrc.js') &&
+        !Fs.existsSync('.eslintrc.yaml') &&
+        !Fs.existsSync('.eslintrc.yml') &&
+        !Fs.existsSync('.eslintrc.json') &&
+        !Fs.existsSync('.eslintrc')) {
         configuration.configFile = Path.join(__dirname, '.eslintrc');
     }
 

--- a/lib/linters/eslint/index.js
+++ b/lib/linters/eslint/index.js
@@ -26,7 +26,7 @@ exports.lint = function () {
         !Fs.existsSync('.eslintrc.yml') &&
         !Fs.existsSync('.eslintrc.json') &&
         !Fs.existsSync('.eslintrc')) {
-        configuration.configFile = Path.join(__dirname, '.eslintrc');
+        configuration.configFile = Path.join(__dirname, '.eslintrc.js');
     }
 
     if (!Fs.existsSync('.eslintignore')) {

--- a/test/lint/eslint/with_config/.eslintrc
+++ b/test/lint/eslint/with_config/.eslintrc
@@ -1,7 +1,0 @@
-{
-    "rules": {
-        "eol-last": 2,
-        "no-unused-vars": 0,
-        "no-undef": 0
-    }
-}

--- a/test/lint/eslint/with_config/.eslintrc.js
+++ b/test/lint/eslint/with_config/.eslintrc.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+    'rules': {
+        'eol-last': 2,
+        'no-unused-vars': 0,
+        'no-undef': 0
+    }
+};


### PR DESCRIPTION
- Fix eslint configuration file checks.
- Use **.eslintrc.js** instead of **.eslintrc** as the default configuration file.
- Solves #504 