### PR TITLE
Fix coverage when require cache is reset

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -285,22 +285,24 @@ internals.instrument = function (filename) {
         };
     }                                                   // $lab:coverage:on$
 
-    global.__$$labCov.files[filename] = {
-        statements: {},
-        lines: {}
-    };
+    if (typeof global.__$$labCov.files[filename] === 'undefined') {
+        global.__$$labCov.files[filename] = {
+            statements: {},
+            lines: {}
+        };
 
-    const record = global.__$$labCov.files[filename];
-    tracking.forEach((item) => {
+        const record = global.__$$labCov.files[filename];
+        tracking.forEach((item) => {
 
-        record.lines[item] = 0;
-    });
+            record.lines[item] = 0;
+        });
 
-    statements.forEach((item) => {
+        statements.forEach((item) => {
 
-        record.statements[item.line] = record.statements[item.line] || {};
-        record.statements[item.line][item.id] = { hit: {}, bool: item.bool, loc: item.loc };
-    });
+            record.statements[item.line] = record.statements[item.line] || {};
+            record.statements[item.line][item.id] = { hit: {}, bool: item.bool, loc: item.loc };
+        });
+    }
 
     return chunks.join('');
 };

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -3,6 +3,7 @@
 // Load modules
 
 const Path = require('path');
+const Module = require('module')
 const Code = require('code');
 const _Lab = require('../test_runner');
 const Lab = require('../');
@@ -229,6 +230,24 @@ describe('Coverage', () => {
             });
 
             expect(sorted).to.deep.equal(['/a/b', '/a/c', '/a/b/a', '/a/b/c', '/a/c/b']);
+            done();
+        });
+    });
+
+    describe('Clear require cache', () => {
+
+        it('does not reset file coverage', (done) => {
+
+            const cacheBackup = require.cache; // backup require cache
+            const filename = Path.resolve(__dirname, './coverage/basic.js')
+            let file = require('./coverage/basic');
+            const fileCovBefore = global.__$$labCov.files[filename];
+            require.cache = Module._cache = {}; // clear require cache before additional require
+            file = require('./coverage/basic');
+            require.cache = Module._cache = cacheBackup; // restore require cache
+
+            const fileCovAfter = global.__$$labCov.files[filename];
+            expect(fileCovAfter).to.equal(fileCovBefore)
             done();
         });
     });


### PR DESCRIPTION
Require-mocking libraries (such as [proxyquire](https://github.com/thlorenz/proxyquire/issues/92)) and other modules may reset the require cache and enable requiring the same file multiple times.