### PR TITLE
lint JS in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ const lab = exports.lab = Lab.script();
 
 lab.test('returns true when 1 + 1 equals 2', (done) => {
 
-    Code.expect(1+1).to.equal(2);
+    Code.expect(1 + 1).to.equal(2);
     done();
 });
 ```
@@ -99,7 +99,7 @@ lab.experiment('math', () => {
 
     lab.test('returns true when 1 + 1 equals 2', (done) => {
 
-        Code.expect(1+1).to.equal(2);
+        Code.expect(1 + 1).to.equal(2);
         done();
     });
 });
@@ -114,7 +114,10 @@ lab.experiment('math', () => {
     lab.before((done) => {
 
         // Wait 1 second
-        setTimeout(() => { done(); }, 1000);
+        setTimeout(() => {
+
+            done();
+        }, 1000);
     });
 
     lab.beforeEach((done) => {
@@ -125,10 +128,11 @@ lab.experiment('math', () => {
 
     lab.test('returns true when 1 + 1 equals 2', (done) => {
 
-        Code.expect(1+1).to.equal(2);
+        Code.expect(1 + 1).to.equal(2);
         done();
     });
 });
+
 ```
 
 Both `test()` and `experiment()` accept an optional `options` argument which must be an object with the following optional keys:
@@ -151,7 +155,7 @@ lab.experiment('math', { timeout: 1000 }, () => {
 
     lab.test('returns true when 1 + 1 equals 2', { parallel: true }, (done) =>  {
 
-        Code.expect(1+1).to.equal(2);
+        Code.expect(1 + 1).to.equal(2);
         done();
     });
 });
@@ -180,9 +184,19 @@ const expect = Code.expect;
 
 describe('math', () => {
 
+    before((done) => {
+
+        done();
+    });
+
+    after((done) => {
+
+        done();
+    });
+
     it('returns true when 1 + 1 equals 2', (done) => {
 
-        expect(1+1).to.equal(2);
+        expect(1 + 1).to.equal(2);
         done();
     });
 });
@@ -196,15 +210,13 @@ const lab = exports.lab = Lab.script();
 
 const suite = lab.suite;
 const test = lab.test;
-const before = lab.before;
-const after = lab.after;
 const expect = Code.expect;
 
 suite('math', () => {
 
     test('returns true when 1 + 1 equals 2', (done) => {
 
-        expect(1+1).to.equal(2);
+        expect(1 + 1).to.equal(2);
         done();
     });
 });
@@ -258,6 +270,7 @@ if (typeof value === 'symbol') {
     return '[' + value.toString() + ']';
 }
 /* $lab:coverage:on$ */
+
 ```
 
 ## Extending the linter

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "code": "2.x.x",
     "cpr": "1.0.x",
+    "eslint-plugin-markdown": "1.0.0-beta.1",
     "lab-event-reporter": "1.x.x",
     "rimraf": "2.4.x"
   },
@@ -38,8 +39,10 @@
   },
   "scripts": {
     "test": "./bin/_lab -fL -t 100 -m 3000",
+    "posttest": "npm run lint-md",
     "test-cov-html": "./bin/_lab -fL -r html -m 3000 -o coverage.html",
-    "lint": "./bin/_lab -d -f -L"
+    "lint": "./bin/_lab -d -f -L",
+    "lint-md": "eslint --config hapi --rule 'strict: 0, eol-last: 0' --plugin markdown --ext md  ."
   },
   "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
When adding the CoffeeScript transform example in #512, I wanted to make sure it followed the style guide but that required running `eslint` against a temporary JS file. By happenstance, I came across [eslint-plugin-markdown](https://www.npmjs.com/package/eslint-plugin-markdown) yesterday which lints code fences in Markdown files. Now, whenever someone runs `npm test` or `npm run lint-md` the JS snippets in any `.md` files (primarily `README.md`) will be linted.