### PR TITLE
upgrade to espree@3.x.x

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -214,20 +214,7 @@ internals.instrument = function (filename) {
         loc: true,
         comment: true,
         range: true,
-        ecmaFeatures: {
-            blockBindings: true,
-            arrowFunctions: true,
-            templateStrings: true,
-            generators: true,
-            forOf: true,
-            binaryLiterals: true,
-            octalLiterals: true,
-            classes: true,
-            spread: true,
-            objectLiteralComputedProperties: true,
-            objectLiteralShorthandProperties: true,
-            objectLiteralShorthandMethods: true
-        }
+        ecmaVersion: 6
     });
 
     // Process comments

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "eslint": "1.10.x",
     "eslint-config-hapi": "8.x.x",
     "eslint-plugin-hapi": "4.x.x",
-    "espree": "2.x.x",
+    "espree": "3.x.x",
     "handlebars": "4.x.x",
     "hoek": "3.x.x",
     "items": "2.x.x",


### PR DESCRIPTION
[espree@3.0.0](https://github.com/eslint/espree/releases/tag/v3.0.0) has been released. Most of the `ecmaFeatures` have been removed (the remaining are currently `jsx`, `globalReturn`, and `experimentalObjectRestSpread`). It has been replaced with `ecmaVersion`. It is much more concise, and allows us to target ES6, instead of constantly adding more `ecmaFeatures`. An explanation is available at http://eslint.org/blog/2015/12/espree-3-alpha-2-released/.