### PR TITLE
update to eslint@2.x.x

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,3 @@
 node_modules
 test_runner
-test/*/**
+test/**/**

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "bossy": "1.x.x",
     "diff": "2.x.x",
-    "eslint": "1.10.x",
-    "eslint-config-hapi": "8.x.x",
+    "eslint": "2.x.x",
+    "eslint-config-hapi": "9.x.x",
     "eslint-plugin-hapi": "4.x.x",
     "espree": "3.x.x",
     "handlebars": "4.x.x",
@@ -32,7 +32,7 @@
     "cpr": "1.0.x",
     "eslint-plugin-markdown": "1.0.0-beta.1",
     "lab-event-reporter": "1.x.x",
-    "rimraf": "2.4.x"
+    "rimraf": "2.5.x"
   },
   "bin": {
     "lab": "./bin/lab"


### PR DESCRIPTION
The `.eslintignore` changed just slightly. And due to, what appears to be, npm3 issues, the rimraf dependency needed to be updated, otherwise a bad version of `glob` was being installed on my local machine.