### PR TITLE
Fix coverage report for single-line functions and single-expression arrow functions

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -156,6 +156,10 @@ internals.instrument = function (filename) {
             }
         }
 
+        if (node.type === 'ExpressionStatement' && node.expression.value === 'use strict') {
+            return;
+        }
+
         const trackedTypes = [
             'ExpressionStatement',
             'BreakStatement',
@@ -175,9 +179,18 @@ internals.instrument = function (filename) {
             'LabeledStatement'
         ];
 
-        if (trackedTypes.indexOf(node.type) !== -1 &&
+
+        if (node.parent && node.parent.type === 'BlockStatement' &&
+            node.parent.parent.type.includes('FunctionExpression') &&
+            node.parent.body[0] === node) {
+
+            line = node.loc.start.line;
+            const id = addStatement(line, node, false);
+
+            node.set(`global.__$$labCov._statement('${filename}', ${id}, ${line}, true); ${node.source()};`);
+        }
+        else if (trackedTypes.indexOf(node.type) !== -1 &&
             (node.type !== 'VariableDeclaration' || (node.parent.type !== 'ForStatement' && node.parent.type !== 'ForInStatement'  && node.parent.type !== 'ForOfStatement')) &&
-            (node.type !== 'ExpressionStatement' || node.expression.value !== 'use strict') &&
             node.parent.type !== 'LabeledStatement') {
 
             tracking.push(node.loc.start.line);

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -197,6 +197,14 @@ internals.instrument = function (filename) {
 
             node.set('(global.__$$labCov._statement(\'' + filename + '\',' + left + ',' + line + ',' + node.left.source() + ')' + node.operator + 'global.__$$labCov._statement(\'' + filename + '\',' + right + ',' + line + ',' + node.right.source() + '))');
         }
+        else if (node.parent && node.parent.type === 'ArrowFunctionExpression' &&
+            node.type.includes('Expression')) {
+
+            line = node.loc.start.line;
+            const id = addStatement(line, node, false);
+
+            node.set(`global.__$$labCov._statement('${filename}', ${id}, ${line}, ${node.source()})`);
+        }
         else if (node.parent &&
             node.parent.test === node &&
             node.parent.type !== 'SwitchCase') {

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -216,15 +216,15 @@ describe('Coverage', () => {
 
         const Test = require('./coverage/single-line-functions');
         let results = [];
-        for(let i = 1; i <= 9; ++i) {
+        for(let i = 1; i <= 10; ++i) {
         	results.push(Test[`method${i}`](3, 4));
         }
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/single-line-functions') });
         const source = cov.files[0].source;
         const missedLines = Object.keys(source).filter((lineNumber) => source[lineNumber].miss);
-        expect(results).to.deep.equal([7, 7, 7, 7, 7, 7, 7, 7, 7]);
-        expect(missedLines).to.deep.equal(['12', '15', '21', '27', '30', '33', '39', '46', '50']);
+        expect(results).to.deep.equal([7, 7, 7, 7, 7, 7, 7, 7, 7, 7]);
+        expect(missedLines).to.deep.equal(['12', '15', '21', '27', '30', '33', '39', '46', '50', '53']);
         done();
     });
 

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -212,7 +212,7 @@ describe('Coverage', () => {
         done();
     });
 
-    it('measures missing coverage on single-line functions correctly', (done) => {
+    it('should measure missing coverage on single-line functions correctly', (done) => {
 
         const Test = require('./coverage/single-line-functions');
         let results = [];

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -220,11 +220,15 @@ describe('Coverage', () => {
         	results.push(Test[`method${i}`](3, 4));
         }
 
+        results.push(Test.method11(5, 10));
+        results.push(Test.method11(0, 10));
+        results.push(Test.method11Partial(5, 10));
+
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/single-line-functions') });
         const source = cov.files[0].source;
         const missedLines = Object.keys(source).filter((lineNumber) => source[lineNumber].miss);
-        expect(results).to.deep.equal([7, 7, 7, 7, 7, 7, 7, 7, 7, 7]);
-        expect(missedLines).to.deep.equal(['12', '15', '21', '27', '30', '33', '39', '46', '50', '53']);
+        expect(results).to.deep.equal([7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 5, 10, 5]);
+        expect(missedLines).to.deep.equal(['12', '15', '21', '27', '30', '33', '39', '46', '50', '53', '56']);
         done();
     });
 

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -216,15 +216,15 @@ describe('Coverage', () => {
 
         const Test = require('./coverage/single-line-functions');
         let results = [];
-        for(let i = 1; i < 9; ++i) {
+        for(let i = 1; i <= 9; ++i) {
         	results.push(Test[`method${i}`](3, 4));
         }
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/single-line-functions') });
         const source = cov.files[0].source;
         const missedLines = Object.keys(source).filter((lineNumber) => source[lineNumber].miss);
-        expect(results).to.deep.equal([7, 7, 7, 7, 7, 7, 7, 7]);
-        expect(missedLines).to.deep.equal(['12', '15', '21', '27', '30', '33', '39', '46']);
+        expect(results).to.deep.equal([7, 7, 7, 7, 7, 7, 7, 7, 7]);
+        expect(missedLines).to.deep.equal(['12', '15', '21', '27', '30', '33', '39', '46', '50']);
         done();
     });
 

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -212,6 +212,22 @@ describe('Coverage', () => {
         done();
     });
 
+    it('measures missing coverage on single-line functions correctly', (done) => {
+
+        const Test = require('./coverage/single-line-functions');
+        let results = [];
+        for(let i = 1; i < 9; ++i) {
+        	results.push(Test[`method${i}`](3, 4));
+        }
+
+        const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/single-line-functions') });
+        const source = cov.files[0].source;
+        const missedLines = Object.keys(source).filter((lineNumber) => source[lineNumber].miss);
+        expect(results).to.deep.equal([7, 7, 7, 7, 7, 7, 7, 7]);
+        expect(missedLines).to.deep.equal(['12', '15', '21', '27', '30', '33', '39', '46']);
+        done();
+    });
+
     describe('#analyze', () => {
 
         it('sorts file paths in report', (done) => {

--- a/test/coverage/single-line-functions.js
+++ b/test/coverage/single-line-functions.js
@@ -45,3 +45,6 @@ exports.method8 = function (a, b) {
 exports.method8NotCalled = function (a, b) {
 	return a * b;
 };
+
+exports.method9 = function (a, b) {a = a - 1; b = b + 1; return a + b;};
+exports.method9NotCalled = function (a, b) {a = a - 1; b = b + 1; return a * b;};

--- a/test/coverage/single-line-functions.js
+++ b/test/coverage/single-line-functions.js
@@ -51,3 +51,6 @@ exports.method9NotCalled = function (a, b) {a = a - 1; b = b + 1; return a * b;}
 
 exports.method10 = (a, b) => exports.method9(a, b);
 exports.method10NotCalled = (a, b) => exports.method9NotCalled(a, b);
+
+exports.method11 = (a, b) => a || b;
+exports.method11Partial = (a, b) => a || b;

--- a/test/coverage/single-line-functions.js
+++ b/test/coverage/single-line-functions.js
@@ -1,0 +1,47 @@
+'use strict';
+
+// Load modules
+
+
+// Declare internals
+
+const internals = {};
+
+
+exports.method1 = (a, b) => a + b;
+exports.method1NotCalled = (a, b) => a * b;
+
+exports.method2 = (a, b) => {return a + b;};
+exports.method2NotCalled = (a, b) => {return a * b;};
+
+exports.method3 = (a, b) => {
+	return a + b;
+};
+exports.method3NotCalled = (a, b) => {
+	return a * b;
+};
+
+exports.method4 = (a, b) =>
+	a + b
+exports.method4NotCalled = (a, b) =>
+	a * b
+
+exports.method5 = function (a, b) {return a + b;};
+exports.method5NotCalled = function (a, b) {return a * b;};
+
+exports.method6 = function (a, b) {return a + b;};
+exports.method6NotCalled = function (a, b) {return a * b;};
+
+exports.method7 = function (a, b) {
+	return a + b;
+};
+exports.method7NotCalled = function (a, b) {
+	return a * b;
+};
+
+exports.method8 = function (a, b) {
+	return a + b;
+};
+exports.method8NotCalled = function (a, b) {
+	return a * b;
+};

--- a/test/coverage/single-line-functions.js
+++ b/test/coverage/single-line-functions.js
@@ -48,3 +48,6 @@ exports.method8NotCalled = function (a, b) {
 
 exports.method9 = function (a, b) {a = a - 1; b = b + 1; return a + b;};
 exports.method9NotCalled = function (a, b) {a = a - 1; b = b + 1; return a * b;};
+
+exports.method10 = (a, b) => exports.method9(a, b);
+exports.method10NotCalled = (a, b) => exports.method9NotCalled(a, b);


### PR DESCRIPTION
It seems like lab does not correctly report coverage on various forms of short function declarations:

1. Any kind of function expression that’s written on a single line (see #274)
2. Single-expression arrow functions (eg. `(a, b) => a+b`), even if they span multiple lines.

This pull request adds a failing coverage test that demonstrates the problem. Unfortunately, I don’t know enough about lab’s AST transformations to be able to fix the problem.