### PR TITLE
Fix coverage of trailing function declaration

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -164,7 +164,6 @@ internals.instrument = function (filename) {
             'ReturnStatement',
             'ThrowStatement',
             'TryStatement',
-            'FunctionDeclaration',
             'IfStatement',
             'WhileStatement',
             'DoWhileStatement',

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -212,6 +212,19 @@ describe('Coverage', () => {
         done();
     });
 
+    it('should measure missing coverage on trailing function declarations correctly', (done) => {
+
+        const Test = require('./coverage/trailing-function-declarations');
+        let result = Test.method(3, 4);
+
+        const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/trailing-function-declarations') });
+        const source = cov.files[0].source;
+        const missedLines = Object.keys(source).filter((lineNumber) => source[lineNumber].miss);
+        expect(result).to.equal(7);
+        expect(missedLines).to.deep.equal(['19', '22']);
+        done();
+    });
+
     describe('#analyze', () => {
 
         it('sorts file paths in report', (done) => {

--- a/test/coverage/trailing-function-declarations.js
+++ b/test/coverage/trailing-function-declarations.js
@@ -1,0 +1,24 @@
+'use strict';
+
+// Load modules
+
+
+// Declare internals
+
+const internals = {};
+
+
+exports.method = function (a, b) {
+	return add(a, b);
+
+	function add(a, b) {
+		return a + b;
+	}
+};
+exports.methodNotCalled = function (a, b) {
+	return add(a, b);
+
+	function add(a, b) {
+		return a + b;
+	}
+};


### PR DESCRIPTION
Declaring a function after a return statement causes lab to report the declaration as "not covered".

The new test demonstrates the problem: The old coverage code incorrectly reports lines 14 and 21 of `test/coverage/trailing-function-declarations.js` as "not covered". The fix in 2ba2d72 solves this problem by excluding function declarations from tracking.

