### PR TITLE
Fix "multiple only" error with multiple outputs

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -70,7 +70,7 @@ exports.report = function (scripts, options, callback) {
             if (err) {
                 const outputStream = [].concat(options.output).find((output) => !!output.write);
                 if (outputStream) {
-                    outputStream.write(err.toString());
+                    outputStream.write(err.toString() + '\n');
                 }
                 else {
                     console.error(err.toString());

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -68,7 +68,13 @@ exports.report = function (scripts, options, callback) {
             // Can only be (and is) covererd via CLI tests
             /* $lab:coverage:off$ */
             if (err) {
-                options.output.write(err.toString());
+                const outputStream = [].concat(options.output).find((output) => !!output.write);
+                if (outputStream) {
+                    outputStream.write(err.toString());
+                }
+                else {
+                    console.error(err.toString());
+                }
                 return process.exit(1);
             }
             /* $lab:coverage:on$ */

--- a/test/cli.js
+++ b/test/cli.js
@@ -566,7 +566,7 @@ describe('CLI', () => {
         afterEach((done) => {
 
             Fs.unlink(filename, () => done());
-        })
+        });
 
         it('displays error message when there is more than one "only" accross multiple files', (done) => {
 
@@ -585,6 +585,20 @@ describe('CLI', () => {
         it('displays error message when there is more than one "only" accross multiple files and the first reporter is not console', (done) => {
 
             RunCli(['-r', 'json', '-o', filename, '-r', 'console', '-o', 'stdout', 'test/cli_only-skip/onlyExperiment.js', 'test/cli_only-skip/onlyTest.js'], (error, result) => {
+
+                if (error) {
+                    done(error);
+                }
+
+                expect(result.combinedOutput).to.contain('Multiple tests are marked as "only":');
+                expect(result.code).to.equal(1);
+                done();
+            });
+        });
+
+        it('displays error message when there is more than one "only" accross multiple files and there’s no console reporter', (done) => {
+
+            RunCli(['-r', 'json', '-o', filename, '-r', 'junit', '-o', filename, 'test/cli_only-skip/onlyExperiment.js', 'test/cli_only-skip/onlyTest.js'], (error, result) => {
 
                 if (error) {
                     done(error);

--- a/test/cli.js
+++ b/test/cli.js
@@ -2,7 +2,9 @@
 
 // Load modules
 
+const Crypto = require('crypto');
 const Fs = require('fs');
+const Os = require('os');
 const Path = require('path');
 const Code = require('code');
 const Pkg = require('../package.json');
@@ -19,6 +21,8 @@ const internals = {};
 const lab = exports.lab = _Lab.script();
 const describe = lab.describe;
 const it = lab.it;
+const beforeEach = lab.beforeEach;
+const afterEach = lab.afterEach;
 const expect = Code.expect;
 
 
@@ -547,6 +551,49 @@ describe('CLI', () => {
             expect(result.combinedOutput).to.contain('Multiple tests are marked as "only":');
             expect(result.code).to.equal(1);
             done();
+        });
+    });
+
+    describe('when using multiple reporters', () => {
+
+        let filename;
+        beforeEach((done) => {
+
+            filename = Path.join(Os.tmpDir(), [Date.now(), process.pid, Crypto.randomBytes(8).toString('hex')].join('-'));
+            done();
+        });
+
+        afterEach((done) => {
+
+            Fs.unlink(filename, () => done());
+        })
+
+        it('displays error message when there is more than one "only" accross multiple files', (done) => {
+
+            RunCli(['-r', 'console', '-o', 'stdout', '-r', 'json', '-o', filename, 'test/cli_only-skip/onlyExperiment.js', 'test/cli_only-skip/onlyTest.js'], (error, result) => {
+
+                if (error) {
+                    done(error);
+                }
+
+                expect(result.combinedOutput).to.contain('Multiple tests are marked as "only":');
+                expect(result.code).to.equal(1);
+                done();
+            });
+        });
+
+        it('displays error message when there is more than one "only" accross multiple files and the first reporter is not console', (done) => {
+
+            RunCli(['-r', 'json', '-o', filename, '-r', 'console', '-o', 'stdout', 'test/cli_only-skip/onlyExperiment.js', 'test/cli_only-skip/onlyTest.js'], (error, result) => {
+
+                if (error) {
+                    done(error);
+                }
+
+                expect(result.combinedOutput).to.contain('Multiple tests are marked as "only":');
+                expect(result.code).to.equal(1);
+                done();
+            });
         });
     });
 


### PR DESCRIPTION
My implementation of [@geek’s suggestion](https://github.com/hapijs/lab/pull/527#issuecomment-188437663) for reporting general test errors fails to work when you specify multiple reporters or non-console reporters.

I’ve patched it for the "multiple only" error but I assume that the original code for this kind of error reporting has the same bug (haven’t tested it).