### PR TITLE
Feature: promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,18 +142,19 @@ lab.experiment('math', () => {
 lab.experiment('math', () => {
 
     lab.before(() => {
-    
-    	const promise = aFunctionReturningAPromise()
 
-		return promise;
+        const promise = aFunctionReturningAPromise();
+
+        return promise;
     });
 
     lab.test('returns true when 1 + 1 equals 2', () => {
 
         return aFunctionReturningAPromise()
-        	.then((aValue) => {
-        		Code.expect(aValue).to.equal(expectedValue);
-        	});
+            .then((aValue) => {
+
+                Code.expect(aValue).to.equal(expectedValue);
+            });
     });
 });
 ```
@@ -335,7 +336,7 @@ node_modules/*
 
 If you would like to run a different linter, or even a custom version of eslint you should
 pass the `-n` or `--linter` argument with the path to the lint runner.  For example,
-if you plan to use jslint, you can install `lab-jslint` then pass `--linter node_modules/lab-jslint`.  
+if you plan to use jslint, you can install `lab-jslint` then pass `--linter node_modules/lab-jslint`.
 
 ## Best practices
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,28 @@ lab.experiment('math', () => {
 
 ```
 
+`test()`, `before()`, `beforeEach()`, `after()` and `afterEach()` also support returning promises instead of using the `done` callback:
+
+```JavaScript
+lab.experiment('math', () => {
+
+    lab.before(() => {
+    
+    	const promise = aFunctionReturningAPromise()
+
+		return promise;
+    });
+
+    lab.test('returns true when 1 + 1 equals 2', () => {
+
+        return aFunctionReturningAPromise()
+        	.then((aValue) => {
+        		Code.expect(aValue).to.equal(expectedValue);
+        	});
+    });
+});
+```
+
 Both `test()` and `experiment()` accept an optional `options` argument which must be an object with the following optional keys:
 - `timeout` -  set a test or experiment specific timeout in milliseconds. Defaults to the global timeout (`2000`ms or the value of `-m`).
 - `parallel` - sets parallel execution of tests within each experiment level. Defaults to `false` (serial execution).

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,7 +50,8 @@ exports.script = function (options) {
         _current: {
             experiments: [],
             tests: [],
-            options: {}
+            options: {},
+            title: 'script'
         },
         _titles: [],
         _path: [],
@@ -210,7 +211,7 @@ internals.test = function (title /*, options, fn */) {
 
     const test = {
         path: this._path,
-        title: this._titles.join(' ') + ' ' + title,
+        title: (this._path.length ? this._titles.join(' ') + ' ' : '') + title,
         relativeTitle: title,
         fn: fn,
         options: settings

--- a/lib/index.js
+++ b/lib/index.js
@@ -134,7 +134,7 @@ internals.before = function (/* options, */ fn) {
     const options = arguments.length === 2 ? arguments[0] : {};
     fn = arguments.length === 2 ? arguments[1] : fn;
 
-    Hoek.assert(fn && fn.length === 1, 'Function for before in "' + this._current.title + '" should take exactly one argument');
+    Hoek.assert(fn, `before in "${this._current.title}" requires a function argument`);
 
     const before = {
         title: 'Before ' + this._titles.join(' '),
@@ -152,7 +152,7 @@ internals.after = function (/* options, */ fn) {
     const options = arguments.length === 2 ? arguments[0] : {};
     fn = arguments.length === 2 ? arguments[1] : fn;
 
-    Hoek.assert(fn && fn.length === 1, 'Function for after in "' + this._current.title + '" should take exactly one argument');
+    Hoek.assert(fn, `after in "${this._current.title}" requires a function argument`);
 
     const after = {
         title: 'After ' + this._titles.join(' '),
@@ -170,7 +170,7 @@ internals.beforeEach = function (/* options, */ fn) {
     const options = arguments.length === 2 ? arguments[0] : {};
     fn = arguments.length === 2 ? arguments[1] : fn;
 
-    Hoek.assert(fn && fn.length === 1, 'Function for beforeEach in "' + this._current.title + '" should take exactly one argument');
+    Hoek.assert(fn, `beforeEach in "${this._current.title}" requires a function argument`);
 
     const beforeEach = {
         title: 'Before each ' + this._titles.join(' '),
@@ -188,7 +188,7 @@ internals.afterEach = function (/* options, */ fn) {
     const options = arguments.length === 2 ? arguments[0] : {};
     fn = arguments.length === 2 ? arguments[1] : fn;
 
-    Hoek.assert(fn && fn.length === 1, 'Function for afterEach in "' + this._current.title + '" should take exactly one argument');
+    Hoek.assert(fn, `afterEach in "${this._current.title}" requires a function argument`);
 
     const afterEach = {
         title: 'After each ' + this._titles.join(' '),
@@ -205,10 +205,6 @@ internals.test = function (title /*, options, fn */) {
 
     const options = arguments.length === 3 ? arguments[1] : {};
     const fn = arguments.length === 3 ? arguments[2] : arguments[1];
-
-    if (fn) {
-        Hoek.assert(fn.length === 1, 'Function for test "' + title + '" should take exactly one argument');
-    }
 
     const settings = Utils.mergeOptions(this._current.options, options, ['only']);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -211,7 +211,7 @@ internals.test = function (title /*, options, fn */) {
 
     const test = {
         path: this._path,
-        title: (this._path.length ? this._titles.join(' ') + ' ' : '') + title,
+        title: this._titles.concat(title).join(' '),
         relativeTitle: title,
         fn: fn,
         options: settings

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -564,10 +564,16 @@ internals.protect = function (item, state, callback) {
     setImmediate(() => {
 
         domain.enter();
-        item.fn.call(null, (err) => {
+        const itemResult = item.fn.call(null, (err) => {
 
             finish(err, 'done');
         });
+        if (itemResult && itemResult.then instanceof Function) {
+            itemResult.then(() => finish(null, 'done'), (err) => finish(err, 'done'));
+        }
+        if (item.fn.length !== 1 && !(itemResult && itemResult.then instanceof Function)) {
+            finish(new Error(`Function for "${item.title}" should either take a callback argument or return a promise`), 'function signature');
+        }
         domain.exit();
     });
 };

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -569,7 +569,7 @@ internals.protect = function (item, state, callback) {
             finish(err, 'done');
         });
         if (itemResult && itemResult.then instanceof Function) {
-            itemResult.then(() => finish(null, 'done'), (err) => finish(err, 'done'));
+            itemResult.then(() => finish(null), (err) => finish(err, 'done'));
         }
         if (item.fn.length !== 1 && !(itemResult && itemResult.then instanceof Function)) {
             finish(new Error(`Function for "${item.title}" should either take a callback argument or return a promise`), 'function signature');

--- a/test/index.js
+++ b/test/index.js
@@ -793,42 +793,49 @@ describe('Lab', () => {
         };
     });
 
-    it('throws on invalid functions', (done) => {
+    it('should not throw on tests without a function', (done) => {
 
-        const script = Lab.script();
+        const script = Lab.script({ schedule: false });
 
         expect(() => {
 
             script.test('a');
         }).not.to.throw();
+        done();
+    });
+
+    it('should not throw on tests with a function without arguments', (done) => {
+
+        const script = Lab.script({ schedule: false });
 
         expect(() => {
 
             script.test('a', () => {});
-        }).to.throw('Function for test "a" should take exactly one argument');
+        }).not.to.throw();
+        done();
+    });
 
-        ['before', 'beforeEach', 'after', 'afterEach'].forEach((fn) => {
+    ['before', 'beforeEach', 'after', 'afterEach'].forEach((fnName) => {
 
-            expect(() => {
+        it(`should throw on "${fnName}" without a function`, (done) => {
 
-                script.experiment('exp', () => {
-
-                    script[fn]();
-                });
-            }).to.throw('Function for ' + fn + ' in "exp" should take exactly one argument');
+            const script = Lab.script({ schedule: false });
 
             expect(() => {
 
-                script.experiment('exp', () => {
-
-                    script[fn](() => {});
-                });
-            }).to.throw('Function for ' + fn + ' in "exp" should take exactly one argument');
+                script[fnName]();
+            }).to.throw(`${fnName} in "script" requires a function argument`);
+            done();
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
+        it(`should not throw on "${fnName}" with a function without arguments`, (done) => {
 
-            expect(err).to.not.exist();
+            const script = Lab.script({ schedule: false });
+
+            expect(() => {
+
+                script[fnName](() => {});
+            }).not.to.throw();
             done();
         });
     });

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -1073,7 +1073,7 @@ describe('Reporter', () => {
         });
     });
 
-    describe('json', () => {
+    describe('json', { timeout: 10000 }, () => {
 
         it('generates a report', (done) => {
 

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -1116,7 +1116,6 @@ describe('Reporter', () => {
                 expect(result.lint[0].filename).to.exist();
                 expect(result.lint[0].errors).to.exist();
                 done();
-                done = function () {};
             });
         });
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -208,6 +208,32 @@ describe('Runner', () => {
         });
     });
 
+    it('should break out of the test promise chain before starting the next test', (done) => {
+
+        const script = Lab.script({ schedule: false });
+
+        script.test('a', () => {
+
+            return Promise.reject(new Error('A reason why this test failed'));
+        });
+
+        script.test('b', (done) => {
+
+            throw new Error('A different reason why this test failed');
+        });
+
+        Lab.execute(script, {}, null, (err, notebook) => {
+
+            expect(err).not.to.exist();
+            expect(notebook.tests).to.have.length(2);
+            expect(notebook.failures).to.equal(2);
+            expect(notebook.tests[0].err.toString()).to.contain('A reason why this test failed');
+            expect(notebook.tests[1].err.toString()).to.contain('A different reason why this test failed');
+            done();
+        });
+    });
+
+
     ['before', 'beforeEach', 'after', 'afterEach'].forEach((fnName) => {
 
         it(`should fail "${fnName}" that neither takes a callback nor returns anything`, (done) => {
@@ -1493,6 +1519,12 @@ describe('Runner', () => {
                 expect(code).to.equal(0);
                 done();
             });
+        });
+
+        it('throws delayed', (done) => {
+            Promise.reject(new Error('faaaail'));
+
+            done();
         });
 
         it('test timeouts still function correctly', (done) => {

--- a/test/runner.js
+++ b/test/runner.js
@@ -821,7 +821,7 @@ describe('Runner', () => {
         Lab.execute(script, null, null, (err, notebook) => {
 
             expect(err).to.not.exist();
-            expect(notebook.tests[0].err).to.contain('\'before\' action failed');
+            expect(notebook.tests[0].err).to.equal('\'before\' action failed');
             expect(steps).to.deep.equal(['before']);
             done();
         });
@@ -855,7 +855,7 @@ describe('Runner', () => {
         Lab.execute(script, null, null, (err, notebook) => {
 
             expect(err).to.not.exist();
-            expect(notebook.tests[0].err).to.contain('\'before each\' action failed');
+            expect(notebook.tests[0].err).to.equal('\'before each\' action failed');
             expect(steps).to.deep.equal(['before']);
             done();
         });

--- a/test/runner.js
+++ b/test/runner.js
@@ -1521,12 +1521,6 @@ describe('Runner', () => {
             });
         });
 
-        it('throws delayed', (done) => {
-            Promise.reject(new Error('faaaail'));
-
-            done();
-        });
-
         it('test timeouts still function correctly', (done) => {
 
             const script = Lab.script();


### PR DESCRIPTION
Implements #536 and fixes two bugs related to naming tests and setup / teardown blocks at the root level (outside any experiment).