### PR TITLE
Allow stdout to flush

### DIFF
--- a/lib/reporters/index.js
+++ b/lib/reporters/index.js
@@ -103,6 +103,11 @@ exports.generate = function (options) {
                     return callback(null, code, output);
                 }
 
+                if (dest === process.stdout) {
+                    // One last empty write to make sure we flushed the stdout buffer completely
+                    return dest.write('', () => process.exit(code));
+                }
+
                 process.exit(code);
             };
 


### PR DESCRIPTION
Because of `process.exit`, the output doesn't have the time to flush so you get a partial report (many issues about that in the node project).

This fixes it but I don't really have time to find how to cover those lines, I thought it already would be, so if anyone can look into it I'd be grateful.