### PR TITLE
Feature/silent skips

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -258,6 +258,11 @@ internals.options = function () {
             type: 'boolean',
             description: 'silence test output'
         },
+        'silent-skips': {
+            alias: 'k',
+            type: 'boolean',
+            description: 'don’t output skipped tests'
+        },
         sourcemaps: {
             alias: ['S', 'sourcemaps'],
             type: 'boolean',
@@ -319,7 +324,7 @@ internals.options = function () {
 
     const keys = ['coverage', 'coverage-path', 'coverage-exclude', 'colors', 'dry', 'debug', 'environment', 'flat',
         'grep', 'globals', 'timeout', 'parallel', 'pattern', 'reporter', 'threshold', 'context-timeout', 'shuffle', 'sourcemaps',
-        'lint', 'linter', 'transform', 'lint-options', 'lint-errors-threshold', 'lint-warnings-threshold'];
+        'lint', 'linter', 'transform', 'lint-options', 'lint-errors-threshold', 'lint-warnings-threshold', 'silent-skips'];
     for (let i = 0; i < keys.length; ++i) {
         if (argv.hasOwnProperty(keys[i]) && argv[keys[i]] !== undefined) {
             options[keys[i]] = argv[keys[i]];

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -35,6 +35,10 @@ internals.Reporter.prototype.test = function (test) {
         return;
     }
 
+    if (this.settings['silent-skips'] && (test.skipped || test.todo)) {
+        return;
+    }
+
     if (this.settings.progress === 1) {
 
         // ..x....x.-..

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -403,5 +403,5 @@ internals.filterNodeModules = function (line) {
 
 internals.filterSkipped = function (test) {
 
-    return test.skipped;
+    return test.skipped || test.todo;
 };

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -714,6 +714,71 @@ describe('Reporter', () => {
             });
         });
 
+        it('generates a report without skipped and todo tests', (done) => {
+
+            const script = Lab.script();
+            script.experiment('test', () => {
+
+                script.test('works', (finished) => {
+
+                    expect(true).to.equal(true);
+                    finished();
+                });
+
+                script.test.skip('a skipped test', (done) => {
+
+                    done(new Error('Should not be called'));
+                });
+
+                script.test('a todo test');
+            });
+
+            Lab.report(script, { reporter: 'console', 'silent-skips': true }, (err, code, output) => {
+
+                expect(err).to.not.exist();
+                expect(code).to.equal(0);
+                expect(output).to.contain([
+                    '  .\n',
+                    '1 tests complete',
+                    '2 skipped'
+                ]);
+                done();
+            });
+        });
+
+        it('generates a verbose report without skipped and todo tests', (done) => {
+
+            const script = Lab.script();
+            script.experiment('test', () => {
+
+                script.test('works', (finished) => {
+
+                    expect(true).to.equal(true);
+                    finished();
+                });
+
+                script.test.skip('a skipped test', (done) => {
+
+                    done(new Error('Should not be called'));
+                });
+
+                script.test('a todo test');
+            });
+
+            Lab.report(script, { reporter: 'console', progress: 2, 'silent-skips': true }, (err, code, output) => {
+
+                expect(err).to.not.exist();
+                expect(code).to.equal(0);
+                expect(output).to.not.contain('a skipped test');
+                expect(output).to.not.contain('a todo test');
+                expect(output).to.contain([
+                    '1 tests complete',
+                    '2 skipped'
+                ]);
+                done();
+            });
+        });
+
         it('generates a coverage report (verbose)', (done) => {
 
             const Test = require('./coverage/console');

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -328,6 +328,37 @@ describe('Reporter', () => {
             });
         });
 
+        it('counts "todo" tests as skipped', (done) => {
+
+            const script = Lab.script();
+            script.experiment('test', () => {
+
+                script.test('works', (finished) => {
+
+                    expect(true).to.equal(true);
+                    finished();
+                });
+
+                script.test.skip('a skipped test', (done) => {
+
+                    done(new Error('Should not be called'));
+                });
+
+                script.test('a todo test');
+            });
+
+            Lab.report(script, { reporter: 'console' }, (err, code, output) => {
+
+                expect(err).to.not.exist();
+                expect(code).to.equal(0);
+                expect(output).to.contain([
+                    '1 tests complete',
+                    '2 skipped'
+                ]);
+                done();
+            });
+        });
+
         it('generates a report with errors', (done) => {
 
             const script = Lab.script();


### PR DESCRIPTION
I’ve implemented a `silent-skips` option to reduce the noise when using `.only` in large test suites. I hope you like it.

With this in place, we could also remove the special case for `ids` / `glob` (see [bullet 2 in my `only` PR](https://github.com/hapijs/lab/pull/527#issue-136092402) and [@geek’s response](https://github.com/hapijs/lab/pull/527#issuecomment-188358276)) since the "noisy output" can now be prevented by adding `-k` when using `ids` / `glob`.

This PR also fixes `todo` tests being reported as `complete` at the end – even though they are displayed as skipped (`-`) in the output itself. I caught this by accident when writing the test for the new feature.

`master` currently contains some uncovered lines from #541 so `npm test` fails atm.