### PR TITLE
Code coverage: Always surround expressions in ternary operator with parenthesis

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -200,7 +200,7 @@ internals.instrument = function (filename) {
             consequent = addStatement(line, node.consequent, false);
             const alternate = addStatement(line, node.alternate, false);
 
-            node.set('(' + node.test.source() + '? global.__$$labCov._statement(\'' + filename + '\',' + consequent + ',' + line + ',' + node.consequent.source() + ') : global.__$$labCov._statement(\'' + filename + '\',' + alternate + ',' + line + ',' + node.alternate.source() + '))');
+            node.set('(' + node.test.source() + '? global.__$$labCov._statement(\'' + filename + '\',' + consequent + ',' + line + ',(' + node.consequent.source() + ')) : global.__$$labCov._statement(\'' + filename + '\',' + alternate + ',' + line + ',(' + node.alternate.source() + ')))');
         }
         else if (node.type === 'LogicalExpression') {
             line = node.loc.start.line;

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -175,6 +175,14 @@ describe('Coverage', () => {
         done();
     });
 
+    it('retains original value of conditional result with comma operator', (done) => {
+
+        const Test = require('./coverage/conditional2');
+        const value = 4711;
+        expect(Test.method(value)).to.equal(value);
+        done();
+    });
+
     it('should not change use strict instructions', (done) => {
 
         const Test = require('./coverage/use-strict.js');

--- a/test/coverage/conditional2.js
+++ b/test/coverage/conditional2.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// Load modules
+
+
+// Declare internals
+
+const internals = {};
+
+
+exports.method = function (value) {
+    return true ? (value-1, value) : value+1;  //Should return value
+};

--- a/test/coverage/conditional2.js
+++ b/test/coverage/conditional2.js
@@ -9,5 +9,5 @@ const internals = {};
 
 
 exports.method = function (value) {
-    return true ? (value-1, value) : value+1;  //Should return value
+    return true ? (value - 1, value) : value + 1;  //Should return value
 };


### PR DESCRIPTION
Fixes #555 __Code coverage for conditional operator with comma operator isn't handled correctly__