### PR TITLE
Adjust gray to comply with solarized dark theme

### DIFF
--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -391,7 +391,7 @@ internals.colors = function (enabled) {
 
     const codes = {
         'black': 0,
-        'gray': 90,
+        'gray': 92,
         'red': 31,
         'green': 32,
         'yellow': 33,

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -736,7 +736,7 @@ describe('Reporter', () => {
             Lab.report(script, { reporter: 'console', progress: 2, output: false }, (err, code, output) => {
 
                 expect(err).not.to.exist();
-                expect(output).to.match(/^test\n  \u001b\[32m✔\u001b\[0m \u001b\[90m1\) works \(\d+ ms\)\u001b\[0m\n\n\n\u001b\[32m1 tests complete\u001b\[0m\nTest duration: \d+ ms\n\u001b\[32mNo global variable leaks detected\u001b\[0m\n\n$/);
+                expect(output).to.match(/^test\n  \u001b\[32m✔\u001b\[0m \u001b\[92m1\) works \(\d+ ms\)\u001b\[0m\n\n\n\u001b\[32m1 tests complete\u001b\[0m\nTest duration: \d+ ms\n\u001b\[32mNo global variable leaks detected\u001b\[0m\n\n$/);
                 done();
             });
         });
@@ -820,7 +820,7 @@ describe('Reporter', () => {
             Lab.report(script, { reporter: 'console', progress: 2, assert: Code, output: false }, (err, code, output) => {
 
                 expect(err).not.to.exist();
-                expect(output).to.match(/^test\n  \u001b\[32m✔\u001b\[0m \u001b\[90m1\) works \(\d+ ms and \d+ assertions\)\u001b\[0m\n\n\n\u001b\[32m1 tests complete\u001b\[0m\nTest duration: \d+ ms\nAssertions count\: \d+ \(verbosity\: \d+\.\d+\)\n\u001b\[32mNo global variable leaks detected\u001b\[0m\n\n$/);
+                expect(output).to.match(/^test\n  \u001b\[32m✔\u001b\[0m \u001b\[92m1\) works \(\d+ ms and \d+ assertions\)\u001b\[0m\n\n\n\u001b\[32m1 tests complete\u001b\[0m\nTest duration: \d+ ms\nAssertions count\: \d+ \(verbosity\: \d+\.\d+\)\n\u001b\[32mNo global variable leaks detected\u001b\[0m\n\n$/);
                 done();
             });
         });


### PR DESCRIPTION
Attempts to fix #592.

![screen shot 2016-05-24 at 9 39 20 pm](https://cloud.githubusercontent.com/assets/1641390/15526949/4524c5f8-21fb-11e6-8714-5c0f567e7c10.png)

However, it would be good for others to verify this works well with other themes.  With the way I have iTerm2 configured, this new gray color appears light green on any other profile setting.