### PR TITLE
Add space after failed test x

### DIFF
--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -78,7 +78,7 @@ internals.Reporter.prototype.test = function (test) {
 
         const spacer = internals.spacer(test.path.length * 2);
         if (test.err) {
-            this.report(spacer + this.colors.red(asterisk + test.id + ') ' + test.relativeTitle) + '\n');
+            this.report(spacer + this.colors.red(asterisk + ' ' + test.id + ') ' + test.relativeTitle) + '\n');
         }
         else {
             const symbol = test.skipped || test.todo ? this.colors.magenta('-') : this.colors.green(check);

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -1073,7 +1073,7 @@ describe('Reporter', () => {
 
                 expect(err).to.not.exist();
                 expect(code).to.equal(1);
-                expect(output).to.match(/test\n  ✔ 1\) works \(\d+ ms\)\n  ✖2\) fails\n  \- 3\) skips \(\d+ ms\)\n/);
+                expect(output).to.match(/test\n  ✔ 1\) works \(\d+ ms\)\n  ✖ 2\) fails\n  \- 3\) skips \(\d+ ms\)\n/);
                 done();
             });
         });


### PR DESCRIPTION
During verbose output there is a space missing after the 'x'. I added a space and adjusted the test to reflect the change. 
Before:
<img width="400" alt="screen shot 2016-05-25 at 4 25 47 pm" src="https://cloud.githubusercontent.com/assets/1743953/15557070/a7b97d80-2296-11e6-9b8d-f0c0056999fd.png">
After:
<img width="402" alt="screen shot 2016-05-25 at 4 27 49 pm" src="https://cloud.githubusercontent.com/assets/1743953/15557066/a180524a-2296-11e6-833a-2b09010d1590.png">

