### PR TITLE
Ensure we're not bypassing loc that should be covered

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -109,7 +109,7 @@ internals.instrument = function (filename) {
 
         // Coverage status
 
-        if (bypass[node.range[0]]) {
+        if (bypass[node.range[0]] && bypass[node.range[1]]) {
             return;
         }
 

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -140,6 +140,19 @@ describe('Coverage', () => {
         done();
     });
 
+    it('bypasses marked code and reports misses correctly', (done) => {
+
+        const Test = require('./coverage/bypass-misses');
+        Test.method(1);
+
+        const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/bypass-misses') });
+        expect(Math.floor(cov.percent)).to.equal(93);
+        expect(cov.sloc).to.equal(15);
+        expect(cov.misses).to.equal(1);
+        expect(cov.hits).to.equal(14);
+        done();
+    });
+
     it('ignores non-matching files', (done) => {
 
         require('./coverage/exclude/ignore');

--- a/test/coverage/bypass-misses.js
+++ b/test/coverage/bypass-misses.js
@@ -1,0 +1,27 @@
+'use strict';
+
+// Load modules
+
+
+// Declare internals
+
+const internals = {};
+
+/*$lab:coverage:off$*/const noop = function () {};
+
+const /*$lab:coverage:on$*/FiveMath = function () {
+
+    this.addFive = function (value) {
+
+        return value + 5;
+    };
+
+    this.subtractFive = function (value) {
+
+      return value - 5;
+    };
+};
+
+const fiveMath = new FiveMath();
+
+exports.method = fiveMath.addFive;


### PR DESCRIPTION
I experienced a strange case of unexpected 100% test coverage when transpiling (seen at https://github.com/nlf/lab-babel/issues/9). This may also be relevant to [hapijs/lab#459](https://github.com/hapijs/lab/issues/459).

I found that if we place `/* $lab:coverage:(off|on)$ */` in certain positions in the tree, we could accidentally bypass loc that should be covered. This happens because we only check if the node's starting range is in the `bypass` object without ensuring the entire node should be skipped.

By adding an additional check that the node's end range is also included in the `bypass` object, we allow `annotate(...)` to continue recursively processing.

My new test case doesn't use transpilation, but simply puts `/* $lab:coverage:(off|on)$ */` in positions that reproduce the symptom as I found it.

Feedback is much appreciated.