### PR TITLE
Test entire node range before bypassing

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -109,7 +109,11 @@ internals.instrument = function (filename) {
 
         // Coverage status
 
-        if (bypass[node.range[0]] && bypass[node.range[1]]) {
+        const bypassTests = [];
+        for (let i = node.range[0]; i <= node.range[1]; ++i) {
+            bypassTests.push(bypass[i]);
+        }
+        if (bypassTests.every((test) => test)) {
             return;
         }
 

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -147,9 +147,9 @@ describe('Coverage', () => {
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/bypass-misses') });
         expect(Math.floor(cov.percent)).to.equal(93);
-        expect(cov.sloc).to.equal(15);
+        expect(cov.sloc).to.equal(16);
         expect(cov.misses).to.equal(1);
-        expect(cov.hits).to.equal(14);
+        expect(cov.hits).to.equal(15);
         done();
     });
 

--- a/test/coverage/bypass-misses.js
+++ b/test/coverage/bypass-misses.js
@@ -19,8 +19,9 @@ const /*$lab:coverage:on$*/FiveMath = function () {
     this.subtractFive = function (value) {
 
       return value - 5;
-    };
+    };/*$lab:coverage:off$*/
 };
+/*$lab:coverage:on$*/
 
 const fiveMath = new FiveMath();
 


### PR DESCRIPTION
I found a new case where, even with #620, we could be bypassing code that should be covered. The fix is to test that the node's full range is in the `bypass` object.