### PR TITLE
fixing invalid markup on filter checkboxes

### DIFF
--- a/lib/reporters/html/partials/tests.html
+++ b/lib/reporters/html/partials/tests.html
@@ -7,11 +7,14 @@
       <div class="duration">{{duration}}</div>
   </div>
   <div id="filters">
-      <input type="checkbox" checked="" onchange="filter(this)" value="success" id="show-success"><label for="show-success">Show Success</label></input>
-      <input type="checkbox" checked="" onchange="filter(this)" value="failure" id="show-failure"><label for="show-failure">Show Failure</label></input>
+      <input type="checkbox" checked="" onchange="filter(this)" value="success" id="show-success">
+      <label for="show-success">Show Success</label>
+      <input type="checkbox" checked="" onchange="filter(this)" value="failure" id="show-failure">
+      <label for="show-failure">Show Failure</label>
       <br>
       {{#each paths}}
-      <input type="checkbox" checked="" onchange="filter(this)" value="{{this}}" id="show-{{this}}"><label for="show-{{this}}">{{replace this "\_" " " "gi"}}</label></input>
+      <input type="checkbox" checked="" onchange="filter(this)" value="{{this}}" id="show-{{this}}">
+      <label for="show-{{this}}">{{replace this "\_" " " "gi"}}</label>
       {{/each}}
   </div>
   <table>


### PR DESCRIPTION
The inputs were wrapping the labels for some reason. Most browsers tolerate this markup and construct a valid DOM-tree anyway but I figured I'd fix it in the markup as well.

I thought about wrapping the inputs with the labels as some people recommend both for accessibility. I'll try to spare myself from overthinking a unit test reporter though.