### PR TITLE
fixes logic for lab.before timeout #652

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -335,7 +335,7 @@ internals.executeDeps = function (deps, state, callback) {
 
     Items.serial(deps, (dep, next) => {
 
-        dep.options.timeout = dep.options.timeout || state.options['context-timeout'];
+        dep.options.timeout = Hoek.isInteger(dep.options.timeout) ? dep.options.timeout : state.options['context-timeout'];
         internals.protect(dep, state, next);
     }, callback);
 };

--- a/test/runner.js
+++ b/test/runner.js
@@ -1797,5 +1797,31 @@ describe('Runner', () => {
                 done();
             });
         });
+
+        it('setTimeout still functions correctly with non-integer timeout', (done) => {
+
+            const script = Lab.script();
+            script.before(overrideGlobals);
+
+            script.after(resetGlobals);
+
+            script.experiment('test', { timeout: 5 }, () => {
+
+                script.test('timeout', { timeout: 'a' }, (testDone) => {
+
+                    setTimeout(() => {
+
+                        testDone();
+                    }, 10);
+                });
+            });
+
+            Lab.execute(script, null, null, (err, notebook) => {
+
+                expect(err).not.to.exist();
+                expect(notebook.failures).to.equal(1);
+                done();
+            });
+        });
     });
 });


### PR DESCRIPTION
Here's my first stab at fixing the logic. (#652)  I didn't see anything in the Hapi style guide on ternary operators, so I left it on a single line.

It seems to work fine, but for some reason one test is failing on me, even when I have a fresh repo without my changes:

```bash
Failed tests:

  65) Coverage identifies lines with partial coverage when having inline sourcemap:

      Expected [ { filename: 'test/coverage/while.js',
    lineNumber: '5',
    originalLineNumber: 11 },
  { filename: 'test/coverage/while.js',
    lineNumber: '6',
    originalLineNumber: 12 } ] to include [ { filename: './while.js',
    lineNumber: '5',
    originalLineNumber: 11 },
  { filename: './while.js',
    lineNumber: '6',
    originalLineNumber: 12 } ]

      at it (/home/kg/Documents/gits/lab/test/coverage.js:122:32


1 of 296 tests failed
Test duration: 35270 ms
No global variable leaks detected
Coverage: 100.00%
Linting results: No issues
```

I'm assuming it's not caused by my changes, however Travis-ci doesn't seem to be failing...
Any ideas?