### PR TITLE
Added a flag (-R, --rejections) to make the test fail if an unhandled Promise rejection happened during its execution

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -343,7 +343,6 @@ internals.options = function () {
     };
 
     const defaults = {
-        verbose: false,
         paths: ['test'],
         coverage: false,
         debug: false,

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -280,6 +280,12 @@ internals.options = function () {
             description: 'file pattern to use for locating tests',
             default: null
         },
+        rejections: {
+            alias: 'R',
+            type: 'boolean',
+            description: 'fail test on unhandled Promise rejections',
+            default: null
+        },
         reporter: {
             alias: 'r',
             type: 'string',
@@ -356,6 +362,7 @@ internals.options = function () {
         'lint-errors-threshold': 0,
         'lint-warnings-threshold': 0,
         parallel: false,
+        rejections: false,
         reporter: 'console',
         shuffle: false,
         silence: false,
@@ -389,7 +396,7 @@ internals.options = function () {
     const keys = ['assert', 'colors', 'context-timeout', 'coverage', 'coverage-exclude',
         'coverage-path', 'debug', 'dry', 'environment', 'flat', 'globals', 'grep',
         'lint', 'lint-errors-threshold', 'lint-fix', 'lint-options', 'lint-warnings-threshold',
-        'linter', 'output', 'parallel', 'pattern', 'reporter', 'shuffle', 'silence',
+        'linter', 'output', 'parallel', 'pattern', 'rejections', 'reporter', 'shuffle', 'silence',
         'silent-skips', 'sourcemaps', 'threshold', 'timeout', 'transform', 'verbose'];
     for (let i = 0; i < keys.length; ++i) {
         if (argv.hasOwnProperty(keys[i]) && argv[keys[i]] !== undefined && argv[keys[i]] !== null) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -48,6 +48,7 @@ internals.defaults = {
     output: process.stdout,                         // Stream.Writable or string (filename)
     parallel: false,
     progress: 1,
+    rejections: false,
     reporter: 'console',
     shuffle: false,
 
@@ -517,6 +518,7 @@ internals.protect = function (item, state, callback) {
     let isFirst = true;
     let timeoutId;
     let countBefore = -1;
+    let failedWithUnhandledRejection = false;
 
     if (state.options.assert && state.options.assert.count) {
         countBefore = state.options.assert.count();
@@ -531,6 +533,11 @@ internals.protect = function (item, state, callback) {
     const finish = function (err, cause) {
 
         clearTimeout(timeoutId);
+        setImmediate(() => process.removeListener('unhandledRejection', promiseRejectionHandler));
+        if (failedWithUnhandledRejection) {
+            return;
+        }
+
         if (state.options.assert && state.options.assert.count) {
             item.assertions = state.options.assert.count() - countBefore;
         }
@@ -622,6 +629,16 @@ internals.protect = function (item, state, callback) {
     domain.title = item.title;
     domain.on('error', onError);
     domains.push(domain);
+
+    const promiseRejectionHandler = function (reason) {
+
+        finish(reason, 'unhandledRejection');
+        failedWithUnhandledRejection = true;
+    };
+
+    if (state.options.rejections) {
+        process.on('unhandledRejection', promiseRejectionHandler);
+    }
 
     setImmediate(() => {
 

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
     "lab": "./bin/lab"
   },
   "scripts": {
-    "test": "./bin/_lab -fL -t 100 -m 3000",
+    "test": "node ./bin/_lab -fL -t 100 -m 3000",
     "posttest": "npm run lint-md",
-    "test-cov-html": "./bin/_lab -fL -r html -m 3000 -o coverage.html",
-    "lint": "./bin/_lab -d -f -L",
+    "test-cov-html": "node ./bin/_lab -fL -r html -m 3000 -o coverage.html",
+    "lint": "node ./bin/_lab -d -f -L",
     "lint-md": "eslint --config hapi --rule 'strict: 0, eol-last: 0' --plugin markdown --ext md  ."
   },
   "license": "BSD-3-Clause"

--- a/test/cli.js
+++ b/test/cli.js
@@ -1024,10 +1024,7 @@ describe('CLI', () => {
 
         RunCli(['test/cli_reject_promise/reject_promise.js'], (error, result) => {
 
-            if (error) {
-                done(error);
-            }
-
+            expect(error).to.not.exist();
             expect(result.code).to.equal(0);
             done();
         });
@@ -1037,10 +1034,7 @@ describe('CLI', () => {
 
         RunCli(['test/cli_reject_promise/reject_promise.js', '-R'], (error, result) => {
 
-            if (error) {
-                done(error);
-            }
-
+            expect(error).to.not.exist();
             expect(result.code).to.equal(1);
             done();
         });

--- a/test/cli.js
+++ b/test/cli.js
@@ -1019,4 +1019,30 @@ describe('CLI', () => {
             done();
         });
     });
+
+    it('passes even with an unhandled Promise rejection in the code under test', (done) => {
+
+        RunCli(['test/cli_reject_promise/reject_promise.js'], (error, result) => {
+
+            if (error) {
+                done(error);
+            }
+
+            expect(result.code).to.equal(0);
+            done();
+        });
+    });
+
+    it('fails with an unhandled Promise rejection if the specified flag is set', (done) => {
+
+        RunCli(['test/cli_reject_promise/reject_promise.js', '-R'], (error, result) => {
+
+            if (error) {
+                done(error);
+            }
+
+            expect(result.code).to.equal(1);
+            done();
+        });
+    });
 });

--- a/test/cli_reject_promise/reject_promise.js
+++ b/test/cli_reject_promise/reject_promise.js
@@ -1,0 +1,28 @@
+'use strict';
+
+// Load modules
+
+const Code = require('code');
+const _Lab = require('../../test_runner');
+
+
+// Declare internals
+
+const internals = {};
+
+
+// Test shortcuts
+
+const lab = exports.lab = _Lab.script();
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
+
+
+describe('Test Promises', () => {
+
+    it('handles a Promise rejection', ( done ) => {
+        Promise.reject(new Error('Rejection!'));
+        done();
+    });
+});

--- a/test/runner.js
+++ b/test/runner.js
@@ -1798,4 +1798,24 @@ describe('Runner', () => {
             });
         });
     });
+
+    it('fails with an unhandled Promise rejection if the specified flag is set', (done) => {
+
+        const script = Lab.script();
+        script.test('handles a Promise rejection', (done) => {
+
+            Promise.reject(new Error('Rejection!'));
+            setImmediate(done);
+        });
+
+        Lab.execute(script, { rejections: true }, null, (err, notebook) => {
+
+            expect(err).not.to.exist();
+            expect(notebook.tests).to.have.length(1);
+            expect(notebook.failures).to.equal(1);
+            expect(notebook.tests[0].err.toString()).to.contain('Rejection!');
+            done();
+        });
+
+    });
 });


### PR DESCRIPTION
Fixes https://github.com/hapijs/lab/issues/649

I'm open to suggestions, specially about naming.

All the relevant discussion is on the #649 issue. To sum up, I've added a flag to Lab, called `--rejections` (alias `-R`). If that flag is set, and an unhandled Promise rejection happens during a test, that test will be failed.

Without this flag, the behaviour will be exactly the same as before: The test pass, and in versions of Node.JS `6.6.0+`, a warning is printed on the console (but the test still passes).

An unhandled Promise rejection looks like this:
```
function foo() {
    functionThatReturnsPromise()
        .then((res) =>{
            throw new Error('This error will be absolutely swallowed.');
        })
        // No .catch() block here
}
```
Initially, the behaviour of unhandled rejections was to be silenced and totally ignored, by design. It looks like everyone is changing their minds, because in the latest versions of Chrome and Node.JS (maybe more engines, I don't know more examples) the unhandled rejections have started to display console warnings. In 99% an unhandled rejection means that something is terribly bad with the code, and the fact that doesn't crash the entire process is just a questionable design choice. So I think it should definitely make a test fail.