### PR TITLE
Updated README to include the --rejections flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ global manipulation. Our goal with **lab** is to keep the execution engine as si
     - `clover` - output results in [Clover XML](https://confluence.atlassian.com/display/CLOVER) format.
     - [Multiple Reporters](#multiple-reporters) - See Below
     - [Custom Reporters](#custom-reporters) - See Below
+- `-R`, `--rejections` - fail tests on unhandled Promise rejections.
 - `--shuffle` - randomize the order that test scripts are executed.  Will not work with `--id`.
 - `-s`, `--silence` - silence test output, defaults to false.
 - `-S`, `--sourcemaps` - enables sourcemap support for stack traces and code coverage, disabled by default.


### PR DESCRIPTION
After submitting https://github.com/hapijs/lab/pull/658 , I realized I hadn't update the flags documentation on `README.md`. This PR simply adds the `--rejects` flag description.