### PR TITLE
fix: don't show seed when shuffle was not enabled

### DIFF
--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -262,7 +262,7 @@ internals.Reporter.prototype.end = function (notebook) {
         }
     }
 
-    if (notebook.seed) {
+    if (notebook.shuffle) {
         output += 'Randomized with seed: ' + notebook.seed + '. Use --shuffle --seed ' + notebook.seed + ' to run tests in same order again.\n';
     }
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -97,6 +97,7 @@ exports.report = function (scripts, options, callback) {
 
             if (settings.shuffle) {
                 result.seed = settings.seed;
+                result.shuffle = true;
             }
 
             return next(null, result);

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -330,13 +330,31 @@ describe('Reporter', () => {
         const reporter = Reporters.generate({ reporter: 'console' });
         const notebook = {
             tests: [],
-            seed: 1234
+            seed: 1234,
+            shuffle: true
         };
 
         reporter.finalize(notebook, (err, code, output) => {
 
             expect(output).to.contain('1234');
             expect(output).to.contain('seed');
+            expect(err).not.to.exist();
+            done();
+        });
+    });
+
+    it('does not include the seed if shuffle was not active', (done) => {
+
+        const reporter = Reporters.generate({ reporter: 'console' });
+        const notebook = {
+            tests: [],
+            seed: 1234
+        };
+
+        reporter.finalize(notebook, (err, code, output) => {
+
+            expect(output).to.not.contain('1234');
+            expect(output).to.not.contain('seed');
             expect(err).not.to.exist();
             done();
         });


### PR DESCRIPTION
Previously the seed was always shown in the output, even when the order
was not randomized. This could be confusing. With this change, the seed
will only be included in the output if shuffle was enabled.