### PR TITLE
Add support for Node.js and WebStorm debuggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ global manipulation. Our goal with **lab** is to keep the execution engine as si
 - `-h`, `--help` - show command line usage.
 - `-i`, `--id` - only run the test for the given identifier (or identifiers range).
 - `-I`, `--ignore` - ignore a list of globals for the leak detection (comma separated)
+- `--inspect` - start lab in debug mode using the native Node.js debugger.
 - `-l`, `--leaks` - disables global variable leak detection.
 - `-L`, `--lint` - run linting rules using linter.  Disabled by default.
 - `--lint-errors-threshold` - maximum absolute amount of linting errors. Defaults to 0.
@@ -501,6 +502,16 @@ describe('expectation', () => {
 
 This is an invalid test but it will pass as the `.false` assertion was not actually called. Lab will report the
 number of incomplete assertions, their location in your code and return a failure of the tests.
+
+## Debuggers
+
+**lab** can be started with the option `--inspect` which will run it with the Node.js native debugger enabled, breaking on the 1st instruction.
+
+This debugger can be accessed using the URL that is printed in the console, or used in association with a few Chrome extensions ([Node.js V8 Inspector](https://chrome.google.com/webstore/detail/nodejs-v8-inspector/lfnddfpljnhbneopljflpombpnkfhggl), [NIM](https://chrome.google.com/webstore/detail/nim-node-inspector-manage/gnhhdgbaldcilmgcpfddgdbkhjohddkj/related), ...).
+
+As you may know, if your tests are associated with the command `npm test`, you can already run `npm test -- --inspect` to run it with the inspector and avoid creating another command.
+
+**lab** also has automatic support for [WebStorm](https://www.jetbrains.com/webstorm/) debugger, just start a normal debugging session on your npm test script.
 
 ## Best practices
 

--- a/bin/lab
+++ b/bin/lab
@@ -2,4 +2,45 @@
 
 'use strict';
 
+if (process.env.NODE_DEBUG_OPTION || process.argv.some((argument) => argument === '--inspect')) {
+    const ChildProcess = require('child_process');
+
+    const node = process.argv[0];
+    const lab = process.argv[1];
+    const args = [];
+
+    if (process.env.NODE_DEBUG_OPTION) { // WebStorm debugger
+        args.push.apply(args, process.env.NODE_DEBUG_OPTION.split(' '));
+        delete process.env.NODE_DEBUG_OPTION;
+    }
+    else { // Node.js native debugger
+        args.push(
+            '--inspect', // node's inspect
+            '--debug-brk' // you probably want to break 1st if you want to have a chance to hook onto the debugger before the tests run
+        );
+    }
+
+    args.push(lab);
+
+    // Remove node, lab, and the --inspect that might have been provided in the options
+    args.push.apply(args, process.argv.slice(2).filter((argument) => argument !== '--inspect'));
+
+    const options = {
+        stdio: 'inherit'
+    };
+
+    const childLab = ChildProcess.spawn(
+        node,
+        args,
+        options
+    );
+
+    childLab.on('close', (code) => {
+
+        process.exit(code);
+    });
+
+    return;
+}
+
 require('../lib/cli').run();

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -228,6 +228,11 @@ internals.options = function () {
             description: 'test identifier',
             default: null
         },
+        inspect: {
+            type: 'boolean',
+            description: 'starts lab with the node.js native debugger',
+            default: null
+        },
         leaks: {
             alias: 'l',
             type: 'boolean',


### PR DESCRIPTION
Probably fixes #651.

Read the readme to see how it works. I'm not using VS Code and have no idea how it works, so if you want it, feel free to contribute.