### PR TITLE
Reduce leaked memory via domains and timers

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -196,6 +196,9 @@ exports.execute = function (scripts, options, reporter, callback) {
         only: onlyNode
     };
 
+    // Instantiate common lazily loaded items that can leak domains.
+    internals.loadLazyObjects();
+
     internals.executeExperiments(experiments, state, settings.dry, () => {
 
         const notebook = {
@@ -207,6 +210,16 @@ exports.execute = function (scripts, options, reporter, callback) {
 
         return callback(null, notebook);
     });
+};
+
+
+internals.loadLazyObjects = () => {
+    // Node core lazily loads many things. Once lab starts creating domains,
+    // any lazily created event emitters will hold a reference to those domains
+    // indefinitely.
+    process.stdout;
+    process.stderr;
+    require('cluster'); // Used in both TCP and UDP sockets.
 };
 
 
@@ -523,6 +536,77 @@ internals.collectDeps = function (experiment, key) {
 };
 
 
+internals.cleanupItem = function (err, item, activeDomain, callback) {
+
+    const immed = setImmediate(() => {
+
+        if (!item.onCleanup) {
+            /* $lab:coverage:off$ */
+            // Don't hold on to objects in the active domain.
+            if (activeDomain) {
+                activeDomain.remove(immed);
+            }
+            /* $lab:coverage:on$ */
+
+            return callback(err);
+        }
+
+        item.onCleanup(() => {
+
+            /* $lab:coverage:off$ */
+            // Don't hold on to objects in the active domain.
+            if (activeDomain) {
+                activeDomain.remove(immed);
+            }
+            /* $lab:coverage:on$ */
+
+            callback(err);
+        });
+    });
+
+    /* $lab:coverage:off$ */
+    if (activeDomain) {
+        // The previously active domain need to be used here in case the callback throws.
+        // This is of course only valid if lab itself is ran in a domain, which is the case for its own tests.
+        activeDomain.add(immed);
+    }
+    /* $lab:coverage:on$ */
+};
+
+
+internals.createItemTimeout = (item, ms, finish) => {
+
+    return setTimeout(() => {
+
+        const error = new Error('Timed out (' + ms + 'ms) - ' + item.title);
+        error.timeout = true;
+        finish(error, 'timeout');
+    }, ms);
+};
+
+
+internals.createDomainErrorHandler = (item, state, domain, domains, finish) => {
+
+    return (err, isForward) => {
+
+        // 1. Do not forward what's already a forward.
+        // 2. Only errors that reach before*/after* are worth forwarding, otherwise we know where they came from.
+
+        if (!isForward &&
+            item.id === undefined) {
+
+            internals.forwardError(err, domain, domains);
+        }
+
+        if (state.options.debug) {
+            state.report.errors.push(err);
+        }
+
+        finish(err, 'error');
+    };
+};
+
+
 internals.protect = function (item, state, callback) {
 
     let isFirst = true;
@@ -543,6 +627,7 @@ internals.protect = function (item, state, callback) {
     const finish = function (err, cause) {
 
         clearTimeout(timeoutId);
+        timeoutId = null;
         setImmediate(() => process.removeListener('unhandledRejection', promiseRejectionHandler));
         if (failedWithUnhandledRejection) {
             return;
@@ -586,55 +671,16 @@ internals.protect = function (item, state, callback) {
             return;
         }
         isFirst = false;
-
-        const immed = setImmediate(() => {
-
-            if (!item.onCleanup) {
-                return callback(err);
-            }
-
-            item.onCleanup(() => callback(err));
-        });
-
-        /* $lab:coverage:off$ */
-        if (activeDomain) {
-
-            // The previously active domain need to be used here in case the callback throws.
-            // This is of course only valid if lab itself is ran in a domain, which is the case for its own tests.
-            activeDomain.add(immed);
-        }
-        /* $lab:coverage:on$ */
+        internals.cleanupItem(err, item, activeDomain, callback);
     };
 
     const ms = item.options.timeout !== undefined ? item.options.timeout : state.options.timeout;
     if (ms) {
-        timeoutId = setTimeout(() => {
-
-            const error = new Error('Timed out (' + ms + 'ms) - ' + item.title);
-            error.timeout = true;
-            finish(error, 'timeout');
-        }, ms);
+        timeoutId = internals.createItemTimeout(item, ms, finish);
     }
 
     const domain = Domain.createDomain();
-
-    const onError = function (err, isForward) {
-
-        // 1. Do not forward what's already a forward.
-        // 2. Only errors that reach before*/after* are worth forwarding, otherwise we know where they came from.
-
-        if (!isForward &&
-            item.id === undefined) {
-
-            internals.forwardError(err, domain, domains);
-        }
-
-        if (state.options.debug) {
-            state.report.errors.push(err);
-        }
-
-        finish(err, 'error');
-    };
+    const onError = internals.createDomainErrorHandler(item, state, domain, domains, finish);
 
     domain.title = item.title;
     domain.on('error', onError);


### PR DESCRIPTION
This commit improves retained memory usage in a few ways.

- Removes things from domains that are explicitly added.
- Isolate closures in separate functions so that they only capture the mimimim number of variables.
- Initialize several global event emitters prior to creating any domains. Currently, this is `process.stdout`, `process.stderr`, and the `cluster` module. Once these are initialized, they hold on to whatever the current domain is for the rest of the program execution. This is not an exhaustive list, so I'm not sure if we actually want to do this or not.

There are other improvements to be made in both lab and hapi, but I think this is a good first step. Using a modified version of hapi, I took heap snapshots in a process exit handler and saw memory usage drop from ~45MB to ~19MB when running the test suite.