### PR TITLE
Add failing test for conditional value

### DIFF
--- a/test/coverage.js
+++ b/test/coverage.js
@@ -312,6 +312,21 @@ describe('Coverage', () => {
         done();
     });
 
+    it('should measure coverage on conditional value', (done) => {
+
+        const Test = require('./coverage/conditional-value');
+        expect(Test.method(1)).to.be.undefined();
+        expect(Test.method(0)).to.be.undefined();
+        expect(Test.method(1, true)).to.equal(1);
+        expect(Test.method(0, true)).to.equal(42);
+
+        const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/conditional-value') });
+        const source = cov.files[0].source;
+        const missedLines = Object.keys(source).filter((lineNumber) => source[lineNumber].miss);
+        expect(missedLines).to.be.empty();
+        done();
+    });
+
     describe('#analyze', () => {
 
         it('sorts file paths in report', (done) => {

--- a/test/coverage/conditional-value.js
+++ b/test/coverage/conditional-value.js
@@ -1,0 +1,17 @@
+'use strict';
+
+// Load modules
+
+
+// Declare internals
+
+const internals = {
+    def: 42
+};
+
+
+exports.method = function (value, bool) {
+
+    const v = bool && (value || internals.def);
+    return v;
+};


### PR DESCRIPTION
We have a similar case on our project where a value is assigned based on boolean short-circuits, it shows it as uncovered so we have to convert it to `A ? A : B` instead of `A || B`. I looked at it quickly but I'm not sure how to fix it or if we want to fix it at all, as it could detect some actual failures in coverage. I'm PRing the failing test in case someone has an idea.