### PR TITLE
Improve bail strategy not to execute next befores/afters

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -285,7 +285,7 @@ internals.executeExperiments = function (experiments, state, skip, callback) {
         const previousDomains = state.domains;
         state.domains = [];
 
-        const skipExperiment = skip || experiment.options.skip || !internals.experimentHasTests(experiment, state);
+        const skipExperiment = skip || experiment.options.skip || !internals.experimentHasTests(experiment, state) || (state.options.bail && state.report.failures);
         const steps = [
             function (next) {
 


### PR DESCRIPTION
Not sure if it should be bug or enhancement, I'll let you decide the label.