### PR TITLE
Fix a domain leak and onCleanup failures

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -452,7 +452,7 @@ internals.executeTests = function (experiment, state, skip, callback) {
                     state.report.tests.push(test);
                     state.reporter.test(test);
 
-                    return next();
+                    setImmediate(next);
                 });
             },
             function (next) {
@@ -610,6 +610,7 @@ internals.createDomainErrorHandler = (item, state, domain, domains, finish) => {
 
 internals.protect = function (item, state, callback) {
 
+    const finished = Hoek.once(callback);
     let isFirst = true;
     let timeoutId;
     let countBefore = -1;
@@ -624,6 +625,8 @@ internals.protect = function (item, state, callback) {
     // We need to keep a reference to the list of domains at the time of the call since those will change with nested
     // experiments.
     const domains = state.domains;
+
+    let cleaningUp = false;
 
     const finish = function (err, cause) {
 
@@ -659,7 +662,8 @@ internals.protect = function (item, state, callback) {
         }
 
         if (!isFirst) {
-            const message = `Multiple callbacks or thrown errors received in test "${item.title}" (${cause})`;
+            const prefix = cleaningUp ? 'An error probably occured while cleaning up' : 'Multiple callbacks or thrown errors received in';
+            const message = `${prefix} test "${item.title}" (${cause})`;
 
             if (err && !/^Multiple callbacks/.test(err.message)) {
                 err.message = message + ': ' + err.message;
@@ -669,10 +673,20 @@ internals.protect = function (item, state, callback) {
             }
 
             state.report.errors.push(err);
+
+            if (cleaningUp) {
+                cleaningUp = false;
+                finished(err);
+            }
+
             return;
         }
         isFirst = false;
-        internals.cleanupItem(err, item, activeDomain, callback);
+        internals.cleanupItem(err, item, activeDomain, (err) => {
+
+            cleaningUp = false;
+            finished(err);
+        });
     };
 
     const ms = item.options.timeout !== undefined ? item.options.timeout : state.options.timeout;
@@ -699,17 +713,23 @@ internals.protect = function (item, state, callback) {
 
     setImmediate(() => {
 
+        const exitDomain = Hoek.once(() => domain.exit());
         domain.enter();
 
         item.onCleanup = null;
         const onCleanup = (func) => {
 
-            item.onCleanup = func;
+            item.onCleanup = (cb) => {
+
+                cleaningUp = true;
+                domain.run(func, cb);
+            };
         };
 
         const done = (err) => {
 
-            finish(err, 'done');
+            exitDomain();
+            setImmediate(finish, err, 'done');
         };
 
         item.notes = [];
@@ -723,13 +743,13 @@ internals.protect = function (item, state, callback) {
         if (itemResult &&
             itemResult.then instanceof Function) {
 
-            itemResult.then(() => finish(null), (err) => finish(err, 'done'));
+            itemResult.then(done, done);
         }
         else if (!item.fn.length) {
             finish(new Error(`Function for "${item.title}" should either take a callback argument or return a promise`), 'function signature');
         }
 
-        domain.exit();
+        exitDomain();
     });
 };
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -126,6 +126,35 @@ describe('Runner', () => {
         });
     });
 
+    it('calls failing cleanup function', (done) => {
+
+        const script = Lab.script();
+
+        script.test('a', (done, onCleanup) => {
+
+            setImmediate(() => {
+
+                onCleanup((next) => {
+
+                    setImmediate(() => {
+
+                        throw new Error('oops');
+                    });
+                });
+
+                setImmediate(done);
+            });
+        });
+
+        Lab.execute(script, {}, null, (err, notebook) => {
+
+            expect(err).not.to.exist();
+            expect(notebook.tests).to.have.length(1);
+            expect(notebook.failures).to.equal(1);
+            done();
+        });
+    });
+
     it('should fail test that neither takes a callback nor returns anything', (done) => {
 
         const script = Lab.script({ schedule: false });


### PR DESCRIPTION
1. Fixes domain contamination of other tests. On synchronous tests, the `done` call was still in the domain, so the next before/after/it/... would be contained in previous test. I don't think it lead to bugs but it's still better this way.

2. `onCleanup` failures could leave lab hanging infinitely, or worst, crash without reporting anything (out of things to do in the event loop).