### PR TITLE
upgrade eslint to 3.19.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "bossy": "3.x.x",
     "diff": "3.x.x",
-    "eslint": "3.17.x",
+    "eslint": "3.19.x",
     "eslint-config-hapi": "10.x.x",
     "eslint-plugin-hapi": "4.x.x",
     "espree": "3.x.x",


### PR DESCRIPTION
due to some new config features like used in eslint-config-airbnb, a new eslint version is needed