### PR TITLE
Support eslint 4 ignore path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ coverage.html
 lib-cov
 test_runner
 test/cli/test/leaks.js
+package-lock.json

--- a/lib/linter/.eslintignore
+++ b/lib/linter/.eslintignore
@@ -1,2 +1,0 @@
-node_modules
-test_runner

--- a/lib/linter/index.js
+++ b/lib/linter/index.js
@@ -15,8 +15,7 @@ const internals = {};
 exports.lint = function () {
 
     const configuration = {
-        ignore: true,
-        useEslintrc: true
+        ignore: true
     };
 
     const options = process.argv[2] ? JSON.parse(process.argv[2]) : undefined;
@@ -27,10 +26,6 @@ exports.lint = function () {
         !Fs.existsSync('.eslintrc.json') &&
         !Fs.existsSync('.eslintrc')) {
         configuration.configFile = Path.join(__dirname, '.eslintrc.js');
-    }
-
-    if (!Fs.existsSync('.eslintignore')) {
-        configuration.ignorePath = Path.join(__dirname, '.eslintignore');
     }
 
     if (options) {


### PR DESCRIPTION
Updates from eslint 4 now move the eslintignore to be relative to the file, which means installing lab v14 before this change without a top level .eslintignore uses the one from lab, which results in node_modules being linted :/ This fixes that bug

Another part of this fix is to not search beyond the cwd for an eslintrc file