### PR TITLE
Expose Code features directly on script

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,9 +446,15 @@ If you would like to run a different linter, or even a custom version of eslint 
 Using the `--assert` argument allows you to integrate Lab with your favorite assertion library. By default the assertion library `code` is included and integrated. However, you can override this behavior by setting the CLI `--assert` argument or changing the `assert` option when executing `report`. Whatever assertion library you specify is imported and assigned to the `Lab.assertions` property. Here is an example using `lab --assert code`:
 
 ```js
+const lab = exports.lab = Lab.script();
+const { describe, it } = lab;
+
 // Testing shortcuts
 const expect = Lab.assertions.expect;
 const fail = Lab.assertions.fail;
+// OR
+// const expect = lab.expect;
+// const fail = lab.fail;
 
 
 describe('expectation', () => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -85,6 +85,11 @@ exports.script = function (options) {
     script.after = internals.after.bind(script);
     script.afterEach = internals.afterEach.bind(script);
 
+    if (exports.assertions) {                           // Assertions can be disabled
+        script.expect = exports.assertions.expect;
+        script.fail = exports.assertions.fail;
+    }
+
     if (options.schedule !== false) {                   // Defaults to true
         setImmediate(() => {
 

--- a/test/index.js
+++ b/test/index.js
@@ -862,4 +862,24 @@ describe('Lab', () => {
             done();
         });
     });
+
+    it('exposes code on the script', (done) => {
+
+        const script = Lab.script({ schedule: false });
+
+        expect(script.expect).to.be.a.function();
+        expect(script.fail).to.be.a.function();
+        done();
+    });
+
+    it('does not expose code on the script if assert false', (done) => {
+
+        const assertions = Lab.assertions;
+        Lab.assertions = null;
+        const script = Lab.script({ schedule: false });
+        Lab.assertions = assertions;
+        expect(script.expect).not.to.exist();
+        expect(script.fail).not.to.exist();
+        done();
+    });
 });


### PR DESCRIPTION
I was frustrated not to be able to do :
```js
const { describe, it, before, after, expect } = exports.lab = require('lab').script();
```
So there's that.