### PR TITLE
Fix npm 5.2 error

### DIFF
--- a/lib/linter/.eslintrc.js
+++ b/lib/linter/.eslintrc.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-    'extends': 'eslint-config-hapi'
+    'extends': require.resolve('eslint-config-hapi')
 };


### PR DESCRIPTION
npm 5.2 stopped hoisting modules or whatever, so eslint doesn't find its modules anymore, I think having the full path satisfies whatever npm version there is.