### PR TITLE
Better color detection

### DIFF
--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -2,7 +2,6 @@
 
 // Load modules
 
-const Tty = require('tty');
 const Diff = require('diff');
 const StringifySafe = require('json-stringify-safe');
 const StableStringify = require('json-stable-stringify');
@@ -393,7 +392,7 @@ internals.color = function (name, code, enabled) {
 internals.colors = function (enabled) {
 
     if (enabled === null) {
-        enabled = Tty.isatty(1) && Tty.isatty(2);
+        enabled = require('supports-color');
     }
 
     const codes = {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "mkdirp": "0.5.x",
     "seedrandom": "2.4.x",
     "source-map": "0.5.x",
-    "source-map-support": "0.4.x"
+    "source-map-support": "0.4.x",
+    "supports-color": "4.2.x"
   },
   "devDependencies": {
     "cpr": "2.2.x",

--- a/test/cli/simpleTty.js
+++ b/test/cli/simpleTty.js
@@ -2,7 +2,6 @@
 
 // Load modules
 
-const Tty = require('tty');
 const Code = require('code');
 const _Lab = require('../../test_runner');
 
@@ -20,11 +19,8 @@ const it = lab.it;
 const expect = Code.expect;
 
 
-Tty.isatty = function () {
-
-    return true;
-};
-
+process.stdout.isTTY = true;
+process.env.FORCE_COLOR = true;
 
 describe('Test CLI', () => {
 

--- a/test/run_cli.js
+++ b/test/run_cli.js
@@ -13,6 +13,7 @@ module.exports = (args, callback, root) => {
 
     const childEnv = Object.assign({}, process.env);
     delete childEnv.NODE_ENV;
+    delete childEnv.FORCE_COLOR;
     const cli = ChildProcess.spawn('node', [].concat(internals.labPath, args), { env: childEnv, cwd : root || '.' });
     let output = '';
     let errorOutput = '';


### PR DESCRIPTION
For a while now, I've never been able to see lab colors on WebStorm console, which is especially annoying for diffs, and I finally found out why.

Turns out that detecting whether it's a TTY or not is not enough to tell if it supports color.