### PR TITLE
update eslint parser version to 8

### DIFF
--- a/lib/linter/.eslintrc.js
+++ b/lib/linter/.eslintrc.js
@@ -1,5 +1,8 @@
 'use strict';
 
 module.exports = {
-    'extends': require.resolve('eslint-config-hapi')
+    'extends': require.resolve('eslint-config-hapi'),
+    'parserOptions': {
+        'ecmaVersion': 8
+    }
 };


### PR DESCRIPTION
Support linting `async` functions.

Refs: https://github.com/eslint/eslint/issues/8126