### PR TITLE
Helpful message when path not found

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -111,7 +111,7 @@ internals.traverse = function (paths, options) {
             throw err;
         }
         options.output.write('Could not find test file or directory \'' + lastPath + '\'.\n');
-        process.exit(0);
+        process.exit(1);
     }
 
     if (options.pattern && !testFiles.length) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -66,9 +66,11 @@ exports.run = function () {
 
 internals.traverse = function (paths, options) {
 
+    let nextPath = null;
     const traverse = function (path) {
 
         let files = [];
+        nextPath = path;
 
         const pathStat = Fs.statSync(path);
         if (pathStat.isFile()) {
@@ -77,20 +79,20 @@ internals.traverse = function (paths, options) {
 
         Fs.readdirSync(path).forEach((filename) => {
 
-            const file = Path.join(path, filename);
-            const stat = Fs.statSync(file);
+            nextPath = Path.join(path, filename);
+            const stat = Fs.statSync(nextPath);
             if (stat.isDirectory() &&
                 !options.flat) {
 
-                files = files.concat(traverse(file, options));
+                files = files.concat(traverse(nextPath, options));
                 return;
             }
 
             if (stat.isFile() &&
                 options.pattern.test(filename) &&
-                Path.basename(file)[0] !== '.') {
+                Path.basename(nextPath)[0] !== '.') {
 
-                files.push(file);
+                files.push(nextPath);
             }
         });
 
@@ -98,11 +100,10 @@ internals.traverse = function (paths, options) {
     };
 
     let testFiles = [];
-    let lastPath = null;
     try {
         paths.forEach((path) => {
 
-            lastPath = path;
+            nextPath = path;
             testFiles = testFiles.concat(traverse(path));
         });
     }
@@ -110,7 +111,7 @@ internals.traverse = function (paths, options) {
         if (err.code !== 'ENOENT') {
             throw err;
         }
-        options.output.write('Could not find test file or directory \'' + lastPath + '\'.\n');
+        options.output.write('Could not find test file or directory \'' + nextPath + '\'.\n');
         process.exit(1);
     }
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -103,7 +103,6 @@ internals.traverse = function (paths, options) {
     try {
         paths.forEach((path) => {
 
-            nextPath = path;
             testFiles = testFiles.concat(traverse(path));
         });
     }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -98,13 +98,24 @@ internals.traverse = function (paths, options) {
     };
 
     let testFiles = [];
-    paths.forEach((path) => {
+    let lastPath = null;
+    try {
+        paths.forEach((path) => {
 
-        testFiles = testFiles.concat(traverse(path));
-    });
+            lastPath = path;
+            testFiles = testFiles.concat(traverse(path));
+        });
+    }
+    catch (err) {
+        if (err.code !== 'ENOENT') {
+            throw err;
+        }
+        options.output.write('Could not find test file or directory \'' + lastPath + '\'.\n');
+        process.exit(0);
+    }
 
     if (options.pattern && !testFiles.length) {
-        options.output.write('The pattern provided (-P or --pattern) didn\'t match any files.');
+        options.output.write('The pattern provided (-P or --pattern) didn\'t match any files.\n');
         process.exit(0);
     }
 
@@ -129,7 +140,7 @@ internals.traverse = function (paths, options) {
             }
         }
         else if (global._labScriptRun) {
-            options.output.write('The file: ' + file + ' includes a lab script that is not exported via exports.lab');
+            options.output.write('The file: ' + file + ' includes a lab script that is not exported via exports.lab\n');
             return process.exit(1);
         }
     });

--- a/test/cli.js
+++ b/test/cli.js
@@ -112,6 +112,21 @@ describe('CLI', () => {
         }, Path.join(__dirname, 'cli_labrc'));
     });
 
+    it('exits with code 1 when the test path does not exist', (done) => {
+
+        RunCli(['test/not_there'], (error, result) => {
+
+            if (error) {
+                done(error);
+            }
+
+            expect(result.code).to.equal(1);
+            expect(result.output).to.contain('Could not find');
+            expect(result.output).to.contain('test/not_there');
+            done();
+        });
+    });
+
     it('exits with code 1 after function throws', (done) => {
 
         RunCli(['test/cli_throws/throws.js'], (error, result) => {


### PR DESCRIPTION
This is a PR for issue #759. Also appended LFs to error messages that `cli.js` outputs to `options.output` so that the shell prompt lands on the following line.