### PR TITLE
Remove domains and callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ coverage.html
 lib-cov
 test_runner
 test/cli/test/leaks.js
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 
 node_js:
-  - "4"
-  - "6"
   - "8"
   - "node"
 

--- a/bin/_lab
+++ b/bin/_lab
@@ -2,26 +2,48 @@
 
 'use strict';
 
-if (process.env.ROOT_SPAWN) {
-    require('../test_runner/cli').run();
-    return;
-}
-
+const Util = require('util');
 const Cpr = require('cpr');
 const Rimraf = require('rimraf');
 
-Cpr('./lib', './test_runner', { deleteFirst: true, confirm: true }, (err) => {
 
-    if (err) {
-        console.error(err);
+if (process.env.ROOT_SPAWN) {
+    (async () => {
+        try {
+        const { code } = await require('../test_runner/cli').run();
+        process.exit(code);
+        }
+        catch (ex) {
+            console.error(ex);
+            process.exit(1);
+        }
+    })();
+    return;
+}
+
+
+const main = async function () {
+
+    const cpr = Util.promisify(Cpr);
+
+    try {
+        await cpr('./lib', './test_runner', { deleteFirst: true, confirm: true });
+        process.env.ROOT_SPAWN = true;
+        const { code } = await require('../test_runner/cli').run();
+        process.exit(code);
+    }
+    catch (ex) {
+        console.error(ex);
         process.exit(1);
     }
+};
 
-    process.env.ROOT_SPAWN = true;
-    require('../test_runner/cli').run();
-});
+main();
 
-process.on('exit', (code) => {
 
-    Rimraf.sync('./test_runner');
+
+process.on('exit', async () => {
+
+    const rimraf = Util.promisify(Rimraf);
+    await rimraf('./test_runner');
 });

--- a/bin/lab
+++ b/bin/lab
@@ -47,4 +47,12 @@ if (process.env.NODE_DEBUG_OPTION || inspectArg) {
     return;
 }
 
-require('../lib/cli').run();
+const main = async () => {
+
+    const { code } = await require('../lib/cli').run();
+    process.exit(code);
+};
+
+main();
+
+

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -192,12 +192,6 @@ internals.options = function () {
             multiple: true,
             default: null
         },
-        debug: {
-            alias: 'D',
-            type: 'boolean',
-            description: 'print the stack during a domain error event',
-            default: null
-        },
         dry: {
             alias: 'd',
             type: 'boolean',
@@ -290,22 +284,10 @@ internals.options = function () {
             multiple: true,
             default: null
         },
-        parallel: {
-            alias: 'p',
-            type: 'boolean',
-            description: 'parallel test execution within each experiment',
-            default: null
-        },
         pattern: {
             alias: 'P',
             type: 'string',
             description: 'file pattern to use for locating tests',
-            default: null
-        },
-        rejections: {
-            alias: 'R',
-            type: 'boolean',
-            description: 'fail test on unhandled Promise rejections',
             default: null
         },
         reporter: {
@@ -378,7 +360,6 @@ internals.options = function () {
     const defaults = {
         bail: false,
         coverage: false,
-        debug: false,
         dry: false,
         environment: 'test',
         flat: false,
@@ -388,9 +369,7 @@ internals.options = function () {
         'lint-fix': false,
         'lint-errors-threshold': 0,
         'lint-warnings-threshold': 0,
-        parallel: false,
         paths: ['test'],
-        rejections: false,
         reporter: 'console',
         shuffle: false,
         silence: false,
@@ -422,9 +401,9 @@ internals.options = function () {
     options.paths = argv._ ? [].concat(argv._) : options.paths;
 
     const keys = ['assert', 'bail', 'colors', 'context-timeout', 'coverage', 'coverage-exclude',
-        'coverage-path', 'debug', 'dry', 'environment', 'flat', 'globals', 'grep',
+        'coverage-path', 'dry', 'environment', 'flat', 'globals', 'grep',
         'lint', 'lint-errors-threshold', 'lint-fix', 'lint-options', 'lint-warnings-threshold',
-        'linter', 'output', 'parallel', 'pattern', 'rejections', 'reporter', 'seed', 'shuffle', 'silence',
+        'linter', 'output', 'pattern', 'reporter', 'seed', 'shuffle', 'silence',
         'silent-skips', 'sourcemaps', 'threshold', 'timeout', 'transform', 'verbose'];
     for (let i = 0; i < keys.length; ++i) {
         if (argv.hasOwnProperty(keys[i]) && argv[keys[i]] !== undefined && argv[keys[i]] !== null) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,11 +30,11 @@ exports.assertions = Code;                                              // Set b
 
         experiment('#isEven()', () => {
 
-            test('returns true on even values', (done) => {
+            test('returns true on even values', () => {
 
             });
 
-            test('returns false on odd values', (done) => {
+            test('returns false on odd values', () => {
 
             });
         });

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -13,55 +13,58 @@ const internals = {
 };
 
 
-exports.lint = function (settings, callback) {
+exports.lint = function (settings) {
 
-    const linterPath = (settings.linter && settings.linter !== 'eslint') ? settings.linter : internals.linter;
+    return new Promise((resolve, reject) => {
 
-    let linterOptions;
+        const linterPath = (settings.linter && settings.linter !== 'eslint') ? settings.linter : internals.linter;
 
-    try {
-        linterOptions = JSON.parse(settings['lint-options'] || '{}');
-    }
-    catch (err) {
-        throw new Error('lint-options could not be parsed');
-    }
+        let linterOptions;
 
-    linterOptions.fix = settings['lint-fix'];
+        try {
+            linterOptions = JSON.parse(settings['lint-options'] || '{}');
+        }
+        catch (err) {
+            return reject(new Error('lint-options could not be parsed'));
+        }
 
-    const child = ChildProcess.fork(linterPath, [JSON.stringify(linterOptions)], { cwd: settings.lintingPath });
-    child.once('message', (message) => {
+        linterOptions.fix = settings['lint-fix'];
 
-        child.kill();
+        const child = ChildProcess.fork(linterPath, [JSON.stringify(linterOptions)], { cwd: settings.lintingPath });
+        child.once('message', (message) => {
 
-        const result = { lint: message, totalErrors: 0, totalWarnings: 0 };
+            child.kill();
 
-        result.lint.forEach((lint) => {
+            const result = { lint: message, totalErrors: 0, totalWarnings: 0 };
 
-            let errors = 0;
-            let warnings = 0;
+            result.lint.forEach((lint) => {
 
-            lint.errors.forEach((err) => {
+                let errors = 0;
+                let warnings = 0;
 
-                if (err.severity === 'ERROR') {
-                    errors++;
-                }
-                else {
-                    warnings++;
+                lint.errors.forEach((err) => {
+
+                    if (err.severity === 'ERROR') {
+                        errors++;
+                    }
+                    else {
+                        warnings++;
+                    }
+                });
+
+                lint.totalErrors = errors;
+                lint.totalWarnings = warnings;
+                result.totalErrors += errors;
+                result.totalWarnings += warnings;
+
+                if (lint.fix) {
+                    Fs.writeFileSync(lint.filename, lint.fix.output);
                 }
             });
 
-            lint.totalErrors = errors;
-            lint.totalWarnings = warnings;
-            result.totalErrors += errors;
-            result.totalWarnings += warnings;
+            result.total = result.totalErrors + result.totalWarnings;
 
-            if (lint.fix) {
-                Fs.writeFileSync(lint.filename, lint.fix.output);
-            }
+            return resolve(result);
         });
-
-        result.total = result.totalErrors + result.totalWarnings;
-
-        return callback(null, result);
     });
 };

--- a/lib/linter/.eslintrc.js
+++ b/lib/linter/.eslintrc.js
@@ -1,8 +1,8 @@
 'use strict';
 
 module.exports = {
-    'extends': require.resolve('eslint-config-hapi'),
-    'parserOptions': {
-        'ecmaVersion': 8
+    extends: require.resolve('eslint-config-hapi'),
+    parserOptions: {
+        ecmaVersion: 8
     }
 };

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -150,7 +150,7 @@ internals.Reporter.prototype.end = function (notebook) {
     const errors = notebook.errors || [];
     if (errors.length) {
         output += 'Test script errors:\n\n';
-        errors.forEach((err) => {
+        errors.forEach((err = {}) => {
 
             output += red(err.message) + '\n';
             if (err.stack) {

--- a/lib/reporters/index.js
+++ b/lib/reporters/index.js
@@ -92,34 +92,32 @@ exports.generate = function (options) {
             }
         };
 
-        reporter.finalize = function (notebook, callback) {
+        reporter.finalize = function (notebook) {
 
             reporter.end(notebook);
 
-            const finalize = function () {
+            return new Promise((resolve, reject) => {
 
-                const code = ((notebook.errors && notebook.errors.length) ||                                                  // Before/after/exceptions
-                            options.coverage && options.threshold && notebook.coverage.percent < options.threshold) ||        // Missing coverage
-                            notebook.failures ||                                                                              // Tests failed
-                            (notebook.leaks && notebook.leaks.length) ||                                                      // Global leaked
-                            (options.lint &&
-                                (internals.isOverLintStatus(notebook.lint, options['lint-errors-threshold'], 'ERROR') ||      // Linting errors
-                                internals.isOverLintStatus(notebook.lint, options['lint-warnings-threshold'], 'WARNING'))     // Linting warnings
-                            ) ? 1 : 0;
+                const finalize = function () {
 
-                if (callback) {
-                    return callback(null, code, output);
+                    const code = ((notebook.errors && notebook.errors.length) ||                                                  // Before/after/exceptions
+                                options.coverage && options.threshold && notebook.coverage.percent < options.threshold) ||        // Missing coverage
+                                notebook.failures ||                                                                              // Tests failed
+                                (notebook.leaks && notebook.leaks.length) ||                                                      // Global leaked
+                                (options.lint &&
+                                    (internals.isOverLintStatus(notebook.lint, options['lint-errors-threshold'], 'ERROR') ||      // Linting errors
+                                    internals.isOverLintStatus(notebook.lint, options['lint-warnings-threshold'], 'WARNING'))     // Linting warnings
+                                ) ? 1 : 0;
+
+                    return resolve({ code, output });
+                };
+
+                if (!dest || dest === process.stdout) {
+                    return finalize();
                 }
 
-                // Flush the buffered output before exiting
-                process.stdout.write('', () => process.exit(code));
-            };
-
-            if (!dest || dest === process.stdout) {
-                return finalize();
-            }
-
-            dest.end(finalize);
+                dest.end(finalize);
+            });
         };
     }
 

--- a/lib/reporters/multiple.js
+++ b/lib/reporters/multiple.js
@@ -71,32 +71,26 @@ internals.Reporter.prototype.report = function (text) {
 };
 
 
-internals.Reporter.prototype.finalize = function (notebook, callback) {
+internals.Reporter.prototype.finalize = async function (notebook) {
 
     this._results = { err: false, code: [], output: [], count: 0 };
 
     for (const key in this._reporters) {
-        this._reporters[key].finalize(notebook, this.finalizeSingle(key, callback));
-    }
-};
-
-
-internals.Reporter.prototype.finalizeSingle = function (key, callback) {
-
-    return (err, code, output) => {
-
         this._results.count++;
-        this._results.err = this._results.err || err;
-        this._results.code[key] = code;
-        this._results.output[key] = output;
-        this._results.processCode = this._results.processCode || code;
-
-        if (this._results.count === Object.keys(this._reporters).length) {
-            if (callback) {
-                return callback(this._results.err, this._results.code, this._results.output);
-            }
-
-            process.exit(this._results.processCode);
+        try {
+            const { code, output } = await this._reporters[key].finalize(notebook);
+            this._results.code[key] = code;
+            this._results.output[key] = output;
+            this._results.processCode = this._results.processCode || code;
         }
-    };
+        catch (ex) {
+            this._results.err = this._results.err || ex;
+        }
+    }
+
+    if (this._results.err) {
+        return Promise.reject(this._results.err);
+    }
+
+    return Promise.resolve({ code: this._results.code, output: this._results.output });
 };

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -2,10 +2,7 @@
 
 // Load modules
 
-// 'cluster' loaded below in internals.loadLazyObjects()
-const Domain = require('domain');
 const Code = require('code');
-const Items = require('items');
 const Hoek = require('hoek');
 const Seedrandom = require('seedrandom');
 const Reporters = require('./reporters');
@@ -39,7 +36,6 @@ internals.defaults = {
     // coverageExclude: ['node_modules', 'test'],
     colors: null,                                   // true, false, null (based on tty)
     dry: false,
-    debug: false,
     environment: 'test',
 
     // flat: false,
@@ -49,9 +45,7 @@ internals.defaults = {
     leaks: true,
     timeout: 2000,
     output: process.stdout,                         // Stream.Writable or string (filename)
-    parallel: false,
     progress: 1,
-    rejections: false,
     reporter: 'console',
     shuffle: false,
     seed: Math.floor(Math.random() * 1000),
@@ -66,28 +60,16 @@ internals.defaults = {
 };
 
 
-exports.report = function (scripts, options, callback) {
+exports.report = async (scripts, options) => {
 
     const settings = Utils.mergeOptions(internals.defaults, options);
     settings.environment = settings.environment.trim();
     const reporter = Reporters.generate(settings);
 
-    const executeScripts = function (next) {
+    const executeScripts = async function () {
 
-        exports.execute(scripts, settings, reporter, (err, result) => {
-            // Can only be (and is) covererd via CLI tests
-            /* $lab:coverage:off$ */
-            if (err) {
-                const outputStream = [].concat(options.output).find((output) => !!output.write);
-                if (outputStream) {
-                    outputStream.write(err.toString() + '\n');
-                }
-                else {
-                    console.error(err.toString());
-                }
-                return process.exit(1);
-            }
-            /* $lab:coverage:on$ */
+        try {
+            const result = await exports.execute(scripts, settings, reporter);
 
             if (settings.leaks) {
                 result.leaks = Leaks.detect(settings.globals);
@@ -102,42 +84,49 @@ exports.report = function (scripts, options, callback) {
                 result.shuffle = true;
             }
 
-            return next(null, result);
-        });
-    };
-
-    const executeLint = function (next) {
-
-        if (!settings.lint) {
-            return next();
+            return Promise.resolve(result);
         }
-
-        Linters.lint(settings, next);
+        catch (ex) {
+            // Can only be (and is) covererd via CLI tests
+            /* $lab:coverage:off$ */
+            const outputStream = [].concat(options.output).find((output) => !!output.write);
+            if (outputStream) {
+                outputStream.write(ex.toString() + '\n');
+            }
+            else {
+                console.error(ex.toString());
+            }
+            return process.exit(1);
+            /* $lab:coverage:on$ */
+        }
     };
 
-    Items.parallel.execute({ notebook: executeScripts, lint: executeLint }, (ignoreErr, results) => {
+    const executeLint = async function () {
 
-        const notebook = results.notebook;
-        notebook.lint = results.lint;
+        return settings.lint ? await Linters.lint(settings) : Promise.resolve();
+    };
 
-        if (settings.assert) {
-            notebook.assertions = settings.assert.count && settings.assert.count();
-            const incompletes = settings.assert.incomplete && settings.assert.incomplete();
-            if (incompletes) {
-                for (let i = 0; i < incompletes.length; ++i) {
-                    const error = new Error('Incomplete assertion at ' + incompletes[i]);
-                    error.stack = undefined;
-                    notebook.errors.push(error);
-                }
+    const results = await Promise.all([executeScripts(), executeLint()]);
+    const notebook = results[0];
+    notebook.lint = results[1];
+
+    if (settings.assert) {
+        notebook.assertions = settings.assert.count && settings.assert.count();
+        const incompletes = settings.assert.incomplete && settings.assert.incomplete();
+        if (incompletes) {
+            for (let i = 0; i < incompletes.length; ++i) {
+                const error = new Error('Incomplete assertion at ' + incompletes[i]);
+                error.stack = undefined;
+                notebook.errors.push(error);
             }
         }
+    }
 
-        return reporter.finalize(notebook, callback);
-    });
+    return reporter.finalize(notebook);
 };
 
 
-exports.execute = function (scripts, options, reporter, callback) {
+exports.execute = async function (scripts, options, reporter) {
 
     const settings = Utils.mergeOptions(internals.defaults, options);
 
@@ -162,7 +151,7 @@ exports.execute = function (scripts, options, reporter, callback) {
             }
             return `Experiment: ${onlyNode.path}`;
         });
-        return callback(new Error('Multiple tests are marked as "only":\n\t' + paths.join('\n\t')));
+        return Promise.reject(new Error('Multiple tests are marked as "only":\n\t' + paths.join('\n\t')));
     }
 
     const onlyNode = onlyNodes[0];
@@ -197,30 +186,15 @@ exports.execute = function (scripts, options, reporter, callback) {
         only: onlyNode
     };
 
-    // Instantiate common lazily loaded items that can leak domains.
-    internals.loadLazyObjects();
+    await internals.executeExperiments(experiments, state, settings.dry);
+    const notebook = {
+        ms: Date.now() - startTime,
+        tests: state.report.tests,
+        failures: state.report.failures,
+        errors: state.report.errors
+    };
 
-    internals.executeExperiments(experiments, state, settings.dry, () => {
-
-        const notebook = {
-            ms: Date.now() - startTime,
-            tests: state.report.tests,
-            failures: state.report.failures,
-            errors: state.report.errors
-        };
-
-        return callback(null, notebook);
-    });
-};
-
-
-internals.loadLazyObjects = () => {
-    // Node core lazily loads many things. Once lab starts creating domains,
-    // any lazily created event emitters will hold a reference to those domains
-    // indefinitely.
-    process.stdout;
-    process.stderr;
-    require('cluster'); // Used in both TCP and UDP sockets.
+    return Promise.resolve(notebook);
 };
 
 
@@ -277,98 +251,68 @@ internals.shuffle = function (scripts, seed) {
 };
 
 
-internals.executeExperiments = function (experiments, state, skip, callback) {
+internals.executeExperiments = async function (experiments, state, skip) {
 
-    Items.serial(experiments, (experiment, nextExperiment) => {
-
-        // Create a new domains context for this level of experiments, keep the old ones to restore them when finishing
-        const previousDomains = state.domains;
-        state.domains = [];
-
+    for (const experiment of experiments) {
         const skipExperiment = skip || experiment.options.skip || !internals.experimentHasTests(experiment, state) || (state.options.bail && state.report.failures);
-        const steps = [
-            function (next) {
 
-                // Before
+        // Before
 
-                if (skipExperiment) {
-                    return next();
+        if (!skipExperiment) {
+            try {
+                await internals.executeDeps(experiment.befores, state);
+            }
+            catch (ex) {
+                internals.fail([experiment], state, skip, '\'before\' action failed');
+                if (!state.report.errors.includes(ex)) {
+                    state.report.errors.push(ex);
                 }
 
-                internals.executeDeps(experiment.befores, state, (err) => {
-
-                    if (err) {
-                        internals.fail([experiment], state, skip, '\'before\' action failed');
-                    }
-
-                    return next(err);
-                });
-            },
-            function (next) {
-
-                // Tests
-
-                internals.executeTests(experiment, state, skipExperiment, next);
-            },
-            function (next) {
-
-                // Sub-experiments
-
-                internals.executeExperiments(experiment.experiments, state, skipExperiment, next);
-            },
-            function (next) {
-
-                // After
-
-                if (skipExperiment) {
-                    return next();
-                }
-
-                internals.executeDeps(experiment.afters, state, next);
+                // skip the tests and afters since the before fails
+                continue;
             }
-        ];
+        }
 
-        Items.serial(steps, (item, next) => {
+        // Tests
 
-            item(next);
-        },
-        (err, results) => {
+        await internals.executeTests(experiment, state, skipExperiment);
 
-            // Restore the domains we had before
-            state.domains = previousDomains;
+        // Sub-experiments
 
-            if (err) {
-                state.report.errors.push(err);
+        await internals.executeExperiments(experiment.experiments, state, skipExperiment);
+
+        // After
+
+        if (!skipExperiment) {
+            try {
+                await internals.executeDeps(experiment.afters, state);
             }
-
-            nextExperiment();
-        });
-    },
-    (err) => {
-
-        callback(err);
-    });
+            catch (ex) {
+                internals.fail([experiment], state, skip, '\'after\' action failed');
+                state.report.errors.push(ex);
+            }
+        }
+    }
 };
 
 
-internals.executeDeps = function (deps, state, callback) {
+internals.executeDeps = async function (deps, state) {
 
-    if (!deps) {
-        return callback();
+    if (!deps || !deps.length) {
+        return Promise.resolve();
     }
 
-    Items.serial(deps, (dep, next) => {
-
+    for (const dep of deps) {
         dep.options.timeout = Hoek.isInteger(dep.options.timeout) ? dep.options.timeout : state.options['context-timeout'];
-        internals.protect(dep, state, next);
-    }, callback);
+        await internals.protect(dep, state);
+    }
 };
 
 
-internals.executeTests = function (experiment, state, skip, callback) {
+internals.executeTests = async function (experiment, state, skip) {
 
     if (!experiment.tests.length) {
-        return callback();
+        return Promise.resolve();
     }
 
     // Collect beforeEach and afterEach from parents
@@ -376,118 +320,80 @@ internals.executeTests = function (experiment, state, skip, callback) {
     const befores = skip ? [] : internals.collectDeps(experiment, 'beforeEaches');
     const afters = skip ? [] : internals.collectDeps(experiment, 'afterEaches');
 
-    // Separate serial and parallel execution tests
-
-    const serial = [];
-    const parallel = [];
-
-    experiment.tests.forEach((test) => {
-
-        if (test.options.parallel ||
-            (test.options.parallel === undefined && state.options.parallel)) {
-
-            parallel.push(test);
-        }
-        else {
-            serial.push(test);
-        }
-    });
-
     // Execute tests
 
-    const execute = function (test, nextTest) {
+    const execute = async function (test) {
 
-        // TODO: I would remove this and use the skip mechanism for it
-        if ((state.filters.ids.length && state.filters.ids.indexOf(test.id) === -1) ||
-            (state.filters.grep && !state.filters.grep.test(test.title))) {
+        const isNotFiltered = state.filters.ids.length && !state.filters.ids.includes(test.id);
+        const isNotGrepped = state.filters.grep && !state.filters.grep.test(test.title);
 
-            return process.nextTick(nextTest);
+        if (isNotFiltered || isNotGrepped) {
+            return new Promise((resolve) => {
+
+                setImmediate(resolve);
+            });
         }
 
-        const skipTest = skip || test.options.skip || (state.options.bail && state.report.failures);
+        const isSkipped = skip || test.options.skip || (state.options.bail && state.report.failures);
 
-        const steps = [
-            function (next) {
+        if (!test.fn ||
+            isSkipped) {
 
-                if (skipTest) {
-                    return next();
-                }
+            test[test.fn ? 'skipped' : 'todo'] = true;
+            test.duration = 0;
+            state.report.tests.push(test);
+            state.reporter.test(test);
+            return new Promise((resolve) => {
 
-                // Before each
+                setImmediate(resolve);
+            });
+        }
 
-                internals.executeDeps(befores, state, (err) => {
+        // Before each
 
-                    if (err) {
-                        internals.failTest(test, state, skip, '\'before each\' action failed');
-                    }
+        try {
+            await internals.executeDeps(befores, state);
+        }
+        catch (ex) {
+            internals.failTest(test, state, skip, ex);
+            return Promise.resolve();
+        }
 
-                    return next(err);
-                });
-            },
-            function (next) {
+        // Unit
 
-                // Unit
+        const start = Date.now();
+        try {
+            await internals.protect(test, state);
+        }
+        catch (ex) {
+            state.report.failures++;
+            test.err = ex;
+            test.timeout = ex.timeout;
+        }
+        test.duration = Date.now() - start;
 
-                if (!test.fn ||
-                    skipTest) {
+        state.report.tests.push(test);
+        state.reporter.test(test);
 
-                    test[test.fn ? 'skipped' : 'todo'] = true;
-                    test.duration = 0;
-                    state.report.tests.push(test);
-                    state.reporter.test(test);
-                    return setImmediate(next);
-                }
+        // After each
 
-                const start = Date.now();
-                internals.protect(test, state, (err) => {
-
-                    if (err) {
-                        state.report.failures++;
-                        test.err = err;
-                        test.timeout = err.timeout;
-                    }
-
-                    test.duration = Date.now() - start;
-
-                    state.report.tests.push(test);
-                    state.reporter.test(test);
-
-                    setImmediate(next);
-                });
-            },
-            function (next) {
-
-                if (skipTest) {
-                    return next();
-                }
-
-                // After each
-
-                return internals.executeDeps(afters, state, next);
+        try {
+            await internals.executeDeps(afters, state);
+        }
+        catch (ex) {
+            if (!state.report.errors.includes(ex)) {
+                state.report.errors.push(ex);
             }
-        ];
+        }
 
-        Items.serial(steps, (item, next) => {
-
-            item(next);
-        },
-        (err, results) => {
-
-            if (err) {
-                state.report.errors.push(err);
-            }
-
-            return nextTest();
-        });
+        return Promise.resolve();
     };
 
-    Items.serial(serial, execute, (err) => {
+    for (const test of experiment.tests) {
+        await execute(test);
+    }
 
-        Items.parallel(parallel, execute, () => {
-
-            return callback(err);
-        });
-    });
+    return Promise.resolve();
 };
 
 
@@ -537,44 +443,6 @@ internals.collectDeps = function (experiment, key) {
 };
 
 
-internals.cleanupItem = function (err, item, activeDomain, callback) {
-
-    const immed = setImmediate(() => {
-
-        if (!item.onCleanup) {
-            /* $lab:coverage:off$ */
-            // Don't hold on to objects in the active domain.
-            if (activeDomain) {
-                activeDomain.remove(immed);
-            }
-            /* $lab:coverage:on$ */
-
-            return callback(err);
-        }
-
-        item.onCleanup(() => {
-
-            /* $lab:coverage:off$ */
-            // Don't hold on to objects in the active domain.
-            if (activeDomain) {
-                activeDomain.remove(immed);
-            }
-            /* $lab:coverage:on$ */
-
-            callback(err);
-        });
-    });
-
-    /* $lab:coverage:off$ */
-    if (activeDomain) {
-        // The previously active domain need to be used here in case the callback throws.
-        // This is of course only valid if lab itself is ran in a domain, which is the case for its own tests.
-        activeDomain.add(immed);
-    }
-    /* $lab:coverage:on$ */
-};
-
-
 internals.createItemTimeout = (item, ms, finish) => {
 
     return setTimeout(() => {
@@ -586,188 +454,127 @@ internals.createItemTimeout = (item, ms, finish) => {
 };
 
 
-internals.createDomainErrorHandler = (item, state, domain, domains, finish) => {
+internals.protect = function (item, state) {
 
-    return (err, isForward) => {
-
-        // 1. Do not forward what's already a forward.
-        // 2. Only errors that reach before*/after* are worth forwarding, otherwise we know where they came from.
-
-        if (!isForward &&
-            item.id === undefined) {
-
-            internals.forwardError(err, domain, domains);
-        }
-
-        if (state.options.debug) {
-            state.report.errors.push(err);
-        }
-
-        finish(err, 'error');
-    };
-};
-
-
-internals.protect = function (item, state, callback) {
-
-    const finished = Hoek.once(callback);
     let isFirst = true;
     let timeoutId;
     let countBefore = -1;
     let failedWithUnhandledRejection = false;
+    let failedWithUncaughtException = false;
 
     if (state.options.assert && state.options.assert.count) {
         countBefore = state.options.assert.count();
     }
 
-    const activeDomain = Domain.active;
+    return new Promise((resolve, reject) => {
 
-    // We need to keep a reference to the list of domains at the time of the call since those will change with nested
-    // experiments.
-    const domains = state.domains;
+        const flags = { notes: [] };
+        flags.note = (note) => {
 
-    let cleaningUp = false;
+            flags.notes.push(note);
+        };
 
-    const finish = function (err, cause) {
+        const finish = async function (err, cause) {
 
-        clearTimeout(timeoutId);
-        timeoutId = null;
-        setImmediate(() => process.removeListener('unhandledRejection', promiseRejectionHandler));
-        if (failedWithUnhandledRejection) {
-            return;
-        }
+            clearTimeout(timeoutId);
+            timeoutId = null;
 
-        if (state.options.assert && state.options.assert.count) {
-            item.assertions = state.options.assert.count() - countBefore;
-        }
+            item.notes = (item.notes || []).concat(flags.notes);
 
-        if (err && err instanceof Error === false) {
-            const data = err;
-            err = new Error('Non Error object received or caught');
-            err.data = data;
-        }
-
-        if (item.options.plan !== undefined && item.options.plan !== item.assertions) {
-            const planMessage = (item.assertions === undefined)
-                ? `Expected ${item.options.plan} assertions, but no assertion library found`
-                : `Expected ${item.options.plan} assertions, but found ${item.assertions}`;
-            if (err && !/^Expected \d+ assertions/.test(err.message)) {
-                err.message = planMessage + ': ' + err.message;
+            process.removeListener('unhandledRejection', promiseRejectionHandler);
+            process.removeListener('uncaughtException', processUncaughtExceptionHandler);
+            // covered by test/cli_error/failure.js
+            /* $lab:coverage:off$ */
+            if (failedWithUnhandledRejection || failedWithUncaughtException) {
+                return reject(err);
             }
-            else {
-                err = new Error(planMessage);
+            /* $lab:coverage:off$ */
+
+            if (state.options.assert && state.options.assert.count) {
+                item.assertions = state.options.assert.count() - countBefore;
             }
 
-            state.report.errors.push(err);
-        }
+            if (flags.onCleanup) {
+                // covered by test/cli_oncleanup/throws.js
+                /* $lab:coverage:off$ */
+                const onCleanupError = (err) => {
 
-        if (!isFirst) {
-            const prefix = cleaningUp ? 'An error occured while cleaning up' : (
-                err ? 'Thrown error received in' : 'Multiple callbacks received in');
-            const message = `${prefix} test "${item.title}" (${cause})`;
+                    return reject(err);
+                };
+                /* $lab:coverage:on$ */
+                process.once('uncaughtException', onCleanupError);
 
-            if (err && !/^Thrown error/.test(err.message)) {
-                err.message = message + ': ' + err.message;
+                try {
+                    await flags.onCleanup();
+                }
+                catch (ex) {
+                    return reject(ex);
+                }
+
+                process.removeListener('uncaughtException', onCleanupError);
             }
-            else {
+
+            if (err && (err instanceof Error === false)) {
+                const data = err;
+                err = new Error('Non Error object received or caught');
+                err.data = data;
+            }
+
+            if (item.options.plan !== undefined && item.options.plan !== item.assertions) {
+                const planMessage = (item.assertions === undefined)
+                    ? `Expected ${item.options.plan} assertions, but no assertion library found`
+                    : `Expected ${item.options.plan} assertions, but found ${item.assertions}`;
+                if (err && !/^Expected \d+ assertions/.test(err.message)) {
+                    err.message = planMessage + ': ' + err.message;
+                }
+                else {
+                    err = new Error(planMessage);
+                }
+            }
+
+            if (!isFirst) {
+                const message = `Thrown error received in test "${item.title}" (${cause})`;
                 err = new Error(message);
             }
+            isFirst = false;
 
-            state.report.errors.push(err);
+            return err ? reject(err) : resolve();
+        };
 
-            if (cleaningUp) {
-                cleaningUp = false;
-                finished(err);
-            }
-
-            return;
+        const ms = item.options.timeout !== undefined ? item.options.timeout : state.options.timeout;
+        if (ms) {
+            timeoutId = internals.createItemTimeout(item, ms, finish);
         }
-        isFirst = false;
-        internals.cleanupItem(err, item, activeDomain, (err) => {
 
-            cleaningUp = false;
-            finished(err);
-        });
-    };
+        // covered by test/cli_error/failure.js
+        /* $lab:coverage:off$ */
+        const promiseRejectionHandler = function (err) {
 
-    const ms = item.options.timeout !== undefined ? item.options.timeout : state.options.timeout;
-    if (ms) {
-        timeoutId = internals.createItemTimeout(item, ms, finish);
-    }
-
-    const domain = Domain.createDomain();
-    const onError = internals.createDomainErrorHandler(item, state, domain, domains, finish);
-
-    domain.title = item.title;
-    domain.on('error', onError);
-    domains.push(domain);
-
-    const promiseRejectionHandler = function (reason) {
-
-        finish(reason, 'unhandledRejection');
-        failedWithUnhandledRejection = true;
-    };
-
-    if (state.options.rejections) {
+            failedWithUnhandledRejection = true;
+            finish(err, 'unhandledRejection');
+        };
         process.on('unhandledRejection', promiseRejectionHandler);
-    }
 
-    setImmediate(() => {
+        const processUncaughtExceptionHandler = function (err) {
 
-        const exitDomain = Hoek.once(() => domain.exit());
-        domain.enter();
-
-        item.onCleanup = null;
-        const onCleanup = (func) => {
-
-            item.onCleanup = (cb) => {
-
-                cleaningUp = true;
-                domain.run(func, cb);
-            };
+            failedWithUncaughtException = true;
+            finish(err, 'uncaughtException');
         };
+        /* $lab:coverage:on$ */
+        process.on('uncaughtException', processUncaughtExceptionHandler);
 
-        const done = (err) => {
+        setImmediate(async () => {
 
-            exitDomain();
-            setImmediate(finish, err, 'done');
-        };
-
-        item.notes = [];
-        done.note = (note) => {
-
-            item.notes.push(note);
-        };
-
-        const itemResult = item.fn.call(null, done, onCleanup);
-
-        if (item.fn.length && itemResult &&
-            itemResult.then instanceof Function) {
-
-            finish(new Error(`Function for "${item.title}" must either take a callback argument or return a promise, but not both`), 'function signature');
-        }
-        else if (itemResult &&
-            itemResult.then instanceof Function) {
-
-            itemResult.then(() => done(), done);
-        }
-        else if (!item.fn.length) {
-            finish(new Error(`Function for "${item.title}" should either take a callback argument or return a promise`), 'function signature');
-        }
-
-        exitDomain();
+            try {
+                await item.fn.call(null, flags);
+                finish();
+            }
+            catch (ex) {
+                state.report.errors.push(ex);
+                return finish(ex);
+            }
+        });
     });
-};
-
-
-internals.forwardError = function (err, sourceDomain, targetDomains) {
-
-    for (let i = 0; i < targetDomains.length; ++i) {
-        const d = targetDomains[i];
-        if (d !== sourceDomain) {
-            d.emit('error', err, true); // Add true to mark this as a forward.
-        }
-    }
 };
 
 
@@ -820,6 +627,7 @@ internals.failTest = function (test, state, skip, err) {
     }
 
     test.duration = 0;
+
     state.report.tests.push(test);
     state.reporter.test(test);
 };

--- a/package.json
+++ b/package.json
@@ -12,22 +12,21 @@
   },
   "dependencies": {
     "bossy": "3.x.x",
-    "code": "4.1.x",
-    "diff": "3.3.x",
-    "eslint": "4.7.x",
+    "code": "5.1.x",
+    "diff": "3.4.x",
+    "eslint": "4.8.x",
     "eslint-config-hapi": "10.x.x",
     "eslint-plugin-hapi": "4.x.x",
-    "espree": "3.5.x",
+    "espree": "^3.5.1",
     "find-rc": "3.0.x",
     "handlebars": "4.x.x",
-    "hoek": "4.x.x",
-    "items": "2.x.x",
+    "hoek": "5.x.x",
     "json-stable-stringify": "1.x.x",
     "json-stringify-safe": "5.x.x",
     "mkdirp": "0.5.x",
     "seedrandom": "2.4.x",
     "source-map": "0.6.x",
-    "source-map-support": "0.4.x",
+    "source-map-support": "0.5.x",
     "supports-color": "4.4.x"
   },
   "devDependencies": {
@@ -44,7 +43,7 @@
     "posttest": "npm run lint-md",
     "test-cov-html": "node ./bin/_lab -fL -r html -m 3000 -o coverage.html",
     "lint": "node ./bin/_lab -d -f -L",
-    "lint-md": "eslint --config hapi --rule 'strict: 0, eol-last: 0' --plugin markdown --ext md  ."
+    "lint-md": "eslint --config hapi --rule 'strict: 0, eol-last: 0' --plugin markdown --ext md --parser-options 'ecmaVersion: 8' ."
   },
   "license": "BSD-3-Clause"
 }

--- a/test/cli/environment.js
+++ b/test/cli/environment.js
@@ -17,7 +17,7 @@ const env = process.env.NODE_ENV;
 
 describe('Test CLI', () => {
 
-    it('Node Environment defaults to test', (done) => {
+    it('Node Environment defaults to test', () => {
 
         if (process.argv[3] && process.argv[3].indexOf('-e') >= 0) {
             expect(env).to.equal('lab');
@@ -25,7 +25,5 @@ describe('Test CLI', () => {
         else {
             expect(env).to.equal('test');
         }
-
-        done();
     });
 });

--- a/test/cli/simple.js
+++ b/test/cli/simple.js
@@ -21,15 +21,13 @@ const expect = Code.expect;
 
 describe('Test CLI', () => {
 
-    it('adds two numbers together', (done) => {
+    it('adds two numbers together', () => {
 
         expect(1 + 1).to.equal(2);
-        done();
     });
 
-    it('subtracts two numbers', (done) => {
+    it('subtracts two numbers', () => {
 
         expect(2 - 2).to.equal(0);
-        done();
     });
 });

--- a/test/cli/simple2.js
+++ b/test/cli/simple2.js
@@ -21,15 +21,13 @@ const expect = Code.expect;
 
 describe('Test CLI 2', () => {
 
-    it('adds multiplies numbers together', (done) => {
+    it('adds multiplies numbers together', () => {
 
         expect(5 * 5).to.equal(25);
-        done();
     });
 
-    it('divides two numbers', (done) => {
+    it('divides two numbers', () => {
 
         expect(25 / 5).to.equal(5);
-        done();
     });
 });

--- a/test/cli/simpleTty.js
+++ b/test/cli/simpleTty.js
@@ -24,15 +24,13 @@ process.env.FORCE_COLOR = true;
 
 describe('Test CLI', () => {
 
-    it('adds two numbers together', (done) => {
+    it('adds two numbers together', () => {
 
         expect(1 + 1).to.equal(2);
-        done();
     });
 
-    it('subtracts two numbers', (done) => {
+    it('subtracts two numbers', () => {
 
         expect(2 - 2).to.equal(0);
-        done();
     });
 });

--- a/test/cli/test/simple.js
+++ b/test/cli/test/simple.js
@@ -21,15 +21,13 @@ const expect = Code.expect;
 
 describe('Test CLI 3', () => {
 
-    it('supports negative numbers', (done) => {
+    it('supports negative numbers', () => {
 
         expect(1 - 2).to.equal(-1);
-        done();
     });
 
-    it('supports infinity', (done) => {
+    it('supports infinity', () => {
 
         expect(Infinity + 1).to.equal(Infinity);
-        done();
     });
 });

--- a/test/cli_assert/assert.js
+++ b/test/cli_assert/assert.js
@@ -20,15 +20,13 @@ const expect = _Lab.assertions.expect;
 
 describe('Test CLI', () => {
 
-    it('adds two numbers together', (done) => {
+    it('adds two numbers together', () => {
 
         expect(1 + 1).to.equal(2);
-        done();
     });
 
-    it('subtracts two numbers', (done) => {
+    it('subtracts two numbers', () => {
 
         expect(2 - 2).to.equal(0);
-        done();
     });
 });

--- a/test/cli_assert/no-assert.js
+++ b/test/cli_assert/no-assert.js
@@ -19,9 +19,8 @@ const it = lab.it;
 
 describe('Test CLI', () => {
 
-    it('assertions property doesn\'t exist', (done) => {
+    it('assertions property doesn\'t exist', () => {
 
         _Lab.expect(_Lab.assertions).to.not.exist();
-        done();
     });
 });

--- a/test/cli_bail/test1.js
+++ b/test/cli_bail/test1.js
@@ -23,22 +23,31 @@ const expect = Code.expect;
 
 describe('test1', () => {
 
-    before((done) => {
+    before(() => {
 
-        process.nextTick(done);
-    });
+        return new Promise((resolve) => {
 
-    it('should add numbers', (done) => {
-
-        process.nextTick(() => {
-
-            expect(1 + 1).to.equal(2);
-            done();
+            process.nextTick(resolve);
         });
     });
 
-    after((done) => {
+    it('should add numbers', () => {
 
-        process.nextTick(done);
+        return new Promise((resolve) => {
+
+            process.nextTick(() => {
+
+                expect(1 + 1).to.equal(2);
+                resolve();
+            });
+        });
+    });
+
+    after(() => {
+
+        return new Promise((resolve) => {
+
+            process.nextTick(resolve);
+        });
     });
 });

--- a/test/cli_bail/test2.js
+++ b/test/cli_bail/test2.js
@@ -23,22 +23,31 @@ const expect = Code.expect;
 
 describe('test2', () => {
 
-    before((done) => {
+    before(() => {
 
-        process.nextTick(done);
-    });
+        return new Promise((resolve) => {
 
-    it('should multiply numbers', (done) => {
-
-        process.nextTick(() => {
-
-            expect(1 * 1).to.equal(2);
-            done();
+            process.nextTick(resolve);
         });
     });
 
-    after((done) => {
+    it('should multiply numbers', () => {
 
-        process.nextTick(done);
+        return new Promise((resolve) => {
+
+            process.nextTick(() => {
+
+                expect(1 * 1).to.equal(2);
+                resolve();
+            });
+        });
+    });
+
+    after(() => {
+
+        return new Promise((resolve) => {
+
+            process.nextTick(resolve);
+        });
     });
 });

--- a/test/cli_bail/test3.js
+++ b/test/cli_bail/test3.js
@@ -23,22 +23,31 @@ const expect = Code.expect;
 
 describe('test2', () => {
 
-    before((done) => {
+    before(() => {
 
-        process.nextTick(done);
-    });
+        return new Promise((resolve) => {
 
-    it('should multiply numbers', (done) => {
-
-        process.nextTick(() => {
-
-            expect(1 * 1).to.equal(1);
-            done();
+            process.nextTick(resolve);
         });
     });
 
-    after((done) => {
+    it('should multiply numbers', () => {
 
-        process.nextTick(done);
+        return new Promise((resolve) => {
+
+            process.nextTick(() => {
+
+                expect(1 * 1).to.equal(1);
+                resolve();
+            });
+        });
+    });
+
+    after(() => {
+
+        return new Promise((resolve) => {
+
+            process.nextTick(resolve);
+        });
     });
 });

--- a/test/cli_coverage/test/include.js
+++ b/test/cli_coverage/test/include.js
@@ -20,10 +20,9 @@ const expect = _Lab.assertions.expect;
 
 describe('Test CLI', () => {
 
-    it('returns the specified value', (done) => {
+    it('returns the specified value', () => {
 
         const result = Include.method('test');
         expect(result).to.equal('test');
-        done();
     });
 });

--- a/test/cli_error/failure.js
+++ b/test/cli_error/failure.js
@@ -21,8 +21,30 @@ const expect = Code.expect;
 
 describe('Test CLI', () => {
 
-    it('handles failure', (done) => {
+    it('handles return rejection', () => {
 
-        done(new Error('fail'));
+        return Promise.reject(new Error('fail'));
+    });
+
+    it('handles return rejection in next tick', () => {
+
+        return new Promise(() => {
+
+            setImmediate(() => {
+
+                Promise.reject(new Error('rejection'));
+            });
+        });
+    });
+
+    it('handles throw in next tick', () => {
+
+        return new Promise(() => {
+
+            setImmediate(() => {
+
+                throw new Error('throw');
+            });
+        });
     });
 });

--- a/test/cli_inspect/simple.js
+++ b/test/cli_inspect/simple.js
@@ -21,9 +21,8 @@ const expect = Code.expect;
 
 describe('Test CLI', () => {
 
-    it('adds two numbers together', (done) => {
+    it('adds two numbers together', () => {
 
         expect(1 + 1).to.equal(2);
-        done();
     });
 });

--- a/test/cli_labrc/index.js
+++ b/test/cli_labrc/index.js
@@ -21,9 +21,8 @@ const expect = Code.expect;
 
 describe('Test .labrc.js', () => {
 
-    it('sets environment from .labrc.js', (done) => {
+    it('sets environment from .labrc.js', () => {
 
         expect(process.env.NODE_ENV).to.equal('labrc');
-        done();
     });
 });

--- a/test/cli_multi/test1.js
+++ b/test/cli_multi/test1.js
@@ -23,22 +23,31 @@ const expect = Code.expect;
 
 describe('test1', () => {
 
-    before((done) => {
+    before(() => {
 
-        process.nextTick(done);
-    });
+        return new Promise((resolve) => {
 
-    it('should add numbers', (done) => {
-
-        process.nextTick(() => {
-
-            expect(1 + 1).to.equal(2);
-            done();
+            process.nextTick(resolve);
         });
     });
 
-    after((done) => {
+    it('should add numbers', () => {
 
-        process.nextTick(done);
+        return new Promise((resolve) => {
+
+            process.nextTick(() => {
+
+                expect(1 + 1).to.equal(2);
+                resolve();
+            });
+        });
+    });
+
+    after(() => {
+
+        return new Promise((resolve) => {
+
+            process.nextTick(resolve);
+        });
     });
 });

--- a/test/cli_multi/test2.js
+++ b/test/cli_multi/test2.js
@@ -23,22 +23,31 @@ const expect = Code.expect;
 
 describe('test2', () => {
 
-    before((done) => {
+    before(() => {
 
-        process.nextTick(done);
-    });
+        return new Promise((resolve) => {
 
-    it('should multiply numbers', (done) => {
-
-        process.nextTick(() => {
-
-            expect(1 * 1).to.equal(1);
-            done();
+            process.nextTick(resolve);
         });
     });
 
-    after((done) => {
+    it('should multiply numbers', () => {
 
-        process.nextTick(done);
+        return new Promise((resolve) => {
+
+            process.nextTick(() => {
+
+                expect(1 * 1).to.equal(1);
+                resolve();
+            });
+        });
+    });
+
+    after(() => {
+
+        return new Promise((resolve) => {
+
+            process.nextTick(resolve);
+        });
     });
 });

--- a/test/cli_no_exports/hasExports.js
+++ b/test/cli_no_exports/hasExports.js
@@ -21,9 +21,8 @@ const expect = Code.expect;
 
 describe('Test CLI Exports', () => {
 
-    it('adds two numbers together', (done) => {
+    it('adds two numbers together', () => {
 
         expect(1 + 1).to.equal(2);
-        done();
     });
 });

--- a/test/cli_no_exports/missingExports.js
+++ b/test/cli_no_exports/missingExports.js
@@ -21,9 +21,8 @@ const expect = Code.expect;
 
 describe('Test CLI', () => {
 
-    it('adds two numbers together', (done) => {
+    it('adds two numbers together', () => {
 
         expect(1 + 1).to.equal(2);
-        done();
     });
 });

--- a/test/cli_oncleanup/throws.js
+++ b/test/cli_oncleanup/throws.js
@@ -1,0 +1,67 @@
+'use strict';
+
+// Load modules
+
+const Code = require('code');
+const _Lab = require('../../test_runner');
+
+
+// Declare internals
+
+const internals = {};
+
+
+// Test shortcuts
+
+const lab = exports.lab = _Lab.script();
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
+
+
+describe('Test CLI', () => {
+
+    it('handles failure', (flags) => {
+
+      return new Promise((resolve) => {
+
+            setImmediate(() => {
+
+                flags.onCleanup = () => {
+
+                    return new Promise(() => {
+
+                        setImmediate(() => {
+
+                            throw new Error('oops');
+                        });
+                    });
+                };
+
+                resolve();
+            });
+        });
+    });
+
+    it('success cleanup', (flags) => {
+
+        return new Promise((resolve) => {
+
+              setImmediate(() => {
+
+                  flags.onCleanup = () => {
+
+                      return new Promise((innerResolve) => {
+
+                          setImmediate(() => {
+
+                              innerResolve();
+                          });
+                      });
+                  };
+
+                  resolve();
+              });
+          });
+      });
+});

--- a/test/cli_only-skip/onlyExperiment.js
+++ b/test/cli_only-skip/onlyExperiment.js
@@ -24,170 +24,144 @@ const afterEach = lab.afterEach;
 
 describe('math', () => {
 
-    before((done) => {
+    before(() => {
 
         console.log('Should execute before 1');
-        done();
     });
 
-    beforeEach((done) => {
+    beforeEach(() => {
 
         console.log('Should execute beforeEach 1');
-        done();
     });
 
-    after((done) => {
+    after(() => {
 
         console.log('Should execute after 1');
-        done();
     });
 
-    afterEach((done) => {
+    afterEach(() => {
 
         console.log('Should execute afterEach 1');
-        done();
     });
 
     describe('addition', () => {
 
-        before((done) => {
+        before(() => {
 
             console.log('Should execute before 2');
-            done();
         });
 
-        beforeEach((done) => {
+        beforeEach(() => {
 
             console.log('Should execute beforeEach 2');
-            done();
         });
 
-        after((done) => {
+        after(() => {
 
             console.log('Should execute after 2');
-            done();
         });
 
-        afterEach((done) => {
+        afterEach(() => {
 
             console.log('Should execute afterEach 2');
-            done();
         });
 
-        it('returns true when 1 + 1 equals 2', (done) => {
+        it('returns true when 1 + 1 equals 2', () => {
 
             throw new Error("Should not execute this test");
-            done();
         });
 
-        it('returns true when 2 + 2 equals 4', (done) => {
+        it('returns true when 2 + 2 equals 4', () => {
 
             throw new Error("Should not execute this test");
-            done();
         });
 
         describe.only('nested addition', () => {
 
-            before((done) => {
+            before(() => {
 
                 console.log('Should execute before 3');
-                done();
             });
 
-            beforeEach((done) => {
+            beforeEach(() => {
 
                 console.log('Should execute beforeEach 3');
-                done();
             });
 
-            after((done) => {
+            after(() => {
 
                 console.log('Should execute after 3');
-                done();
             });
 
-            afterEach((done) => {
+            afterEach(() => {
 
                 console.log('Should execute afterEach 3');
-                done();
             });
 
-            it('returns true when 3 + 3 equals 6', (done) => {
+            it('returns true when 3 + 3 equals 6', () => {
 
                 expect(3 + 3).to.equal(6);
-                done();
             });
 
-            it('returns true when 4 + 4 equals 8', (done) => {
+            it('returns true when 4 + 4 equals 8', () => {
 
                 expect(4 + 4).to.equal(8);
-                done();
             });
 
             describe('deeply nested addtion', () => {
 
-                before((done) => {
+                before(() => {
 
                     console.log('Should execute before 4');
-                    done();
                 });
 
-                beforeEach((done) => {
+                beforeEach(() => {
 
                     console.log('Should execute beforeEach 4');
-                    done();
                 });
 
-                after((done) => {
+                after(() => {
 
                     console.log('Should execute after 4');
-                    done();
                 });
 
-                afterEach((done) => {
+                afterEach(() => {
 
                     console.log('Should execute afterEach 4');
-                    done();
                 });
 
-                it('returns true when 5 + 5 equals 10', (done) => {
+                it('returns true when 5 + 5 equals 10', () => {
 
                     expect(5 + 5).to.equal(10);
-                    done();
                 });
             });
         });
 
         describe('another nested addition', () => {
 
-            before((done) => {
+            before(() => {
 
                 throw new Error('Should not execute sibling before');
-                done();
             });
 
-            beforeEach((done) => {
+            beforeEach(() => {
 
                 throw new Error('Should not execute sibling beforeEach');
-                done();
             });
 
-            after((done) => {
+            after(() => {
 
                 throw new Error('Should not execute sibling after');
-                done();
             });
 
-            afterEach((done) => {
+            afterEach(() => {
 
                 throw new Error('Should not execute sibling afterEach');
-                done();
             });
 
-            it('returns true when 6 + 6 equals 12', (done) => {
+            it('returns true when 6 + 6 equals 12', () => {
 
                 throw new Error("Should not execute this test");
-                done();
             });
 
         });
@@ -195,73 +169,62 @@ describe('math', () => {
 
     describe('subtract', () => {
 
-        before((done) => {
+        before(() => {
 
             throw new Error('Should not execute unrelated before');
-            done();
         });
 
-        beforeEach((done) => {
+        beforeEach(() => {
 
             throw new Error('Should not execute unrelated beforeEach');
-            done();
         });
 
-        after((done) => {
+        after(() => {
 
             throw new Error('Should not execute unrelated after');
-            done();
         });
 
-        afterEach((done) => {
+        afterEach(() => {
 
             throw new Error('Should not execute unrelated afterEach');
-            done();
         });
 
-        it('returns true when 1 - 1 equals 0', (done) => {
+        it('returns true when 1 - 1 equals 0', () => {
 
             throw new Error("Should not execute this test");
-            done();
         });
 
-        it('returns true when 2 - 1 equals 1', (done) => {
+        it('returns true when 2 - 1 equals 1', () => {
 
             throw new Error("Should not execute this test");
-            done();
         });
     });
 });
 
 describe('unrelated subtract', () => {
 
-    before((done) => {
+    before(() => {
 
         throw new Error('Should not execute unrelated before');
-        done();
     });
 
-    beforeEach((done) => {
+    beforeEach(() => {
 
         throw new Error('Should not execute unrelated beforeEach');
-        done();
     });
 
-    after((done) => {
+    after(() => {
 
         throw new Error('Should not execute unrelated after');
-        done();
     });
 
-    afterEach((done) => {
+    afterEach(() => {
 
         throw new Error('Should not execute unrelated afterEach');
-        done();
     });
 
-    it('returns true when 3 - 3 equals 0', (done) => {
+    it('returns true when 3 - 3 equals 0', () => {
 
         throw new Error("Should not execute this test");
-        done();
     });
 });

--- a/test/cli_only-skip/onlyMultiple.js
+++ b/test/cli_only-skip/onlyMultiple.js
@@ -24,244 +24,206 @@ const afterEach = lab.afterEach;
 
 describe('math', () => {
 
-    before((done) => {
+    before(() => {
 
         console.log('Should execute before 1');
-        done();
     });
 
-    beforeEach((done) => {
+    beforeEach(() => {
 
         console.log('Should execute beforeEach 1');
-        done();
     });
 
-    after((done) => {
+    after(() => {
 
         console.log('Should execute after 1');
-        done();
     });
 
-    afterEach((done) => {
+    afterEach(() => {
 
         console.log('Should execute afterEach 1');
-        done();
     });
 
     describe('addition', () => {
 
-        before((done) => {
+        before(() => {
 
             console.log('Should execute before 2');
-            done();
         });
 
-        beforeEach((done) => {
+        beforeEach(() => {
 
             console.log('Should execute beforeEach 2');
-            done();
         });
 
-        after((done) => {
+        after(() => {
 
             console.log('Should execute after 2');
-            done();
         });
 
-        afterEach((done) => {
+        afterEach(() => {
 
             console.log('Should execute afterEach 2');
-            done();
         });
 
-        it('returns true when 1 + 1 equals 2', (done) => {
+        it('returns true when 1 + 1 equals 2', () => {
 
             throw new Error("Should not execute this test");
-            done();
         });
 
-        it('returns true when 2 + 2 equals 4', (done) => {
+        it('returns true when 2 + 2 equals 4', () => {
 
             throw new Error("Should not execute this test");
-            done();
         });
 
         describe.only('nested addition', () => {
 
-            before((done) => {
+            before(() => {
 
                 console.log('Should execute before 3');
-                done();
             });
 
-            beforeEach((done) => {
+            beforeEach(() => {
 
                 console.log('Should execute beforeEach 3');
-                done();
             });
 
-            after((done) => {
+            after(() => {
 
                 console.log('Should execute after 3');
-                done();
             });
 
-            afterEach((done) => {
+            afterEach(() => {
 
                 console.log('Should execute afterEach 3');
-                done();
             });
 
-            it('returns true when 3 + 3 equals 6', (done) => {
+            it('returns true when 3 + 3 equals 6', () => {
 
 	            throw new Error("Should not execute this test");
-                done();
             });
 
-            it('returns true when 4 + 4 equals 8', (done) => {
+            it('returns true when 4 + 4 equals 8', () => {
 
             	throw new Error("Should not execute this test");
-                done();
             });
 
             describe('deeply nested addtion', () => {
 
-                before((done) => {
+                before(() => {
 
                     console.log('Should execute before 4');
-                    done();
                 });
 
-                beforeEach((done) => {
+                beforeEach(() => {
 
                     console.log('Should execute beforeEach 4');
-                    done();
                 });
 
-                after((done) => {
+                after(() => {
 
                     console.log('Should execute after 4');
-                    done();
                 });
 
-                afterEach((done) => {
+                afterEach(() => {
 
                     console.log('Should execute afterEach 4');
-                    done();
                 });
 
-                it('returns true when 5 + 5 equals 10', (done) => {
+                it('returns true when 5 + 5 equals 10', () => {
 
 		            throw new Error("Should not execute this test");
-                    done();
                 });
             });
         });
 
         describe('another nested addition', () => {
 
-            before((done) => {
+            before(() => {
 
                 throw new Error('Should not execute sibling before');
-                done();
             });
 
-            beforeEach((done) => {
+            beforeEach(() => {
 
                 throw new Error('Should not execute sibling beforeEach');
-                done();
             });
 
-            after((done) => {
+            after(() => {
 
                 throw new Error('Should not execute sibling after');
-                done();
             });
 
-            afterEach((done) => {
+            afterEach(() => {
 
                 throw new Error('Should not execute sibling afterEach');
-                done();
             });
 
-            it.only('returns true when 6 + 6 equals 12', (done) => {
+            it.only('returns true when 6 + 6 equals 12', () => {
 
                 throw new Error("Should not execute this test");
-                done();
             });
-
         });
     });
 
     describe('subtract', () => {
 
-        before((done) => {
+        before(() => {
 
             throw new Error('Should not execute unrelated before');
-            done();
         });
 
-        beforeEach((done) => {
+        beforeEach(() => {
 
             throw new Error('Should not execute unrelated beforeEach');
-            done();
         });
 
-        after((done) => {
+        after(() => {
 
             throw new Error('Should not execute unrelated after');
-            done();
         });
 
-        afterEach((done) => {
+        afterEach(() => {
 
             throw new Error('Should not execute unrelated afterEach');
-            done();
         });
 
-        it('returns true when 1 - 1 equals 0', (done) => {
+        it('returns true when 1 - 1 equals 0', () => {
 
             throw new Error("Should not execute this test");
-            done();
         });
 
-        it('returns true when 2 - 1 equals 1', (done) => {
+        it('returns true when 2 - 1 equals 1', () => {
 
             throw new Error("Should not execute this test");
-            done();
         });
     });
 });
 
 describe('unrelated subtract', () => {
 
-    before((done) => {
+    before(() => {
 
         throw new Error('Should not execute unrelated before');
-        done();
     });
 
-    beforeEach((done) => {
+    beforeEach(() => {
 
         throw new Error('Should not execute unrelated beforeEach');
-        done();
     });
 
-    after((done) => {
+    after(() => {
 
         throw new Error('Should not execute unrelated after');
-        done();
     });
 
-    afterEach((done) => {
+    afterEach(() => {
 
         throw new Error('Should not execute unrelated afterEach');
-        done();
     });
 
-    it('returns true when 3 - 3 equals 0', (done) => {
+    it('returns true when 3 - 3 equals 0', () => {
 
         throw new Error("Should not execute this test");
-        done();
     });
 });

--- a/test/cli_only-skip/onlyRootExperiment.js
+++ b/test/cli_only-skip/onlyRootExperiment.js
@@ -22,246 +22,209 @@ const beforeEach = lab.beforeEach;
 const after = lab.after;
 const afterEach = lab.afterEach;
 
+
 describe.only('math', () => {
 
-    before((done) => {
+    before(() => {
 
         console.log('Should execute before 1');
-        done();
     });
 
-    beforeEach((done) => {
+    beforeEach(() => {
 
         console.log('Should execute beforeEach 1');
-        done();
     });
 
-    after((done) => {
+    after(() => {
 
         console.log('Should execute after 1');
-        done();
     });
 
-    afterEach((done) => {
+    afterEach(() => {
 
         console.log('Should execute afterEach 1');
-        done();
     });
 
     describe('addition', () => {
 
-        before((done) => {
+        before(() => {
 
             console.log('Should execute before 2');
-            done();
         });
 
-        beforeEach((done) => {
+        beforeEach(() => {
 
             console.log('Should execute beforeEach 2');
-            done();
         });
 
-        after((done) => {
+        after(() => {
 
             console.log('Should execute after 2');
-            done();
         });
 
-        afterEach((done) => {
+        afterEach(() => {
 
             console.log('Should execute afterEach 2');
-            done();
         });
 
-        it('returns true when 1 + 1 equals 2', (done) => {
+        it('returns true when 1 + 1 equals 2', () => {
 
             expect(1 + 1).to.equal(2);
-            done();
         });
 
-        it('returns true when 2 + 2 equals 4', (done) => {
+        it('returns true when 2 + 2 equals 4', () => {
 
             expect(2 + 2).to.equal(4);
-            done();
         });
 
         describe('nested addition', () => {
 
-            before((done) => {
+            before(() => {
 
                 console.log('Should execute before 3');
-                done();
             });
 
-            beforeEach((done) => {
+            beforeEach(() => {
 
                 console.log('Should execute beforeEach 3');
-                done();
             });
 
-            after((done) => {
+            after(() => {
 
                 console.log('Should execute after 3');
-                done();
             });
 
-            afterEach((done) => {
+            afterEach(() => {
 
                 console.log('Should execute afterEach 3');
-                done();
             });
 
-            it('returns true when 3 + 3 equals 6', (done) => {
+            it('returns true when 3 + 3 equals 6', () => {
 
                 expect(3 + 3).to.equal(6);
-                done();
             });
 
-            it('returns true when 4 + 4 equals 8', (done) => {
+            it('returns true when 4 + 4 equals 8', () => {
 
                 expect(4 + 4).to.equal(8);
-                done();
             });
 
             describe('deeply nested addtion', () => {
 
-                before((done) => {
+                before(() => {
 
                     console.log('Should execute before 4');
-                    done();
                 });
 
-                beforeEach((done) => {
+                beforeEach(() => {
 
                     console.log('Should execute beforeEach 4');
-                    done();
                 });
 
-                after((done) => {
+                after(() => {
 
                     console.log('Should execute after 4');
-                    done();
                 });
 
-                afterEach((done) => {
+                afterEach(() => {
 
                     console.log('Should execute afterEach 4');
-                    done();
                 });
 
-                it('returns true when 5 + 5 equals 10', (done) => {
+                it('returns true when 5 + 5 equals 10', () => {
 
                     expect(5 + 5).to.equal(10);
-                    done();
                 });
             });
         });
 
         describe('another nested addition', () => {
 
-            before((done) => {
+            before(() => {
 
                 console.log('Should execute before 5');
-                done();
             });
 
-            beforeEach((done) => {
+            beforeEach(() => {
 
                 console.log('Should execute beforeEach 5');
-                done();
             });
 
-            after((done) => {
+            after(() => {
 
                 console.log('Should execute after 5');
-                done();
             });
 
-            afterEach((done) => {
+            afterEach(() => {
 
                 console.log('Should execute afterEach 5');
-                done();
             });
 
-            it('returns true when 6 + 6 equals 12', (done) => {
+            it('returns true when 6 + 6 equals 12', () => {
 
                 expect(6 + 6).to.equal(12);
-                done();
             });
-
         });
     });
 
     describe('subtract', () => {
 
-        before((done) => {
+        before(() => {
 
             console.log('Should execute before 6');
-            done();
         });
 
-        beforeEach((done) => {
+        beforeEach(() => {
 
             console.log('Should execute beforeEach 6');
-            done();
         });
 
-        after((done) => {
+        after(() => {
 
             console.log('Should execute after 6');
-            done();
         });
 
-        afterEach((done) => {
+        afterEach(() => {
 
             console.log('Should execute afterEach 6');
-            done();
         });
 
-        it('returns true when 1 - 1 equals 0', (done) => {
+        it('returns true when 1 - 1 equals 0', () => {
 
             expect(1 - 1).to.equal(0);
-            done();
         });
 
-        it('returns true when 2 - 1 equals 1', (done) => {
+        it('returns true when 2 - 1 equals 1', () => {
 
             expect(2 - 1).to.equal(1);
-            done();
         });
     });
 });
 
 describe('unrelated subtract', () => {
 
-    before((done) => {
+    before(() => {
 
         throw new Error('Should not execute unrelated before');
-        done();
     });
 
-    beforeEach((done) => {
+    beforeEach(() => {
 
         throw new Error('Should not execute unrelated beforeEach');
-        done();
     });
 
-    after((done) => {
+    after(() => {
 
         throw new Error('Should not execute unrelated after');
-        done();
     });
 
-    afterEach((done) => {
+    afterEach(() => {
 
         throw new Error('Should not execute unrelated afterEach');
-        done();
     });
 
-    it('returns true when 3 - 3 equals 0', (done) => {
+    it('returns true when 3 - 3 equals 0', () => {
 
         throw new Error("Should not execute this test");
-        done();
     });
 });

--- a/test/cli_only-skip/onlyTest.js
+++ b/test/cli_only-skip/onlyTest.js
@@ -22,246 +22,212 @@ const beforeEach = lab.beforeEach;
 const after = lab.after;
 const afterEach = lab.afterEach;
 
+
 describe('math', () => {
 
-    before((done) => {
+    before(() => {
 
         console.log('Should execute before 1');
-        done();
     });
 
-    beforeEach((done) => {
+    beforeEach(() => {
 
         console.log('Should execute beforeEach 1');
-        done();
     });
 
-    after((done) => {
+    after(() => {
 
         console.log('Should execute after 1');
-        done();
     });
 
-    afterEach((done) => {
+    afterEach(() => {
 
         console.log('Should execute afterEach 1');
-        done();
     });
 
     describe('addition', () => {
 
-        before((done) => {
+        before(() => {
 
             console.log('Should execute before 2');
-            done();
         });
 
-        beforeEach((done) => {
+        beforeEach(() => {
 
             console.log('Should execute beforeEach 2');
-            done();
         });
 
-        after((done) => {
+        after(() => {
 
             console.log('Should execute after 2');
-            done();
         });
 
-        afterEach((done) => {
+        afterEach(() => {
 
             console.log('Should execute afterEach 2');
-            done();
         });
 
-        it('returns true when 1 + 1 equals 2', (done) => {
+        it('returns true when 1 + 1 equals 2', () => {
 
             throw new Error("Should not execute this test");
-            done();
         });
 
-        it('returns true when 2 + 2 equals 4', (done) => {
+        it('returns true when 2 + 2 equals 4', () => {
 
             throw new Error("Should not execute this test");
-            done();
         });
 
         describe('nested addition', () => {
 
-            before((done) => {
+            before(() => {
 
                 console.log('Should execute before 3');
-                done();
+
             });
 
-            beforeEach((done) => {
+            beforeEach(() => {
 
                 console.log('Should execute beforeEach 3');
-                done();
+
             });
 
-            after((done) => {
+            after(() => {
 
                 console.log('Should execute after 3');
-                done();
             });
 
-            afterEach((done) => {
+            afterEach(() => {
 
                 console.log('Should execute afterEach 3');
-                done();
             });
 
-            it.only('returns true when 3 + 3 equals 6', (done) => {
+            it.only('returns true when 3 + 3 equals 6', () => {
 
                 expect(3 + 3).to.equal(6);
-                done();
             });
 
-            it('returns true when 4 + 4 equals 8', (done) => {
+            it('returns true when 4 + 4 equals 8', () => {
 
                 throw new Error("Should not execute this test");
-                done();
             });
 
             describe('deeply nested addtion', () => {
 
-                before((done) => {
+                before(() => {
 
                     throw new Error('Should not execute nested before');
-                    done();
                 });
 
-                beforeEach((done) => {
+                beforeEach(() => {
 
                     throw new Error('Should not execute nested beforeEach');
-                    done();
                 });
 
-                after((done) => {
+                after(() => {
 
                     throw new Error('Should not execute nested after');
-                    done();
                 });
 
-                afterEach((done) => {
+                afterEach(() => {
 
                     throw new Error('Should not execute nested afterEach');
-                    done();
                 });
 
-                it('returns true when 5 + 5 equals 10', (done) => {
+                it('returns true when 5 + 5 equals 10', () => {
 
                     throw new Error("Should not execute this test");
-                    done();
                 });
             });
         });
 
         describe('another nested addition', () => {
 
-            before((done) => {
+            before(() => {
 
                 throw new Error('Should not execute sibling before');
-                done();
             });
 
-            beforeEach((done) => {
+            beforeEach(() => {
 
                 throw new Error('Should not execute sibling beforeEach');
-                done();
             });
 
-            after((done) => {
+            after(() => {
 
                 throw new Error('Should not execute sibling after');
-                done();
             });
 
-            afterEach((done) => {
+            afterEach(() => {
 
                 throw new Error('Should not execute sibling afterEach');
-                done();
             });
 
-            it('returns true when 6 + 6 equals 12', (done) => {
+            it('returns true when 6 + 6 equals 12', () => {
 
                 throw new Error("Should not execute this test");
-                done();
-            });
 
+            });
         });
     });
 
     describe('subtract', () => {
 
-        before((done) => {
+        before(() => {
 
             throw new Error('Should not execute unrelated before');
-            done();
         });
 
-        beforeEach((done) => {
+        beforeEach(() => {
 
             throw new Error('Should not execute unrelated beforeEach');
-            done();
         });
 
-        after((done) => {
+        after(() => {
 
             throw new Error('Should not execute unrelated after');
-            done();
         });
 
-        afterEach((done) => {
+        afterEach(() => {
 
             throw new Error('Should not execute unrelated afterEach');
-            done();
         });
 
-        it('returns true when 1 - 1 equals 0', (done) => {
+        it('returns true when 1 - 1 equals 0', () => {
 
             throw new Error("Should not execute this test");
-            done();
         });
 
-        it('returns true when 2 - 1 equals 1', (done) => {
+        it('returns true when 2 - 1 equals 1', () => {
 
             throw new Error("Should not execute this test");
-            done();
         });
     });
 });
 
 describe('unrelated subtract', () => {
 
-    before((done) => {
+    before(() => {
 
         throw new Error('Should not execute unrelated before');
-        done();
     });
 
-    beforeEach((done) => {
+    beforeEach(() => {
 
         throw new Error('Should not execute unrelated beforeEach');
-        done();
     });
 
-    after((done) => {
+    after(() => {
 
         throw new Error('Should not execute unrelated after');
-        done();
     });
 
-    afterEach((done) => {
+    afterEach(() => {
 
         throw new Error('Should not execute unrelated afterEach');
-        done();
     });
 
-    it('returns true when 3 - 3 equals 0', (done) => {
+    it('returns true when 3 - 3 equals 0', () => {
 
         throw new Error("Should not execute this test");
-        done();
     });
 });

--- a/test/cli_only-skip/skip.js
+++ b/test/cli_only-skip/skip.js
@@ -24,244 +24,206 @@ const afterEach = lab.afterEach;
 
 describe('math', () => {
 
-    before((done) => {
+    before(() => {
 
         console.log('Should execute before 1');
-        done();
     });
 
-    beforeEach((done) => {
+    beforeEach(() => {
 
         console.log('Should execute beforeEach 1');
-        done();
     });
 
-    after((done) => {
+    after(() => {
 
         console.log('Should execute after 1');
-        done();
     });
 
-    afterEach((done) => {
+    afterEach(() => {
 
         console.log('Should execute afterEach 1');
-        done();
     });
 
     describe('addition', () => {
 
-        before((done) => {
+        before(() => {
 
             console.log('Should execute before 2');
-            done();
         });
 
-        beforeEach((done) => {
+        beforeEach(() => {
 
             console.log('Should execute beforeEach 2');
-            done();
         });
 
-        after((done) => {
+        after(() => {
 
             console.log('Should execute after 2');
-            done();
         });
 
-        afterEach((done) => {
+        afterEach(() => {
 
             console.log('Should execute afterEach 2');
-            done();
         });
 
-        it('returns true when 1 + 1 equals 2', (done) => {
+        it('returns true when 1 + 1 equals 2', () => {
 
             expect(1 + 1).to.equal(2);
-            done();
         });
 
-        it.skip('returns true when 2 + 2 equals 4', (done) => {
+        it.skip('returns true when 2 + 2 equals 4', () => {
 
             throw new Error("Should not execute this test");
-            done();
         });
 
         describe('nested addition', () => {
 
-            before((done) => {
+            before(() => {
 
                 console.log('Should execute before 3');
-                done();
             });
 
-            beforeEach((done) => {
+            beforeEach(() => {
 
                 console.log('Should execute beforeEach 3');
-                done();
             });
 
-            after((done) => {
+            after(() => {
 
                 console.log('Should execute after 3');
-                done();
             });
 
-            afterEach((done) => {
+            afterEach(() => {
 
                 console.log('Should execute afterEach 3');
-                done();
             });
 
-            it('returns true when 3 + 3 equals 6', (done) => {
+            it('returns true when 3 + 3 equals 6', () => {
 
                 expect(3 + 3).to.equal(6);
-                done();
             });
 
-            it('returns true when 4 + 4 equals 8', (done) => {
+            it('returns true when 4 + 4 equals 8', () => {
 
                 expect(4 + 4).to.equal(8);
-                done();
             });
 
             describe('deeply nested addtion', () => {
 
-                before((done) => {
+                before(() => {
 
                     console.log('Should execute before 4');
-                    done();
                 });
 
-                beforeEach((done) => {
+                beforeEach(() => {
 
                     console.log('Should execute beforeEach 4');
-                    done();
                 });
 
-                after((done) => {
+                after(() => {
 
                     console.log('Should execute after 4');
-                    done();
                 });
 
-                afterEach((done) => {
+                afterEach(() => {
 
                     console.log('Should execute afterEach 4');
-                    done();
                 });
 
-                it('returns true when 5 + 5 equals 10', (done) => {
+                it('returns true when 5 + 5 equals 10', () => {
 
                     expect(5 + 5).to.equal(10);
-                    done();
                 });
             });
         });
 
         describe.skip('another nested addition', () => {
 
-            before((done) => {
+            before(() => {
 
                 throw new Error('Should not execute sibling before');
-                done();
             });
 
-            beforeEach((done) => {
+            beforeEach(() => {
 
                 throw new Error('Should not execute sibling beforeEach');
-                done();
             });
 
-            after((done) => {
+            after(() => {
 
                 throw new Error('Should not execute sibling after');
-                done();
             });
 
-            afterEach((done) => {
+            afterEach(() => {
 
                 throw new Error('Should not execute sibling afterEach');
-                done();
             });
 
-            it('returns true when 6 + 6 equals 12', (done) => {
+            it('returns true when 6 + 6 equals 12', () => {
 
 	            throw new Error("Should not execute this test");
-                done();
             });
-
         });
     });
 
     describe.skip('subtract', () => {
 
-        before((done) => {
+        before(() => {
 
             throw new Error('Should not execute unrelated before');
-            done();
         });
 
-        beforeEach((done) => {
+        beforeEach(() => {
 
             throw new Error('Should not execute unrelated beforeEach');
-            done();
         });
 
-        after((done) => {
+        after(() => {
 
             throw new Error('Should not execute unrelated after');
-            done();
         });
 
-        afterEach((done) => {
+        afterEach(() => {
 
             throw new Error('Should not execute unrelated afterEach');
-            done();
         });
 
-        it('returns true when 1 - 1 equals 0', (done) => {
+        it('returns true when 1 - 1 equals 0', () => {
 
             throw new Error("Should not execute this test");
-            done();
         });
 
-        it('returns true when 2 - 1 equals 1', (done) => {
+        it('returns true when 2 - 1 equals 1', () => {
 
             throw new Error("Should not execute this test");
-            done();
         });
     });
 });
 
 describe('unrelated subtract', () => {
 
-    before((done) => {
+    before(() => {
 
         console.log('Should execute before 5');
-        done();
     });
 
-    beforeEach((done) => {
+    beforeEach(() => {
 
         console.log('Should execute beforeEach 5');
-        done();
     });
 
-    after((done) => {
+    after(() => {
 
         console.log('Should execute after 5');
-        done();
     });
 
-    afterEach((done) => {
+    afterEach(() => {
 
         console.log('Should execute afterEach 5');
-        done();
     });
 
-    it('returns true when 3 - 3 equals 0', (done) => {
+    it('returns true when 3 - 3 equals 0', () => {
 
         expect(3 - 3).to.equal(0);
-        done();
     });
 });

--- a/test/cli_pattern/file-test-something.js
+++ b/test/cli_pattern/file-test-something.js
@@ -20,9 +20,8 @@ const expect = _Lab.assertions.expect;
 
 describe('Test CLI', () => {
 
-    it('adds two numbers together', (done) => {
+    it('adds two numbers together', () => {
 
         expect(1 + 1).to.equal(2);
-        done();
     });
 });

--- a/test/cli_pattern/file-test.js
+++ b/test/cli_pattern/file-test.js
@@ -20,9 +20,8 @@ const expect = _Lab.assertions.expect;
 
 describe('Test CLI', () => {
 
-    it('adds two numbers together', (done) => {
+    it('adds two numbers together', () => {
 
         expect(1 + 1).to.equal(2);
-        done();
     });
 });

--- a/test/cli_pattern/file.js
+++ b/test/cli_pattern/file.js
@@ -20,9 +20,8 @@ const expect = _Lab.assertions.expect;
 
 describe('Test CLI', () => {
 
-    it('adds two numbers together', (done) => {
+    it('adds two numbers together', () => {
 
         expect(1 + 1).to.equal(2);
-        done();
     });
 });

--- a/test/cli_plan/simple.js
+++ b/test/cli_plan/simple.js
@@ -21,25 +21,20 @@ const expect = Code.expect;
 
 describe('Test Plan', () => {
 
-    it('adds two numbers together', { plan: 1 }, (done) => {
+    it('adds two numbers together', { plan: 1 }, () => {
 
         expect(1 + 1).to.equal(2);
-        done();
     });
 
-    it('subtracts two numbers', { plan: 2 }, (done) => {
+    it('subtracts two numbers', { plan: 2 }, () => {
 
         expect(2 - 2).to.equal(0);
         expect(4 - 4).to.equal(0);
-        done();
     });
 
-    it('multiplies numbers', { plan: 1 }, (done) => {
+    it('multiplies numbers', { plan: 1 }, () => {
 
         expect(2 * 2).to.equal(4);
-        if (done) {
-          expect(4 * 4).to.equal(16);
-        }
-        done();
+        expect(4 * 4).to.equal(16);
     });
 });

--- a/test/cli_reject_promise/reject_promise.js
+++ b/test/cli_reject_promise/reject_promise.js
@@ -21,8 +21,7 @@ const expect = Code.expect;
 
 describe('Test Promises', () => {
 
-    it('handles a Promise rejection', ( done ) => {
-        Promise.reject(new Error('Rejection!'));
-        done();
+    it('handles a Promise rejection', () => {
+        return Promise.reject(new Error('Rejection!'));
     });
 });

--- a/test/cli_throws/debug.js
+++ b/test/cli_throws/debug.js
@@ -20,19 +20,18 @@ const it = lab.it;
 
 describe('Test CLI domain error debug', () => {
 
-    after((done) => {
+    after(() => {
 
-        done();
     });
 
-    it('throws badly', (done) => {
+    it('throws badly', () => {
 
         setTimeout(() => {
 
             throw new Error('throwing later');
         }, 0);
 
-        done();
+        return Promise.resolve();
     });
 });
 

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -26,47 +26,43 @@ describe('Coverage', () => {
 
     Lab.coverage.instrument({ coveragePath: Path.join(__dirname, 'coverage'), coverageExclude: 'exclude' });
 
-    it('computes sloc without comments', (done) => {
+    it('computes sloc without comments', () => {
 
         const Test = require('./coverage/sloc');
         Test.method(1);
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/sloc') });
         expect(cov.percent).to.equal(100);
-        done();
     });
 
-    it('computes sloc on script that has no comments', (done) => {
+    it('computes sloc on script that has no comments', () => {
 
         const Test = require('./coverage/nocomment');
         Test.method(1);
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/nocomment') });
         expect(cov.percent).to.equal(100);
-        done();
     });
 
-    it('instruments and measures coverage', (done) => {
+    it('instruments and measures coverage', () => {
 
         const Test = require('./coverage/basic');
         Test.method(1);
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/basic') });
         expect(cov.percent).to.equal(100);
-        done();
     });
 
-    it('measures coverage on an empty return statement', (done) => {
+    it('measures coverage on an empty return statement', () => {
 
         const Test = require('./coverage/return');
         Test.method();
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/return') });
         expect(cov.percent).to.equal(100);
-        done();
     });
 
-    it('identifies lines with partial coverage', (done) => {
+    it('identifies lines with partial coverage', () => {
 
         const Test = require('./coverage/partial');
         Test.method(1, 2, 3);
@@ -76,20 +72,18 @@ describe('Coverage', () => {
         expect(cov.sloc).to.equal(49);
         expect(cov.misses).to.equal(19);
         expect(cov.hits).to.equal(30);
-        done();
     });
 
-    it('measures coverage a file with test in the name', (done) => {
+    it('measures coverage a file with test in the name', () => {
 
         const Test = require('./coverage/test-folder/test-name.js');
         Test.method();
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/test-folder'), coverageExclude: ['test', 'node_modules'] });
         expect(cov.percent).to.equal(100);
-        done();
     });
 
-    it('identifies lines with partial coverage when having external sourcemap', (done) => {
+    it('identifies lines with partial coverage when having external sourcemap', () => {
 
         const Test = require('./coverage/sourcemaps-external');
         Test.method(false);
@@ -114,11 +108,9 @@ describe('Coverage', () => {
             { filename: 'while.js', lineNumber: '4', originalLineNumber: 13 },
             { filename: 'while.js', lineNumber: '5', originalLineNumber: 14 }
         ]);
-
-        done();
     });
 
-    it('identifies lines with partial coverage when having inline sourcemap', (done) => {
+    it('identifies lines with partial coverage when having inline sourcemap', () => {
 
         const Test = require('./coverage/sourcemaps-inline');
         Test.method(false);
@@ -159,11 +151,9 @@ describe('Coverage', () => {
         expect(missedChunks).to.include([
             { filename: 'while.js', lineNumber: '3', originalLineNumber: 13, originalColumn: 12  }
         ]);
-
-        done();
     });
 
-    it('bypasses marked code', (done) => {
+    it('bypasses marked code', () => {
 
         const Test = require('./coverage/bypass');
         Test.method(1, 2, 3);
@@ -173,10 +163,9 @@ describe('Coverage', () => {
         expect(cov.sloc).to.equal(12);
         expect(cov.misses).to.equal(0);
         expect(cov.hits).to.equal(12);
-        done();
     });
 
-    it('bypasses marked code and reports misses correctly', (done) => {
+    it('bypasses marked code and reports misses correctly', () => {
 
         const Test = require('./coverage/bypass-misses');
         Test.method(1);
@@ -186,30 +175,27 @@ describe('Coverage', () => {
         expect(cov.sloc).to.equal(13);
         expect(cov.misses).to.equal(1);
         expect(cov.hits).to.equal(12);
-        done();
     });
 
-    it('ignores non-matching files', (done) => {
+    it('ignores non-matching files', () => {
 
         require('./coverage/exclude/ignore');
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/exclude/ignore') });
         expect(Math.floor(cov.percent)).to.equal(0);
         expect(cov.files).to.have.length(0);
-        done();
     });
 
-    it('measures missing while statement coverage', (done) => {
+    it('measures missing while statement coverage', () => {
 
         const Test = require('./coverage/while');
         Test.method(false);
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/while') });
         expect(cov.percent).to.be.lessThan(100);
-        done();
     });
 
-    it('measures when errors are thrown', (done) => {
+    it('measures when errors are thrown', () => {
 
         const Test = require('./coverage/throws');
 
@@ -223,26 +209,23 @@ describe('Coverage', () => {
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/throws') });
         expect(cov.percent).to.equal(100);
-        done();
     });
 
-    it('retains original value of conditional result', (done) => {
+    it('retains original value of conditional result', () => {
 
         const Test = require('./coverage/conditional');
         const value = { a: 1 };
         expect(Test.method(value)).to.equal(value);
-        done();
     });
 
-    it('retains original value of conditional result with comma operator', (done) => {
+    it('retains original value of conditional result with comma operator', () => {
 
         const Test = require('./coverage/conditional2');
         const value = 4711;
         expect(Test.method(value)).to.equal(value);
-        done();
     });
 
-    it('should not change use strict instructions', (done) => {
+    it('should not change use strict instructions', () => {
 
         const Test = require('./coverage/use-strict.js');
         expect(Test.method.toString()).to.not.contain('13'); // This is the line of the inner use strict
@@ -251,11 +234,9 @@ describe('Coverage', () => {
         expect(Test.singleLine.toString()).to.contain('"use strict"; global.__$$labCov._line(\'' + testFile + '\',19);return value;');
 
         expect(Test.shouldFail).to.throw('unknownvar is not defined');
-
-        done();
     });
 
-    it('should work with loop labels', (done) => {
+    it('should work with loop labels', () => {
 
         const Test = require('./coverage/loop-labels.js');
         expect(Test.method()).to.equal([1, 0]);
@@ -275,11 +256,9 @@ describe('Coverage', () => {
         });
 
         expect(missedChunks).to.have.length(1).and.to.equal([{ source: 'j < 1', miss: 'true', column: 22 }]);
-
-        done();
     });
 
-    it('should measure missing coverage on single-line functions correctly', (done) => {
+    it('should measure missing coverage on single-line functions correctly', () => {
 
         const Test = require('./coverage/single-line-functions');
         const results = [];
@@ -296,10 +275,9 @@ describe('Coverage', () => {
         const missedLines = Object.keys(source).filter((lineNumber) => source[lineNumber].miss);
         expect(results).to.equal([7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 5, 10, 5]);
         expect(missedLines).to.equal(['12', '15', '21', '27', '30', '33', '39', '46', '50', '53', '56']);
-        done();
     });
 
-    it('should measure missing coverage on trailing function declarations correctly', (done) => {
+    it('should measure missing coverage on trailing function declarations correctly', () => {
 
         const Test = require('./coverage/trailing-function-declarations');
         const result = Test.method(3, 4);
@@ -309,10 +287,9 @@ describe('Coverage', () => {
         const missedLines = Object.keys(source).filter((lineNumber) => source[lineNumber].miss);
         expect(result).to.equal(7);
         expect(missedLines).to.equal(['19', '22']);
-        done();
     });
 
-    it('should measure coverage on conditional value', (done) => {
+    it('should measure coverage on conditional value', () => {
 
         const Test = require('./coverage/conditional-value');
         expect(Test.method(false)).to.equal(false);
@@ -324,12 +301,11 @@ describe('Coverage', () => {
         const source = cov.files[0].source;
         const missedLines = Object.keys(source).filter((lineNumber) => source[lineNumber].miss);
         expect(missedLines).to.be.empty();
-        done();
     });
 
     describe('#analyze', () => {
 
-        it('sorts file paths in report', (done) => {
+        it('sorts file paths in report', () => {
 
             const files = global.__$$labCov.files;
             const paths = ['/a/b', '/a/b/c', '/a/c/b', '/a/c', '/a/b/c', '/a/b/a'];
@@ -345,13 +321,12 @@ describe('Coverage', () => {
             });
 
             expect(sorted).to.equal(['/a/b', '/a/c', '/a/b/a', '/a/b/c', '/a/c/b']);
-            done();
         });
     });
 
     describe('Clear require cache', () => {
 
-        it('does not reset file coverage', (done) => {
+        it('does not reset file coverage', () => {
 
             const cacheBackup = require.cache; // backup require cache
             const filename = Path.resolve(__dirname, './coverage/basic.js');
@@ -363,7 +338,6 @@ describe('Coverage', () => {
 
             const fileCovAfter = global.__$$labCov.files[filename];
             expect(fileCovAfter).to.equal(fileCovBefore);
-            done();
         });
     });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -22,778 +22,568 @@ const expect = Code.expect;
 
 describe('Lab', () => {
 
-    it('creates a script and executes', (done) => {
+    it('creates a script and executes', async () => {
 
         let a = 0;
         const script = Lab.script({ schedule: false });
         script.experiment('test', () => {
 
-            script.before((testDone) => {
+            script.before(() => {
 
                 ++a;
-                testDone();
             });
 
-            script.test('value of a', (testDone) => {
+            script.test('value of a', () => {
 
                 expect(a).to.equal(1);
-                testDone();
             });
 
-            script.after((testDone) => {
+            script.after(() => {
 
                 ++a;
-                testDone();
             });
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(a).to.equal(2);
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.tests[0].id).to.equal(1);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(a).to.equal(2);
+        expect(notebook.tests).to.have.length(1);
+        expect(notebook.tests[0].id).to.equal(1);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('creates a script and executes (BDD)', (done) => {
+    it('creates a script and executes (BDD)', async () => {
 
         let a = 0;
         const script = Lab.script({ schedule: false });
         script.describe('test', () => {
 
-            script.before((testDone) => {
+            script.before(() => {
 
                 ++a;
-                testDone();
             });
 
-            script.it('value of a', (testDone) => {
+            script.it('value of a', () => {
 
                 expect(a).to.equal(1);
-                testDone();
             });
 
-            script.after((testDone) => {
+            script.after(() => {
 
                 ++a;
-                testDone();
             });
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(a).to.equal(2);
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(a).to.equal(2);
+        expect(notebook.tests).to.have.length(1);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('creates a script and executes (TDD)', (done) => {
+    it('creates a script and executes (TDD)', async () => {
 
         let a = 0;
         const script = Lab.script({ schedule: false });
         script.suite('test', () => {
 
-            script.before((testDone) => {
+            script.before(() => {
 
                 ++a;
-                testDone();
             });
 
-            script.test('value of a', (testDone) => {
+            script.test('value of a', () => {
 
                 expect(a).to.equal(1);
-                testDone();
             });
 
-            script.after((testDone) => {
+            script.after(() => {
 
                 ++a;
-                testDone();
             });
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(a).to.equal(2);
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(a).to.equal(2);
+        expect(notebook.tests).to.have.length(1);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('executes beforeEach and afterEach', (done) => {
+    it('executes beforeEach and afterEach', async () => {
 
         let a = 0;
         let b = 0;
         const script = Lab.script({ schedule: false });
         script.experiment('test', () => {
 
-            script.before((testDone) => {
+            script.before(() => {
 
                 ++a;
-                testDone();
             });
 
-            script.beforeEach((testDone) => {
+            script.beforeEach(() => {
 
                 ++b;
-                testDone();
             });
 
-            script.test('value of a', (testDone) => {
+            script.test('value of a', () => {
 
                 expect(a).to.equal(1);
                 expect(b).to.equal(1);
-                testDone();
             });
 
-            script.test('value of b', (testDone) => {
+            script.test('value of b', () => {
 
                 expect(a).to.equal(1);
                 expect(b).to.equal(3);
-                testDone();
             });
 
-            script.after((testDone) => {
+            script.after(() => {
 
                 ++a;
-                testDone();
             });
 
-            script.afterEach((testDone) => {
+            script.afterEach(() => {
 
                 ++b;
-                testDone();
             });
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(a).to.equal(2);
-            expect(b).to.equal(4);
-            expect(notebook.tests).to.have.length(2);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(a).to.equal(2);
+        expect(b).to.equal(4);
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('executes multiple pre/post processors', (done) => {
+    it('executes multiple pre/post processors', async () => {
 
         let a = 0;
         let b = 0;
         const script = Lab.script({ schedule: false });
         script.experiment('test', () => {
 
-            script.before((testDone) => {
+            script.before(() => {
 
                 ++a;
-                testDone();
             });
 
-            script.before((testDone) => {
+            script.before(() => {
 
                 ++a;
-                testDone();
             });
 
-            script.beforeEach((testDone) => {
+            script.beforeEach(() => {
 
                 ++b;
-                testDone();
             });
 
-            script.beforeEach((testDone) => {
+            script.beforeEach(() => {
 
                 ++b;
-                testDone();
             });
 
-            script.test('value of a', (testDone) => {
+            script.test('value of a', () => {
 
                 expect(a).to.equal(2);
                 expect(b).to.equal(2);
-                testDone();
             });
 
-            script.test('value of b', (testDone) => {
+            script.test('value of b', () => {
 
                 expect(a).to.equal(2);
                 expect(b).to.equal(6);
-                testDone();
             });
 
-            script.after((testDone) => {
+            script.after(() => {
 
                 ++a;
-                testDone();
             });
 
-            script.after((testDone) => {
+            script.after(() => {
 
                 ++a;
-                testDone();
             });
 
-            script.afterEach((testDone) => {
+            script.afterEach(() => {
 
                 ++b;
-                testDone();
             });
 
-            script.afterEach((testDone) => {
+            script.afterEach(() => {
 
                 ++b;
-                testDone();
             });
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(a).to.equal(4);
-            expect(b).to.equal(8);
-            expect(notebook.tests).to.have.length(2);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(a).to.equal(4);
+        expect(b).to.equal(8);
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('reports errors', (done) => {
+    it('reports errors', async () => {
 
         const script = Lab.script({ schedule: false });
         script.experiment('test', () => {
 
-            script.test('works', (testDone) => {
+            script.test('works', () => {
 
                 expect(0).to.equal(1);
-                testDone();
             });
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.failures).to.equal(1);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(notebook.tests).to.have.length(1);
+        expect(notebook.failures).to.equal(1);
     });
 
-    it('multiple experiments', (done) => {
+    it('multiple experiments', async () => {
 
         const script = Lab.script({ schedule: false });
         script.experiment('test1', () => {
 
-            script.test('works', (testDone) => {
-
-                testDone();
-            });
+            script.test('works', () => {});
         });
 
         script.experiment('test2', () => {
 
-            script.test('works', (testDone) => {
-
-                testDone();
-            });
+            script.test('works', () => {});
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(notebook.tests).to.have.length(2);
-            expect(notebook.tests[0].id).to.equal(1);
-            expect(notebook.tests[1].id).to.equal(2);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.tests[0].id).to.equal(1);
+        expect(notebook.tests[1].id).to.equal(2);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('nested experiments', (done) => {
+    it('nested experiments', async (done) => {
 
         const script = Lab.script({ schedule: false });
         script.experiment('test1', () => {
 
-            script.test('a', (testDone) => {
-
-                testDone();
-            });
+            script.test('a', () => {});
 
             script.experiment('test2', () => {
 
-                script.test('b', (testDone) => {
-
-                    testDone();
-                });
+                script.test('b', () => {});
             });
 
-            script.test('c', (testDone) => {
-
-                testDone();
-            });
+            script.test('c', () => {});
 
             script.experiment('test3', () => {
 
-                script.test('d', (testDone) => {
-
-                    testDone();
-                });
+                script.test('d', () => {});
             });
 
-            script.test('e', (testDone) => {
-
-                testDone();
-            });
+            script.test('e', () => {});
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(notebook.tests).to.have.length(5);
-            expect(notebook.tests[0].id).to.equal(1);
-            expect(notebook.tests[1].id).to.equal(2);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(notebook.tests).to.have.length(5);
+        expect(notebook.tests[0].id).to.equal(1);
+        expect(notebook.tests[1].id).to.equal(2);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('skips experiment', (done) => {
+    it('skips experiment', async () => {
 
         const script = Lab.script({ schedule: false });
         script.experiment('test1', () => {
 
-            script.test('works', (testDone) => {
-
-                testDone();
-            });
+            script.test('works', () => {});
         });
 
         script.experiment('test2', { skip: true }, () => {
 
-            script.test('works', (testDone) => {
-
-                testDone();
-            });
+            script.test('works', () => {});
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(notebook.tests).to.have.length(2);
-            expect(notebook.tests[0].skipped).to.not.exist();
-            expect(notebook.tests[1].skipped).to.equal(true);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.tests[0].skipped).to.not.exist();
+        expect(notebook.tests[1].skipped).to.equal(true);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('skips experiment using helper (2 args)', (done) => {
+    it('skips experiment using helper (2 args)', async () => {
 
         const script = Lab.script({ schedule: false });
         script.experiment('test1', () => {
 
-            script.test('works', (testDone) => {
-
-                testDone();
-            });
+            script.test('works', () => {});
         });
 
         script.experiment.skip('test2', () => {
 
-            script.test('works', (testDone) => {
-
-                testDone();
-            });
+            script.test('works', () => {});
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(notebook.tests).to.have.length(2);
-            expect(notebook.tests[0].skipped).to.not.exist();
-            expect(notebook.tests[1].skipped).to.equal(true);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.tests[0].skipped).to.not.exist();
+        expect(notebook.tests[1].skipped).to.equal(true);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('skips experiment using helper (3 args)', (done) => {
+    it('skips experiment using helper (3 args)', async () => {
 
         const script = Lab.script({ schedule: false });
         script.experiment('test1', () => {
 
-            script.test('works', (testDone) => {
-
-                testDone();
-            });
+            script.test('works', () => {});
         });
 
         script.experiment.skip('test2', {}, () => {
 
-            script.test('works', (testDone) => {
-
-                testDone();
-            });
+            script.test('works', () => {});
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(notebook.tests).to.have.length(2);
-            expect(notebook.tests[0].skipped).to.not.exist();
-            expect(notebook.tests[1].skipped).to.equal(true);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.tests[0].skipped).to.not.exist();
+        expect(notebook.tests[1].skipped).to.equal(true);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('runs only one experiment (only first)', (done) => {
+    it('runs only one experiment (only first)', async () => {
 
         const script = Lab.script({ schedule: false });
         script.experiment('test1', { only: true }, () => {
 
-            script.test('works', (testDone) => {
-
-                testDone();
-            });
+            script.test('works', () => {});
         });
 
         script.experiment('test2', () => {
 
-            script.test('works', (testDone) => {
-
-                testDone();
-            });
+            script.test('works', () => {});
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(notebook.tests).to.have.length(2);
-            expect(notebook.tests[0].skipped).to.not.exist();
-            expect(notebook.tests[1].skipped).to.equal(true);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.tests[0].skipped).to.not.exist();
+        expect(notebook.tests[1].skipped).to.equal(true);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('runs only one experiment (only not first)', (done) => {
+    it('runs only one experiment (only not first)', async () => {
 
         const script = Lab.script({ schedule: false });
         script.experiment('test1', () => {
 
-            script.test('works', (testDone) => {
-
-                testDone();
-            });
+            script.test('works', () => {});
         });
 
         script.experiment('test2', { only: true }, () => {
 
-            script.test('works', (testDone) => {
-
-                testDone();
-            });
+            script.test('works', () => {});
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(notebook.tests).to.have.length(2);
-            expect(notebook.tests[0].skipped).to.equal(true);
-            expect(notebook.tests[1].skipped).to.not.exist();
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.tests[0].skipped).to.equal(true);
+        expect(notebook.tests[1].skipped).to.not.exist();
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('runs only one experiment using helper (2 args)', (done) => {
+    it('runs only one experiment using helper (2 args)', async () => {
 
         const script = Lab.script({ schedule: false });
         script.experiment('test1', () => {
 
-            script.test('works', (testDone) => {
-
-                testDone();
-            });
+            script.test('works', () => {});
         });
 
         script.experiment.only('test2', () => {
 
-            script.test('works', (testDone) => {
-
-                testDone();
-            });
+            script.test('works', () => {});
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(notebook.tests).to.have.length(2);
-            expect(notebook.tests[0].skipped).to.equal(true);
-            expect(notebook.tests[1].skipped).to.not.exist();
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.tests[0].skipped).to.equal(true);
+        expect(notebook.tests[1].skipped).to.not.exist();
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('runs only one experiment using helper (3 args)', (done) => {
+    it('runs only one experiment using helper (3 args)', async () => {
 
         const script = Lab.script({ schedule: false });
         script.experiment('test1', () => {
 
-            script.test('works', (testDone) => {
-
-                testDone();
-            });
+            script.test('works', () => {});
         });
 
         script.experiment.only('test2', {}, () => {
 
-            script.test('works', (testDone) => {
-
-                testDone();
-            });
+            script.test('works', () => {});
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(notebook.tests).to.have.length(2);
-            expect(notebook.tests[0].skipped).to.equal(true);
-            expect(notebook.tests[1].skipped).to.not.exist();
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.tests[0].skipped).to.equal(true);
+        expect(notebook.tests[1].skipped).to.not.exist();
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('skips test', (done) => {
+    it('skips test', async () => {
 
         const script = Lab.script({ schedule: false });
         script.experiment('test1', () => {
 
-            script.test('works', (testDone) => {
-
-                testDone();
-            });
+            script.test('works', () => {});
         });
 
         script.experiment('test2', () => {
 
-            script.test('works', { skip: true }, (testDone) => {
-
-                testDone();
-            });
+            script.test('works', { skip: true }, () => {});
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(notebook.tests).to.have.length(2);
-            expect(notebook.tests[0].skipped).to.not.exist();
-            expect(notebook.tests[1].skipped).to.equal(true);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.tests[0].skipped).to.not.exist();
+        expect(notebook.tests[1].skipped).to.equal(true);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('skips test using helper (2 args)', (done) => {
+    it('skips test using helper (2 args)', async () => {
 
         const script = Lab.script({ schedule: false });
         script.experiment('test1', () => {
 
-            script.test('works', (testDone) => {
-
-                testDone();
-            });
+            script.test('works', () => {});
         });
 
         script.experiment('test2', () => {
 
-            script.test.skip('works', (testDone) => {
-
-                testDone();
-            });
+            script.test.skip('works', () => {});
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(notebook.tests).to.have.length(2);
-            expect(notebook.tests[0].skipped).to.not.exist();
-            expect(notebook.tests[1].skipped).to.equal(true);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.tests[0].skipped).to.not.exist();
+        expect(notebook.tests[1].skipped).to.equal(true);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('skips test using helper (3 args)', (done) => {
+    it('skips test using helper (3 args)', async () => {
 
         const script = Lab.script({ schedule: false });
         script.experiment('test1', () => {
 
-            script.test('works', (testDone) => {
-
-                testDone();
-            });
+            script.test('works', () => {});
         });
 
         script.experiment('test2', () => {
 
-            script.test.skip('works', {}, (testDone) => {
-
-                testDone();
-            });
+            script.test.skip('works', {}, () => {});
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(notebook.tests).to.have.length(2);
-            expect(notebook.tests[0].skipped).to.not.exist();
-            expect(notebook.tests[1].skipped).to.equal(true);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.tests[0].skipped).to.not.exist();
+        expect(notebook.tests[1].skipped).to.equal(true);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('runs only one test (only first)', (done) => {
+    it('runs only one test (only first)', async () => {
 
         const script = Lab.script({ schedule: false });
         script.experiment('test1', () => {
 
-            script.test('a', { only: true }, (testDone) => {
+            script.test('a', { only: true }, () => {});
 
-                testDone();
-            });
-
-            script.test('b', (testDone) => {
-
-                testDone();
-            });
+            script.test('b', () => {});
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(notebook.tests).to.have.length(2);
-            expect(notebook.tests[0].skipped).to.not.exist();
-            expect(notebook.tests[1].skipped).to.equal(true);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.tests[0].skipped).to.not.exist();
+        expect(notebook.tests[1].skipped).to.equal(true);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('runs only one test (only not first)', (done) => {
+    it('runs only one test (only not first)', async () => {
 
         const script = Lab.script({ schedule: false });
         script.experiment('test1', () => {
 
-            script.test('a', (testDone) => {
+            script.test('a', () => {});
 
-                testDone();
-            });
-
-            script.test('b', { only: true }, (testDone) => {
-
-                testDone();
-            });
+            script.test('b', { only: true }, () => {});
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(notebook.tests).to.have.length(2);
-            expect(notebook.tests[0].skipped).to.equal(true);
-            expect(notebook.tests[1].skipped).to.not.exist();
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.tests[0].skipped).to.equal(true);
+        expect(notebook.tests[1].skipped).to.not.exist();
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('runs only one test using helper (2 args)', (done) => {
+    it('runs only one test using helper (2 args)', async () => {
 
         const script = Lab.script({ schedule: false });
         script.experiment('test1', () => {
 
-            script.test('a', (testDone) => {
+            script.test('a', () => {});
 
-                testDone();
-            });
-
-            script.test.only('b', (testDone) => {
-
-                testDone();
-            });
+            script.test.only('b', () => {});
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(notebook.tests).to.have.length(2);
-            expect(notebook.tests[0].skipped).to.equal(true);
-            expect(notebook.tests[1].skipped).to.not.exist();
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.tests[0].skipped).to.equal(true);
+        expect(notebook.tests[1].skipped).to.not.exist();
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('runs only one test using helper (3 args)', (done) => {
+    it('runs only one test using helper (3 args)', async () => {
 
         const script = Lab.script({ schedule: false });
         script.experiment('test1', () => {
 
-            script.test('a', (testDone) => {
+            script.test('a', () => {});
 
-                testDone();
-            });
-
-            script.test.only('b', {}, (testDone) => {
-
-                testDone();
-            });
+            script.test.only('b', {}, () => {});
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(notebook.tests).to.have.length(2);
-            expect(notebook.tests[0].skipped).to.equal(true);
-            expect(notebook.tests[1].skipped).to.not.exist();
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.tests[0].skipped).to.equal(true);
+        expect(notebook.tests[1].skipped).to.not.exist();
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('schedules automatic execution', { parallel: false }, (done) => {
+    it('schedules automatic execution of scripts', async () => {
 
+        let executed = 0;
         const script = Lab.script({ output: false });
         script.experiment('test', () => {
 
-            script.test('works', (testDone) => {
+            script.test('works', () => {
 
-                testDone();
+                return new Promise((resolve) => {
+
+                    process.nextTick(() => {
+
+                        ++executed;
+                        resolve();
+                    });
+                });
             });
         });
 
-        const orig = process.exit;
-        process.exit = function (code) {
+        return new Promise((resolve) => {
 
-            process.exit = orig;
-            expect(code).to.equal(0);
-            done();
-        };
+            setTimeout(() => {
+
+                expect(executed).to.equal(1);
+                resolve();
+            }, 50);
+        });
     });
 
-    it('should not throw on tests without a function', (done) => {
+    it('should not throw on tests without a function', () => {
 
         const script = Lab.script({ schedule: false });
 
@@ -801,10 +591,9 @@ describe('Lab', () => {
 
             script.test('a');
         }).not.to.throw();
-        done();
     });
 
-    it('should not throw on tests with a function without arguments', (done) => {
+    it('should not throw on tests with a function without arguments', () => {
 
         const script = Lab.script({ schedule: false });
 
@@ -812,12 +601,11 @@ describe('Lab', () => {
 
             script.test('a', () => {});
         }).not.to.throw();
-        done();
     });
 
     ['before', 'beforeEach', 'after', 'afterEach'].forEach((fnName) => {
 
-        it(`should throw on "${fnName}" without a function`, (done) => {
+        it(`should throw on "${fnName}" without a function`, () => {
 
             const script = Lab.script({ schedule: false });
 
@@ -825,10 +613,9 @@ describe('Lab', () => {
 
                 script[fnName]();
             }).to.throw(`${fnName} in "script" requires a function argument`);
-            done();
         });
 
-        it(`should not throw on "${fnName}" with a function without arguments`, (done) => {
+        it(`should not throw on "${fnName}" with a function without arguments`, () => {
 
             const script = Lab.script({ schedule: false });
 
@@ -836,43 +623,36 @@ describe('Lab', () => {
 
                 script[fnName](() => {});
             }).not.to.throw();
-            done();
         });
     });
 
-    it('code is the default assertion library', (done) => {
+    it('code is the default assertion library', async () => {
 
         const script = Lab.script({ schedule: false });
 
         script.experiment('experiment', () => {
 
-            script.test('test', { plan: 1 }, (testDone) => {
+            script.test('test', { plan: 1 }, () => {
 
-                Lab.expect(testDone).to.exist();
-                testDone();
+                Lab.expect(1 + 1).to.equal(2);
             });
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.tests[0].assertions).to.equal(1);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(notebook.tests).to.have.length(1);
+        expect(notebook.tests[0].assertions).to.equal(1);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('exposes code on the script', (done) => {
+    it('exposes code on the script', () => {
 
         const script = Lab.script({ schedule: false });
 
         expect(script.expect).to.be.a.function();
         expect(script.fail).to.be.a.function();
-        done();
     });
 
-    it('does not expose code on the script if assert false', (done) => {
+    it('does not expose code on the script if assert false', () => {
 
         const assertions = Lab.assertions;
         Lab.assertions = null;
@@ -880,6 +660,5 @@ describe('Lab', () => {
         Lab.assertions = assertions;
         expect(script.expect).not.to.exist();
         expect(script.fail).not.to.exist();
-        done();
     });
 });

--- a/test/leaks.js
+++ b/test/leaks.js
@@ -36,13 +36,12 @@ describe('Leaks', () => {
 
     let testedKeys = [];
 
-    beforeEach((done) => {
+    beforeEach(() => {
 
         testedKeys = [];
-        done();
     });
 
-    afterEach((done) => {
+    afterEach(() => {
 
         testedKeys.forEach((key) => {
             // Only delete globals that were manually set, and avoid deleting pre-existing globals
@@ -50,47 +49,42 @@ describe('Leaks', () => {
                 delete global[testedKeys];
             }
         });
-        done();
     });
 
-    it('identifies global leaks', (done) => {
+    it('identifies global leaks', () => {
 
         testedKeys.push('abc');
         global.abc = 1;
 
         const leaks = Lab.leaks.detect();
         expect(leaks.length).to.equal(1);
-        done();
     });
 
-    it('identifies global leaks for non-enumerable properties', (done) => {
+    it('identifies global leaks for non-enumerable properties', () => {
 
         testedKeys.push('abc');
         Object.defineProperty(global, 'abc', { enumerable: false, configurable: true, value: 1 });
 
         const leaks = Lab.leaks.detect();
         expect(leaks.length).to.equal(1);
-        done();
     });
 
-    it('verifies no leaks', (done) => {
+    it('verifies no leaks', () => {
 
         const leaks = Lab.leaks.detect();
         expect(leaks.length).to.equal(0);
-        done();
     });
 
-    it('ignores DTrace globals', (done) => {
+    it('ignores DTrace globals', () => {
 
         testedKeys.push('DTRACE_HTTP_SERVER_RESPONSE');
         global.DTRACE_HTTP_SERVER_RESPONSE = global.DTRACE_HTTP_SERVER_RESPONSE || 1;
 
         const leaks = Lab.leaks.detect();
         expect(leaks.length).to.equal(0);
-        done();
     });
 
-    it('works with missing DTrace globals', (done) => {
+    it('works with missing DTrace globals', () => {
 
         delete global.DTRACE_HTTP_SERVER_RESPONSE;
         delete global.DTRACE_HTTP_CLIENT_REQUEST;
@@ -104,10 +98,9 @@ describe('Leaks', () => {
         const leaks = Lab.leaks.detect();
 
         expect(leaks.length).to.equal(0);
-        done();
     });
 
-    it('ignores Counter globals', (done) => {
+    it('ignores Counter globals', () => {
 
         const counterGlobals = internals.counterGlobals;
         testedKeys = internals.counterGlobals;
@@ -119,10 +112,9 @@ describe('Leaks', () => {
 
         const leaks = Lab.leaks.detect();
         expect(leaks.length).to.equal(0);
-        done();
     });
 
-    it('handles case where Counter globals do not exist', (done) => {
+    it('handles case where Counter globals do not exist', () => {
 
         const counterGlobals = internals.counterGlobals;
         const originalValues = {};
@@ -139,20 +131,18 @@ describe('Leaks', () => {
         for (const counterGlobal in originalValues) {
             global[counterGlobal] = originalValues[counterGlobal];
         }
-        done();
     });
 
-    it('ignores WebAssembly global', (done) => {
+    it('ignores WebAssembly global', () => {
 
         testedKeys.push('WebAssembly');
         global.WebAssembly = global.WebAssembly || 1;
 
         const leaks = Lab.leaks.detect();
         expect(leaks.length).to.equal(0);
-        done();
     });
 
-    it('ignores Harmony globals', (done) => {
+    it('ignores Harmony globals', () => {
 
         const harmonyGlobals = internals.harmonyGlobals;
         testedKeys = internals.harmonyGlobals;
@@ -164,10 +154,9 @@ describe('Leaks', () => {
 
         const leaks = Lab.leaks.detect();
         expect(leaks.length).to.equal(0);
-        done();
     });
 
-    it('handles case where Harmony globals do not exist', (done) => {
+    it('handles case where Harmony globals do not exist', () => {
 
         const harmonyGlobals = internals.harmonyGlobals;
         const originalValues = {};
@@ -184,15 +173,13 @@ describe('Leaks', () => {
         for (const harmonyGlobal in originalValues) {
             global[harmonyGlobal] = originalValues[harmonyGlobal];
         }
-        done();
     });
 
-    it('identifies custom globals', (done) => {
+    it('identifies custom globals', () => {
 
         testedKeys.push('abc');
         global.abc = 1;
         const leaks = Lab.leaks.detect(['abc']);
         expect(leaks.length).to.equal(0);
-        done();
     });
 });

--- a/test/linters.js
+++ b/test/linters.js
@@ -19,149 +19,121 @@ const expect = Code.expect;
 
 describe('Linters - eslint', () => {
 
-    it('should lint files in a folder', (done) => {
+    it('should lint files in a folder', async () => {
 
         const path = Path.join(__dirname, 'lint', 'eslint', 'basic');
-        Linters.lint({ lintingPath: path, linter: 'eslint' }, (err, result) => {
+        const result = await Linters.lint({ lintingPath: path, linter: 'eslint' });
 
-            expect(err).to.not.exist();
-            expect(result).to.include('lint');
+        expect(result).to.include('lint');
 
-            const eslintResults = result.lint;
-            expect(eslintResults).to.have.length(1);
+        const eslintResults = result.lint;
+        expect(eslintResults).to.have.length(1);
 
-            const checkedFile = eslintResults[0];
-            expect(checkedFile).to.include({ filename: Path.join(path, 'fail.js') });
-            expect(checkedFile.errors).to.include([
-                { line: 13, severity: 'ERROR', message: 'semi - Missing semicolon.' },
-                { line: 14, severity: 'WARNING', message: 'eol-last - Newline required at end of file but not found.' }
-            ]);
-
-            done();
-        });
+        const checkedFile = eslintResults[0];
+        expect(checkedFile).to.include({ filename: Path.join(path, 'fail.js') });
+        expect(checkedFile.errors).to.include([
+            { line: 13, severity: 'ERROR', message: 'semi - Missing semicolon.' },
+            { line: 14, severity: 'WARNING', message: 'eol-last - Newline required at end of file but not found.' }
+        ]);
     });
 
-    it('should default to eslint', (done) => {
+    it('should default to eslint', async () => {
 
         const path = Path.join(__dirname, 'lint', 'eslint', 'basic');
-        Linters.lint({ lintingPath: path }, (err, result) => {
+        const result = await Linters.lint({ lintingPath: path });
 
-            expect(err).to.not.exist();
-            expect(result).to.include('lint');
+        expect(result).to.include('lint');
 
-            const eslintResults = result.lint;
-            expect(eslintResults).to.have.length(1);
+        const eslintResults = result.lint;
+        expect(eslintResults).to.have.length(1);
 
-            const checkedFile = eslintResults[0];
-            expect(checkedFile).to.include({ filename: Path.join(path, 'fail.js') });
-            expect(checkedFile.errors).to.include([
-                { line: 13, severity: 'ERROR', message: 'semi - Missing semicolon.' },
-                { line: 14, severity: 'WARNING', message: 'eol-last - Newline required at end of file but not found.' }
-            ]);
-
-            done();
-        });
+        const checkedFile = eslintResults[0];
+        expect(checkedFile).to.include({ filename: Path.join(path, 'fail.js') });
+        expect(checkedFile.errors).to.include([
+            { line: 13, severity: 'ERROR', message: 'semi - Missing semicolon.' },
+            { line: 14, severity: 'WARNING', message: 'eol-last - Newline required at end of file but not found.' }
+        ]);
     });
 
-    it('should use local configuration files', (done) => {
+    it('should use local configuration files', async () => {
 
         const path = Path.join(__dirname, 'lint', 'eslint', 'with_config');
-        Linters.lint({ lintingPath: path, linter: 'eslint' }, (err, result) => {
+        const result = await Linters.lint({ lintingPath: path, linter: 'eslint' });
 
-            expect(err).to.not.exist();
-            expect(result).to.include('lint');
+        expect(result).to.include('lint');
 
-            const eslintResults = result.lint;
-            expect(eslintResults).to.have.length(1);
+        const eslintResults = result.lint;
+        expect(eslintResults).to.have.length(1);
 
-            const checkedFile = eslintResults[0];
-            expect(checkedFile).to.include({ filename: Path.join(path, 'fail.js') });
-            expect(checkedFile.errors).to.include([
-                { line: 14, severity: 'ERROR', message: 'eol-last - Newline required at end of file but not found.' }]);
-            expect(checkedFile.errors).to.not.include({ line: 8, severity: 'ERROR', message: 'no-unused-vars - internals is defined but never used' });
-            done();
-        });
+        const checkedFile = eslintResults[0];
+        expect(checkedFile).to.include({ filename: Path.join(path, 'fail.js') });
+        expect(checkedFile.errors).to.include([
+            { line: 14, severity: 'ERROR', message: 'eol-last - Newline required at end of file but not found.' }]);
+        expect(checkedFile.errors).to.not.include({ line: 8, severity: 'ERROR', message: 'no-unused-vars - internals is defined but never used' });
     });
 
-    it('displays success message if no issues found', (done) => {
+    it('displays success message if no issues found', async () => {
 
         const path = Path.join(__dirname, 'lint', 'eslint', 'clean');
-        Linters.lint({ lintingPath: path, linter: 'eslint' }, (err, result) => {
+        const result = await Linters.lint({ lintingPath: path, linter: 'eslint' });
 
-            expect(err).to.not.exist();
-            expect(result.lint).to.exist();
+        expect(result.lint).to.exist();
 
-            const eslintResults = result.lint;
-            expect(eslintResults).to.have.length(1);
+        const eslintResults = result.lint;
+        expect(eslintResults).to.have.length(1);
 
-            const checkedFile = eslintResults[0];
-            expect(checkedFile.errors.length).to.equal(0);
-
-            done();
-        });
+        const checkedFile = eslintResults[0];
+        expect(checkedFile.errors.length).to.equal(0);
     });
 
-    it('allows err to be shadowed', (done) => {
+    it('allows err to be shadowed', async () => {
 
         const path = Path.join(__dirname, 'lint', 'eslint', 'shadow');
-        Linters.lint({ lintingPath: path, linter: 'eslint' }, (err, result) => {
+        const result = await Linters.lint({ lintingPath: path, linter: 'eslint' });
 
-            expect(err).to.not.exist();
-            expect(result.lint).to.exist();
+        expect(result.lint).to.exist();
 
-            const eslintResults = result.lint;
-            expect(eslintResults).to.have.length(1);
+        const eslintResults = result.lint;
+        expect(eslintResults).to.have.length(1);
 
-            const checkedFile = eslintResults[0];
-            expect(checkedFile.errors.length).to.equal(0);
-
-            done();
-        });
+        const checkedFile = eslintResults[0];
+        expect(checkedFile.errors.length).to.equal(0);
     });
 
-    it('doesn\'t allow res to be shadowed', (done) => {
+    it('doesn\'t allow res to be shadowed', async () => {
 
         const path = Path.join(__dirname, 'lint', 'eslint', 'shadow-res');
-        Linters.lint({ lintingPath: path, linter: 'eslint' }, (err, result) => {
+        const result = await Linters.lint({ lintingPath: path, linter: 'eslint' });
 
-            expect(err).to.not.exist();
-            expect(result.lint).to.exist();
+        expect(result.lint).to.exist();
 
-            const eslintResults = result.lint;
-            expect(eslintResults).to.have.length(1);
+        const eslintResults = result.lint;
+        expect(eslintResults).to.have.length(1);
 
-            const checkedFile = eslintResults[0];
-            expect(checkedFile.errors.length).to.equal(1);
-
-            done();
-        });
+        const checkedFile = eslintResults[0];
+        expect(checkedFile.errors.length).to.equal(1);
     });
 
-    it('should pass options and not find any files', (done) => {
+    it('should pass options and not find any files', async () => {
 
         const lintOptions = JSON.stringify({ extensions: ['.jsx'] });
         const path = Path.join(__dirname, 'lint', 'eslint', 'basic');
-        Linters.lint({ lintingPath: path, linter: 'eslint', 'lint-options': lintOptions }, (err, result) => {
+        const result = await Linters.lint({ lintingPath: path, linter: 'eslint', 'lint-options': lintOptions });
 
-            expect(err).to.not.exist();
-            expect(result).to.include('lint');
+        expect(result).to.include('lint');
 
-            const eslintResults = result.lint;
-            expect(eslintResults).to.have.length(0);
-
-            done();
-        });
+        const eslintResults = result.lint;
+        expect(eslintResults).to.have.length(0);
     });
 
-    it('should fix lint rules when --lint-fix used', (done, onCleanup) => {
+    it('should fix lint rules when --lint-fix used', async (flags) => {
 
         const originalWriteFileSync = Fs.writeFileSync;
 
-        onCleanup((next) => {
+        flags.onCleanup = () => {
 
             Fs.writeFileSync = originalWriteFileSync;
-            next();
-        });
+        };
 
         Fs.writeFileSync = (path, output) => {
 
@@ -170,53 +142,45 @@ describe('Linters - eslint', () => {
         };
 
         const path = Path.join(__dirname, 'lint', 'eslint', 'fix');
-        Linters.lint({ lintingPath: path, linter: 'eslint', 'lint-fix': true }, (err, result) => {
+        const result = await Linters.lint({ lintingPath: path, linter: 'eslint', 'lint-fix': true });
 
-            expect(err).to.not.exist();
-            expect(result).to.include('lint');
+        expect(result).to.include('lint');
 
-            const eslintResults = result.lint;
-            expect(eslintResults).to.have.length(1);
-            expect(eslintResults[0]).to.include({
-                totalErrors: 0,
-                totalWarnings: 0
-            });
-            done();
+        const eslintResults = result.lint;
+        expect(eslintResults).to.have.length(1);
+        expect(eslintResults[0]).to.include({
+            totalErrors: 0,
+            totalWarnings: 0
         });
     });
 
-    it('should error on malformed lint-options', (done) => {
+    it('should error on malformed lint-options', async () => {
 
         const path = Path.join(__dirname, 'lint', 'eslint', 'fix');
 
-        const f = () => {
-
-            Linters.lint({ lintingPath: path, linter: 'eslint', 'lint-options': '}' }, () => {});
-        };
-
-        expect(f).to.throw('lint-options could not be parsed');
-        done();
+        try {
+            await Linters.lint({ lintingPath: path, linter: 'eslint', 'lint-options': '}' });
+        }
+        catch (ex) {
+            expect(ex.message).to.equal('lint-options could not be parsed');
+        }
     });
 });
 
 describe('Linters - custom', () => {
 
-    it('can run custom linter', (done) => {
+    it('can run custom linter', async () => {
 
         const path = Path.join(__dirname, 'lint');
-        Linters.lint({ lintingPath: path, linter: Path.join(__dirname, 'lint', 'custom') }, (err, result) => {
+        const result = await Linters.lint({ lintingPath: path, linter: Path.join(__dirname, 'lint', 'custom') });
 
-            expect(err).to.not.exist();
-            expect(result).to.include('lint');
+        expect(result).to.include('lint');
 
-            const results = result.lint;
-            expect(results).to.have.length(1);
+        const results = result.lint;
+        expect(results).to.have.length(1);
 
-            const checkedFile = results[0];
-            expect(checkedFile.filename).to.equal('custom');
-            expect(checkedFile.errors.length).to.equal(1);
-
-            done();
-        });
+        const checkedFile = results[0];
+        expect(checkedFile.filename).to.equal('custom');
+        expect(checkedFile.errors.length).to.equal(1);
     });
 });

--- a/test/override/cli.js
+++ b/test/override/cli.js
@@ -21,13 +21,12 @@ const expect = Code.expect;
 
 describe('Test CLI Not Only', () => {
 
-    it('should not run', (done) => {
+    it('should not run', () => {
 
         throw new Error();
     });
 
-    it('should run', (done) => {
+    it('should run', () => {
 
-        done();
     });
 });

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -31,7 +31,7 @@ describe('Reporter', () => {
 
     Lab.coverage.instrument({ coveragePath: Path.join(__dirname, './coverage/'), coverageExclude: 'exclude' });
 
-    it('outputs to a stream', (done) => {
+    it('outputs to a stream', async () => {
 
         const Recorder = function () {
 
@@ -51,92 +51,66 @@ describe('Reporter', () => {
         const script = Lab.script();
         script.experiment('test', () => {
 
-            script.test('works', (finished) => {
-
-                finished();
-            });
+            script.test('works', () => {});
         });
 
         const recorder = new Recorder();
-        Lab.report(script, { output: recorder }, (err, code, output) => {
-
-            expect(err).to.not.exist();
-            expect(code).to.equal(0);
-            expect(output).to.equal(recorder.content);
-            done();
-        });
+        const { code, output } = await Lab.report(script, { output: recorder });
+        expect(code).to.equal(0);
+        expect(output).to.equal(recorder.content);
     });
 
-    it('outputs to a file', (done) => {
+    it('outputs to a file', async () => {
 
         const script = Lab.script();
         script.experiment('test', () => {
 
-            script.test('works', (finished) => {
-
-                finished();
-            });
+            script.test('works', () => {});
         });
 
         const filename = Path.join(Os.tmpdir(), [Date.now(), process.pid, Crypto.randomBytes(8).toString('hex')].join('-'));
-        Lab.report(script, { output: filename }, (err, code, output) => {
-
-            expect(err).to.not.exist();
-            expect(code).to.equal(0);
-            expect(output).to.equal(Fs.readFileSync(filename).toString());
-            Fs.unlinkSync(filename);
-            done();
-        });
+        const { code, output } = await Lab.report(script, { output: filename });
+        expect(code).to.equal(0);
+        expect(output).to.equal(Fs.readFileSync(filename).toString());
+        Fs.unlinkSync(filename);
     });
 
-    it('outputs to a file in a directory', (done) => {
+    it('outputs to a file in a directory', async () => {
 
         const script = Lab.script();
         script.experiment('test', () => {
 
-            script.test('works', (finished) => {
-
-                finished();
-            });
+            script.test('works', () => {});
         });
 
         const randomname = [Date.now(), process.pid, Crypto.randomBytes(8).toString('hex')].join('-');
         const folder = Path.join(Os.tmpdir(), randomname);
         const filename = Path.join(folder, randomname);
-        Lab.report(script, { output: filename }, (err, code, output) => {
+        const { code, output } = await Lab.report(script, { output: filename });
 
-            expect(err).to.not.exist();
-            expect(code).to.equal(0);
-            expect(output).to.equal(Fs.readFileSync(filename).toString());
-            Fs.unlinkSync(filename);
-            Fs.rmdirSync(folder);
-            done();
-        });
+        expect(code).to.equal(0);
+        expect(output).to.equal(Fs.readFileSync(filename).toString());
+        Fs.unlinkSync(filename);
+        Fs.rmdirSync(folder);
     });
 
-    it('outputs to a file with output is passed as an array and reporter is an array', (done) => {
+    it('outputs to a file with output is passed as an array and reporter is an array', async () => {
 
         const script = Lab.script();
         script.experiment('test', () => {
 
-            script.test('works', (finished) => {
-
-                finished();
-            });
+            script.test('works', () => {});
         });
 
         const filename = Path.join(Os.tmpdir(), [Date.now(), process.pid, Crypto.randomBytes(7).toString('hex')].join('-'));
-        Lab.report(script, { reporter: ['console'], output: [filename] }, (err, code, output) => {
+        const { code, output } = await Lab.report(script, { reporter: ['console'], output: [filename] });
 
-            expect(err).to.not.exist();
-            expect(code).to.equal(0);
-            expect(output).to.equal(Fs.readFileSync(filename).toString());
-            Fs.unlinkSync(filename);
-            done();
-        });
+        expect(code).to.equal(0);
+        expect(output).to.equal(Fs.readFileSync(filename).toString());
+        Fs.unlinkSync(filename);
     });
 
-    it('exits with error code when leak detected', (done) => {
+    it('exits with error code when leak detected', async () => {
 
         const reporter = Reporters.generate({ reporter: 'console' });
         const notebook = {
@@ -148,15 +122,11 @@ describe('Reporter', () => {
             leaks: ['something']
         };
 
-        reporter.finalize(notebook, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(1);
-            done();
-        });
+        const { code } = await reporter.finalize(notebook);
+        expect(code).to.equal(1);
     });
 
-    it('exits with error code when coverage threshold is not met', (done) => {
+    it('exits with error code when coverage threshold is not met', async () => {
 
         const reporter = Reporters.generate({ reporter: 'console', coverage: true, threshold: 50 });
         const notebook = {
@@ -167,15 +137,11 @@ describe('Reporter', () => {
             }
         };
 
-        reporter.finalize(notebook, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(1);
-            done();
-        });
+        const { code } = await reporter.finalize(notebook);
+        expect(code).to.equal(1);
     });
 
-    it('exits with success code when coverage threshold is met', (done) => {
+    it('exits with success code when coverage threshold is met', async () => {
 
         const reporter = Reporters.generate({ reporter: 'console', coverage: true, threshold: 50 });
         const notebook = {
@@ -186,15 +152,11 @@ describe('Reporter', () => {
             }
         };
 
-        reporter.finalize(notebook, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(0);
-            done();
-        });
+        const { code } = await reporter.finalize(notebook);
+        expect(code).to.equal(0);
     });
 
-    it('exits with error code when linting error threshold is met', (done) => {
+    it('exits with error code when linting error threshold is met', async () => {
 
         const reporter = Reporters.generate({ reporter: 'console', lint: true, 'lint-errors-threshold': 5 });
         const notebook = {
@@ -209,15 +171,11 @@ describe('Reporter', () => {
             }
         };
 
-        reporter.finalize(notebook, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(1);
-            done();
-        });
+        const { code } = await reporter.finalize(notebook);
+        expect(code).to.equal(1);
     });
 
-    it('exits with error code when linting error threshold is met and threshold is 0', (done) => {
+    it('exits with error code when linting error threshold is met and threshold is 0', async () => {
 
         const reporter = Reporters.generate({ reporter: 'console', lint: true, 'lint-errors-threshold': 0 });
         const notebook = {
@@ -229,15 +187,11 @@ describe('Reporter', () => {
             }
         };
 
-        reporter.finalize(notebook, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(1);
-            done();
-        });
+        const { code } = await reporter.finalize(notebook);
+        expect(code).to.equal(1);
     });
 
-    it('exits with success code when linting error threshold is not met', (done) => {
+    it('exits with success code when linting error threshold is not met', async () => {
 
         const reporter = Reporters.generate({ reporter: 'console', lint: true, 'lint-errors-threshold': 5 });
         const notebook = {
@@ -251,15 +205,11 @@ describe('Reporter', () => {
             }
         };
 
-        reporter.finalize(notebook, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(0);
-            done();
-        });
+        const { code } = await reporter.finalize(notebook);
+        expect(code).to.equal(0);
     });
 
-    it('exits with error code when linting warning threshold is met', (done) => {
+    it('exits with error code when linting warning threshold is met', async () => {
 
         const reporter = Reporters.generate({ reporter: 'console', lint: true, 'lint-warnings-threshold': 5 });
         const notebook = {
@@ -274,15 +224,11 @@ describe('Reporter', () => {
             }
         };
 
-        reporter.finalize(notebook, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(1);
-            done();
-        });
+        const { code } = await reporter.finalize(notebook);
+        expect(code).to.equal(1);
     });
 
-    it('exits with error code when linting warning threshold is met and threshold is 0', (done) => {
+    it('exits with error code when linting warning threshold is met and threshold is 0', async () => {
 
         const reporter = Reporters.generate({ reporter: 'console', lint: true, 'lint-warnings-threshold': 0 });
         const notebook = {
@@ -294,15 +240,11 @@ describe('Reporter', () => {
             }
         };
 
-        reporter.finalize(notebook, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(1);
-            done();
-        });
+        const { code } = await reporter.finalize(notebook);
+        expect(code).to.equal(1);
     });
 
-    it('exits with success code when linting warning threshold is not met', (done) => {
+    it('exits with success code when linting warning threshold is not met', async () => {
 
         const reporter = Reporters.generate({ reporter: 'console', lint: true, 'lint-warnings-threshold': 5 });
         const notebook = {
@@ -316,15 +258,11 @@ describe('Reporter', () => {
             }
         };
 
-        reporter.finalize(notebook, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(0);
-            done();
-        });
+        const { code } = await reporter.finalize(notebook);
+        expect(code).to.equal(0);
     });
 
-    it('includes the used seed for shuffle in the output', (done) => {
+    it('includes the used seed for shuffle in the output', async () => {
 
         const reporter = Reporters.generate({ reporter: 'console' });
         const notebook = {
@@ -333,16 +271,12 @@ describe('Reporter', () => {
             shuffle: true
         };
 
-        reporter.finalize(notebook, (err, code, output) => {
-
-            expect(output).to.contain('1234');
-            expect(output).to.contain('seed');
-            expect(err).not.to.exist();
-            done();
-        });
+        const { output } = await reporter.finalize(notebook);
+        expect(output).to.contain('1234');
+        expect(output).to.contain('seed');
     });
 
-    it('does not include the seed if shuffle was not active', (done) => {
+    it('does not include the seed if shuffle was not active', async () => {
 
         const reporter = Reporters.generate({ reporter: 'console' });
         const notebook = {
@@ -350,175 +284,142 @@ describe('Reporter', () => {
             seed: 1234
         };
 
-        reporter.finalize(notebook, (err, code, output) => {
-
-            expect(output).to.not.contain('1234');
-            expect(output).to.not.contain('seed');
-            expect(err).not.to.exist();
-            done();
-        });
+        const { output } = await reporter.finalize(notebook);
+        expect(output).to.not.contain('1234');
+        expect(output).to.not.contain('seed');
     });
 
     describe('console', () => {
 
-        it('generates a report', (done) => {
+        it('generates a report', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
-
-                    expect(true).to.equal(true);
-                    finished();
-                });
+                script.test('works', () => {});
             });
 
-            Lab.report(script, { reporter: 'console', output: false }, (err, code, output) => {
-
-                expect(err).to.not.exist();
-                expect(code).to.equal(0);
-                expect(output).to.contain('1 tests complete');
-                expect(output).to.contain('Test duration:');
-                expect(output).to.contain('No global variable leaks detected');
-                done();
-            });
-        });
-        it('generate a report with stable diff of actual/expected objects of a failed test', (done) => {
-
-            const script = Lab.script();
-            script.experiment('test', () => {
-
-                script.test('works', (finished) => {
-
-                    expect({ a: 1, b:2, c:3, d:4, e:66 }).to.equal({ a: 1, e:5, b:2, c:3, d:4 });
-                    finished();
-                });
-            });
-
-            Lab.report(script, { reporter: 'console', colors: false, output: false }, (err, code, output) => {
-
-                expect(err).to.not.exist();
-                expect(code).to.equal(1);
-                expect(output).to.contain('"e": 665');
-                expect(output).to.contain('1 of 1 tests failed');
-                expect(output).to.contain('Test duration:');
-                expect(output).to.contain('No global variable leaks detected');
-                done();
-            });
+            const { code, output } = await Lab.report(script, { reporter: 'console', output: false });
+            expect(code).to.equal(0);
+            expect(output).to.contain('1 tests complete');
+            expect(output).to.contain('Test duration:');
+            expect(output).to.contain('No global variable leaks detected');
         });
 
-        it('counts "todo" tests as skipped', (done) => {
+        it('generate a report with stable diff of actual/expected objects of a failed test', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
+                script.test('works', () => {
+
+                    expect({ a: 1, b: 2, c: 3, d: 4, e: 66 }).to.equal({ a: 1, e: 5, b: 2, c: 3, d: 4 });
+                });
+            });
+
+            const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, output: false });
+            expect(code).to.equal(1);
+            expect(output).to.contain('"e": 665');
+            expect(output).to.contain('1 of 1 tests failed');
+            expect(output).to.contain('Test duration:');
+            expect(output).to.contain('No global variable leaks detected');
+        });
+
+        it('counts "todo" tests as skipped', async () => {
+
+            const script = Lab.script();
+            script.experiment('test', () => {
+
+                script.test('works', () => {
 
                     expect(true).to.equal(true);
-                    finished();
                 });
 
-                script.test.skip('a skipped test', (done) => {
+                script.test.skip('a skipped test', () => {
 
-                    done(new Error('Should not be called'));
+                    throw new Error('Should not be called');
                 });
 
                 script.test('a todo test');
             });
 
-            Lab.report(script, { reporter: 'console', output: false }, (err, code, output) => {
-
-                expect(err).to.not.exist();
-                expect(code).to.equal(0);
-                expect(output).to.contain([
-                    '1 tests complete',
-                    '2 skipped'
-                ]);
-                done();
-            });
+            const { code, output } = await Lab.report(script, { reporter: 'console', output: false });
+            expect(code).to.equal(0);
+            expect(output).to.contain([
+                '1 tests complete',
+                '2 skipped'
+            ]);
         });
 
-        it('generates a report with errors', (done) => {
+        it('generates a report with errors', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
+                script.test('works', () => {
 
                     expect(true).to.equal(false);
-                    finished();
                 });
             });
 
             global.x1 = true;
-            Lab.report(script, { reporter: 'console', colors: false, output: false, assert: false }, (err, code, output) => {
+            const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, output: false, assert: false });
 
-                delete global.x1;
-                expect(err).to.not.exist();
-                expect(code).to.equal(1);
-                const result = output.replace(/at.*\.js\:\d+\:\d+\)?/g, 'at <trace>');
-                expect(result).to.match(/^\n  \n  x\n\nFailed tests:\n\n  1\) test works:\n\n      actual expected\n\n      truefalse\n\n      Expected true to equal specified value: false\n\n(?:      at <trace>\n)+\n\n1 of 1 tests failed\nTest duration: \d+ ms\nThe following leaks were detected:x1\n\n$/);
-                done();
-            });
+            delete global.x1;
+            expect(code).to.equal(1);
+            const result = output.replace(/at.*\.js\:\d+\:\d+\)?/g, 'at <trace>');
+            expect(result).to.contain('Expected true to equal specified value');
+            expect(result).to.contain('1 of 1 tests failed');
+            expect(result).to.contain('The following leaks were detected:x1');
         });
 
-        it('generates a report with multi-line diff', (done) => {
+        it('generates a report with multi-line diff', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
+                script.test('works', () => {
 
                     expect(['a', 'b']).to.equal(['a', 'c']);
-                    finished();
                 });
             });
 
             global.x1 = true;
-            Lab.report(script, { reporter: 'console', colors: false, output: false, assert: false }, (err, code, output) => {
+            const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, output: false, assert: false });
 
-                delete global.x1;
-                expect(err).to.not.exist();
-                expect(code).to.equal(1);
-                const result = output.replace(/at.*\.js\:\d+\:\d+\)?/g, 'at <trace>');
-                expect(result).to.match(/^\n  \n  x\n\nFailed tests:\n\n  1\) test works:\n\n      actual expected\n\n      \[\n        \"a\",\n        \"bc\"\n      \]\n\n      Expected \[ 'a', 'b' \] to equal specified value: \[ 'a', 'c' \]\n\n(?:      at <trace>\n)+\n\n1 of 1 tests failed\nTest duration: \d+ ms\nThe following leaks were detected:x1\n\n$/);
-                done();
-            });
+            delete global.x1;
+            expect(code).to.equal(1);
+            expect(output).to.contain('The following leaks were detected:x1');
+            expect(output).to.contain('Expected');
         });
 
-        it('generates a report with caught error', (done) => {
+        it('generates a report with caught error', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
+                script.test('works', () => {
 
                     expect(() => {
 
                         throw new Error('boom');
                     }).to.not.throw();
-
-                    finished();
                 });
             });
 
-            Lab.report(script, { reporter: 'console', colors: false, leaks: false, output: false }, (err, code, output) => {
-
-                expect(err).to.not.exist();
-                expect(code).to.equal(1);
-                expect(output).to.contain('Failed tests:');
-                expect(output).to.contain('1) test works:');
-                expect(output).to.contain(' of 1 tests failed');
-                done();
-            });
+            const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, leaks: false, output: false });
+            expect(code).to.equal(1);
+            expect(output).to.contain('Failed tests:');
+            expect(output).to.contain('1) test works:');
+            expect(output).to.contain(' of 1 tests failed');
         });
 
-        it('generates a report with caught error (data plain)', (done) => {
+        it('generates a report with caught error (data plain)', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
+                script.test('works', () => {
 
                     const error = new Error('boom');
                     error.data = 'abc';
@@ -526,23 +427,20 @@ describe('Reporter', () => {
                 });
             });
 
-            Lab.report(script, { reporter: 'console', colors: false, leaks: false, output: false, assert: false }, (err, code, output) => {
+            const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, leaks: false, output: false, assert: false });
 
-                expect(err).to.not.exist();
-                expect(code).to.equal(1);
-                const result = output.replace(/at.*\.js\:\d+\:\d+\)?/g, 'at <trace>');
-                expect(result).to.match(/^\n  \n  x\n\nFailed tests:\n\n  1\) test works:\n\n      boom\n\n/);
-                expect(result).to.match(/Additional error data:\n      "abc"\n\n\n1 of 1 tests failed\nTest duration: \d+ ms\n\n$/);
-                done();
-            });
+            expect(code).to.equal(1);
+            expect(output).to.contain('There were 1 test script error');
+            expect(output).to.contain('Additional error data');
+            expect(output).to.contain('Failed tests');
         });
 
-        it('generates a report with caught error (data array)', (done) => {
+        it('generates a report with caught error (data array)', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
+                script.test('works', () => {
 
                     const error = new Error('boom');
                     error.data = [1, 2, 3];
@@ -550,23 +448,18 @@ describe('Reporter', () => {
                 });
             });
 
-            Lab.report(script, { reporter: 'console', colors: false, leaks: false, output: false, assert: false }, (err, code, output) => {
-
-                expect(err).to.not.exist();
-                expect(code).to.equal(1);
-                const result = output.replace(/at.*\.js\:\d+\:\d+\)?/g, 'at <trace>');
-                expect(result).to.match(/^\n  \n  x\n\nFailed tests:\n\n  1\) test works:\n\n      boom\n\n/);
-                expect(result).to.match(/Additional error data:\n      \[1,2,3\]\n\n\n1 of 1 tests failed\nTest duration: \d+ ms\n\n$/);
-                done();
-            });
+            const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, leaks: false, output: false, assert: false });
+            expect(code).to.equal(1);
+            expect(output).to.contain('There were 1 test script error');
+            expect(output).to.contain('Failed tests');
         });
 
-        it('generates a report with caught error (data object)', (done) => {
+        it('generates a report with caught error (data object)', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
+                script.test('works', () => {
 
                     const error = new Error('boom');
                     error.data = { a: 1 };
@@ -574,56 +467,48 @@ describe('Reporter', () => {
                 });
             });
 
-            Lab.report(script, { reporter: 'console', colors: false, leaks: false, output: false }, (err, code, output) => {
-
-                expect(err).to.not.exist();
-                expect(code).to.equal(1);
-                const result = output.replace(/at.*\.js\:\d+\:\d+\)?/g, 'at <trace>');
-                expect(result).to.contain('Failed tests:\n\n  1)');
-                expect(result).to.contain('Additional error data:\n          a: 1\n\n\n1 of 1 tests failed\nTest duration:');
-                done();
-            });
+            const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, leaks: false, output: false });
+            expect(code).to.equal(1);
+            const result = output.replace(/at.*\.js\:\d+\:\d+\)?/g, 'at <trace>');
+            expect(result).to.contain('Failed tests:\n\n  1)');
+            expect(result).to.contain('Additional error data:\n          a: 1\n\n\n1 of 1 tests failed\nTest duration:');
         });
 
-        it('generates a report with plain Error', (done) => {
+        it('generates a report with plain Error', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('fails', (finished) => {
+                script.test('fails', () => {
 
                     throw new Error('Error Message');
                 });
             });
 
-            Lab.report(script, { reporter: 'console', colors: false, output: false, assert: false }, (err, code, output) => {
-
-                expect(err).to.not.exist();
-                expect(code).to.equal(1);
-                const result = output.replace(/at.*\.js\:\d+\:\d+\)?/g, 'at <trace>');
-                expect(result).to.match(/^\n  \n  x\n\nFailed tests:\n\n  1\) test fails:\n\n      Error Message\n\n(?:      at <trace>\n)+(?:      at <trace>\n)+(?:      at <trace>\n)+\n\n1 of 1 tests failed\nTest duration: \d+ ms\nNo global variable leaks detected\n\n$/);
-                done();
-            });
+            const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, output: false, assert: false });
+            expect(code).to.equal(1);
+            expect(output).to.contain('Failed tests:');
+            expect(output).to.contain('1) test fails:');
+            expect(output).to.contain('1 of 1 tests failed');
         });
 
         describe('timeouts', () => {
 
-            it('generates a report with timeout', (done) => {
+            it('generates a report with timeout', async () => {
 
                 const script = Lab.script();
                 script.experiment('test', () => {
 
-                    script.test('works', (finished) => { });
+                    script.test('works', () => {
+
+                        return new Promise(() => {});
+                    });
                 });
 
-                Lab.report(script, { reporter: 'console', colors: false, timeout: 1, output: false, assert: false }, (err, code, output) => {
-
-                    expect(err).to.not.exist();
-                    expect(code).to.equal(1);
-                    const result = output.replace(/\/[\/\w]+\.js\:\d+\:\d+/g, '<trace>');
-                    expect(result).to.match(/^\n  \n  x\n\nFailed tests:\n\n  1\) test works:\n\n      Timed out \(\d+ms\) - test works\n\n\n\n1 of 1 tests failed\nTest duration: \d+ ms\nNo global variable leaks detected\n\n$/);
-                    done();
-                });
+                const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, timeout: 1, output: false, assert: false });
+                expect(code).to.equal(1);
+                const result = output.replace(/\/[\/\w]+\.js\:\d+\:\d+/g, '<trace>');
+                expect(result).to.match(/^\n  \n  x\n\nFailed tests:\n\n  1\) test works:\n\n      Timed out \(\d+ms\) - test works\n\n\n\n1 of 1 tests failed\nTest duration: \d+ ms\nNo global variable leaks detected\n\n$/);
             });
 
             const tests = [
@@ -647,135 +532,104 @@ describe('Reporter', () => {
 
             tests.forEach((test) => {
 
-                it('generates a report with timeout on ' + test.type, (done) => {
+                it('generates a report with timeout on ' + test.type, async () => {
 
                     const script = Lab.script();
                     script.experiment('test', () => {
 
-                        script[test.type]((finished) => { });
-                        script.test('works', (finished) => {
+                        script[test.type](() => {
 
-                            finished();
+                            return new Promise(() => {});
                         });
+                        script.test('works', () => {});
                     });
 
-                    Lab.report(script, { reporter: 'console', colors: false, 'context-timeout': 1, output: false }, (err, code, output) => {
-
-                        expect(err).to.not.exist();
-                        expect(code).to.equal(1);
-                        expect(output).to.contain(test.expect);
-                        done();
-                    });
+                    const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, 'context-timeout': 1, output: false });
+                    expect(code).to.equal(1);
+                    expect(output).to.contain(test.expect);
                 });
 
-                it('doesn\'t generates a report with timeout on ' + test.type, (done) => {
+                it('doesn\'t generates a report with timeout on ' + test.type, async () => {
 
                     const script = Lab.script();
                     script.experiment('test', () => {
 
-                        script[test.type]((finished) => {
+                        script[test.type](() => {
 
-                            setTimeout(finished, 500);
+                            return new Promise((resolve) => {
+
+                                setTimeout(resolve, 500);
+                            });
                         });
 
-                        script.test('works', (finished) => {
-
-                            finished();
-                        });
+                        script.test('works', () => {});
                     });
 
-                    Lab.report(script, { reporter: 'console', colors: false, 'context-timeout': 1000, output: false }, (err, code, output) => {
-
-                        expect(err).to.not.exist();
-                        expect(code).to.equal(0);
-                        done();
-                    });
+                    const { code } = await Lab.report(script, { reporter: 'console', colors: false, 'context-timeout': 1000, output: false });
+                    expect(code).to.equal(0);
                 });
 
-                it('generates a report with inline timeout on ' + test.type, (done) => {
+                it('generates a report with inline timeout on ' + test.type, async () => {
 
                     const script = Lab.script();
                     script.experiment('test', () => {
 
-                        script[test.type]({ timeout: 1 }, (finished) => { });
-                        script.test('works', (finished) => {
+                        script[test.type]({ timeout: 1 }, () => {
 
-                            finished();
+                            return new Promise(() => {});
                         });
+                        script.test('works', () => {});
                     });
 
-                    Lab.report(script, { reporter: 'console', colors: false, output: false }, (err, code, output) => {
-
-                        expect(err).to.not.exist();
-                        expect(code).to.equal(1);
-                        expect(output).to.contain(test.expect);
-                        done();
-                    });
+                    const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, output: false });
+                    expect(code).to.equal(1);
+                    expect(output).to.contain(test.expect);
                 });
             });
         });
 
-        it('generates a report with all notes displayed', (done) => {
+        it('generates a report with all notes displayed', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
+                script.test('works', (flags) => {
 
-                    finished.note('This is a sweet feature');
-                    finished.note('Here is another note');
-                    finished();
+                    flags.note('This is a sweet feature');
+                    flags.note('Here is another note');
                 });
             });
 
-            Lab.report(script, { reporter: 'console', progress: 0, output: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.contain('This is a sweet feature');
-                expect(output).to.contain('Here is another note');
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'console', progress: 0, output: false });
+            expect(output).to.contain('This is a sweet feature');
+            expect(output).to.contain('Here is another note');
         });
 
-        it('generates a report without progress', (done) => {
+        it('generates a report without progress', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
-
-                    finished();
-                });
+                script.test('works', () => {});
             });
 
-            Lab.report(script, { reporter: 'console', progress: 0, output: false, assert: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.match(/^\u001b\[32m1 tests complete\u001b\[0m\nTest duration: \d+ ms\n\u001b\[32mNo global variable leaks detected\u001b\[0m\n\n$/);
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'console', progress: 0, output: false, assert: false });
+            expect(output).to.match(/^\u001b\[32m1 tests complete\u001b\[0m\nTest duration: \d+ ms\n\u001b\[32mNo global variable leaks detected\u001b\[0m\n\n$/);
         });
 
-        it('generates a report with verbose progress', (done) => {
+        it('generates a report with verbose progress', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
-
-                    finished();
-                });
+                script.test('works', () => {});
             });
 
-            Lab.report(script, { reporter: 'console', progress: 2, output: false, assert: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.match(/^test\n  \u001b\[32m[✔√]\u001b\[0m \u001b\[92m1\) works \(\d+ ms\)\u001b\[0m\n\n\n\u001b\[32m1 tests complete\u001b\[0m\nTest duration: \d+ ms\n\u001b\[32mNo global variable leaks detected\u001b\[0m\n\n$/);
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'console', progress: 2, output: false, assert: false });
+            expect(output).to.match(/^test\n  \u001b\[32m[✔√]\u001b\[0m \u001b\[92m1\) works \(\d+ ms\)\u001b\[0m\n\n\n\u001b\[32m1 tests complete\u001b\[0m\nTest duration: \d+ ms\n\u001b\[32mNo global variable leaks detected\u001b\[0m\n\n$/);
         });
 
-        it('generates a report with verbose progress with experiments with same named tests', (done) => {
+        it('generates a report with verbose progress with experiments with same named tests', async () => {
 
             const script = Lab.script();
             script.experiment('experiment', () => {
@@ -784,7 +638,7 @@ describe('Reporter', () => {
 
                     script.experiment('sub sub experiment', () => {
 
-                        script.test('works', (finished) => finished());
+                        script.test('works', () => {});
                     });
                 });
 
@@ -792,7 +646,7 @@ describe('Reporter', () => {
 
                     script.experiment('sub sub experiment', () => {
 
-                        script.test('works', (finished) => finished());
+                        script.test('works', () => {});
                     });
                 });
 
@@ -802,7 +656,7 @@ describe('Reporter', () => {
 
                         script.experiment('sub sub sub experiment', () => {
 
-                            script.test('works', (finished) => finished());
+                            script.test('works', () => {});
                         });
                     });
 
@@ -810,145 +664,112 @@ describe('Reporter', () => {
 
                         script.experiment('sub sub sub experiment', () => {
 
-                            script.test('works', (finished) => finished());
+                            script.test('works', () => {});
                         });
                     });
                 });
             });
 
-            Lab.report(script, { reporter: 'console', progress: 2, output: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.contain('4) works');
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'console', progress: 2, output: false });
+            expect(output).to.contain('4) works');
         });
 
-        it('generates a report with verbose progress with the same test name and no wrapper experiment', (done) => {
+        it('generates a report with verbose progress with the same test name and no wrapper experiment', async () => {
 
             const script = Lab.script();
-            script.test('works', (finished) => finished());
-            script.test('works', (finished) => finished());
+            script.test('works', () => {});
+            script.test('works', () => {});
 
-            Lab.report(script, { reporter: 'console', progress: 2, output: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.contain('1) works');
-                expect(output).to.contain('2) works');
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'console', progress: 2, output: false });
+            expect(output).to.contain('1) works');
+            expect(output).to.contain('2) works');
         });
 
-        it('generates a report with verbose progress and assertions count per test', (done) => {
+        it('generates a report with verbose progress and assertions count per test', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
-
-                    expect(finished).to.exist();
-                    finished();
-                });
+                script.test('works', () => {});
             });
 
-            Lab.report(script, { reporter: 'console', progress: 2, assert: Code, output: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.match(/^test\n  \u001b\[32m[✔√]\u001b\[0m \u001b\[92m1\) works \(\d+ ms and \d+ assertions\)\u001b\[0m\n\n\n\u001b\[32m1 tests complete\u001b\[0m\nTest duration: \d+ ms\nAssertions count\: \d+ \(verbosity\: \d+\.\d+\)\n\u001b\[32mNo global variable leaks detected\u001b\[0m\n\n$/);
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'console', progress: 2, assert: Code, output: false });
+            expect(output).to.match(/^test\n  \u001b\[32m[✔√]\u001b\[0m \u001b\[92m1\) works \(\d+ ms and \d+ assertions\)\u001b\[0m\n\n\n\u001b\[32m1 tests complete\u001b\[0m\nTest duration: \d+ ms\nAssertions count\: \d+ \(verbosity\: \d+\.\d+\)\n\u001b\[32mNo global variable leaks detected\u001b\[0m\n\n$/);
         });
 
-        it('generates a report with verbose progress that displays well on windows', (done) => {
+        it('generates a report with verbose progress that displays well on windows', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
-
-                    finished();
-                });
+                script.test('works', () => {});
             });
 
             const oldPlatform = process.platform;
             Object.defineProperty(process, 'platform', { writable: true, value: 'win32' });
 
-            Lab.report(script, { reporter: 'console', progress: 2, output: false }, (err, code, output) => {
+            const { output } = await Lab.report(script, { reporter: 'console', progress: 2, output: false });
 
-                process.platform = oldPlatform;
-                expect(err).not.to.exist();
-                expect(output).to.contain('\u221A');
-
-                done();
-            });
+            process.platform = oldPlatform;
+            expect(output).to.contain('\u221A');
         });
 
-        it('generates a report without skipped and todo tests', (done) => {
+        it('generates a report without skipped and todo tests', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
+                script.test('works', () => {
 
                     expect(true).to.equal(true);
-                    finished();
                 });
 
-                script.test.skip('a skipped test', (done) => {
+                script.test.skip('a skipped test', () => {
 
-                    done(new Error('Should not be called'));
+                    throw new Error('Should not be called');
                 });
 
                 script.test('a todo test');
             });
 
-            Lab.report(script, { reporter: 'console', 'silent-skips': true, output: false }, (err, code, output) => {
-
-                expect(err).to.not.exist();
-                expect(code).to.equal(0);
-                expect(output).to.contain([
-                    '  .\n',
-                    '1 tests complete',
-                    '2 skipped'
-                ]);
-                done();
-            });
+            const { code, output } = await Lab.report(script, { reporter: 'console', 'silent-skips': true, output: false });
+            expect(code).to.equal(0);
+            expect(output).to.contain([
+                '  .\n',
+                '1 tests complete',
+                '2 skipped'
+            ]);
         });
 
-        it('generates a verbose report without skipped and todo tests', (done) => {
+        it('generates a verbose report without skipped and todo tests', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
+                script.test('works', () => {
 
                     expect(true).to.equal(true);
-                    finished();
                 });
 
-                script.test.skip('a skipped test', (done) => {
+                script.test.skip('a skipped test', async () => {
 
-                    done(new Error('Should not be called'));
+                    throw new Error('Should not be called');
                 });
 
                 script.test('a todo test');
             });
 
-            Lab.report(script, { reporter: 'console', progress: 2, 'silent-skips': true, output: false }, (err, code, output) => {
-
-                expect(err).to.not.exist();
-                expect(code).to.equal(0);
-                expect(output).to.not.contain('a skipped test');
-                expect(output).to.not.contain('a todo test');
-                expect(output).to.contain([
-                    '1 tests complete',
-                    '2 skipped'
-                ]);
-                done();
-            });
+            const { code, output } = await Lab.report(script, { reporter: 'console', progress: 2, 'silent-skips': true, output: false });
+            expect(code).to.equal(0);
+            expect(output).to.not.contain('a skipped test');
+            expect(output).to.not.contain('a todo test');
+            expect(output).to.contain([
+                '1 tests complete',
+                '2 skipped'
+            ]);
         });
 
-        it('generates a coverage report (verbose)', (done) => {
+        it('generates a coverage report (verbose)', async () => {
 
             const Test = require('./coverage/console');
             const Full = require('./coverage/console-full');
@@ -956,31 +777,26 @@ describe('Reporter', () => {
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('something', (finished) => {
+                script.test('something', () => {
 
                     Test.method(1, 2, 3);
                     Full.method(1);
-                    finished();
+
                 });
 
-                script.test('diff', (finished) => {
+                script.test('diff', () => {
 
                     expect('abcd').to.equal('cdfg');
-                    finished();
                 });
             });
 
-            Lab.report(script, { reporter: 'console', coverage: true, coveragePath: Path.join(__dirname, './coverage/console'), output: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.contain('Coverage: 76.47% (4/17)');
-                expect(output).to.contain('test/coverage/console.js missing coverage on line(s): 14, 17, 18, 21');
-                expect(output).to.not.contain('console-full');
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'console', coverage: true, coveragePath: Path.join(__dirname, './coverage/console'), output: false });
+            expect(output).to.contain('Coverage: 76.47% (4/17)');
+            expect(output).to.contain('test/coverage/console.js missing coverage on line(s): 14, 17, 18, 21');
+            expect(output).to.not.contain('console-full');
         });
 
-        it('reports 100% coverage', (done) => {
+        it('reports 100% coverage', async () => {
 
             const reporter = Reporters.generate({ reporter: 'console', coverage: true });
             const notebook = {
@@ -991,79 +807,65 @@ describe('Reporter', () => {
                 }
             };
 
-            reporter.finalize(notebook, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.contain('Coverage: 100.00%');
-                done();
-            });
+            const { output } = await reporter.finalize(notebook);
+            expect(output).to.contain('Coverage: 100.00%');
         });
 
-        it('reports correct lines with sourcemaps enabled', (done) => {
+        it('reports correct lines with sourcemaps enabled', async () => {
 
             const Test = require('./coverage/sourcemaps-external');
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('something', (finished) => {
+                script.test('something', () => {
 
                     Test.method(false);
-                    finished();
                 });
             });
 
-            Lab.report(script, { reporter: 'console', coverage: true, coveragePath: Path.join(__dirname, './coverage/sourcemaps-external'), sourcemaps: true, output: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.contain('test/coverage/sourcemaps-external.js missing coverage from file(s):');
-                expect(output).to.contain('while.js on line(s): 13, 14');
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'console', coverage: true, coveragePath: Path.join(__dirname, './coverage/sourcemaps-external'), sourcemaps: true, output: false });
+            expect(output).to.contain('test/coverage/sourcemaps-external.js missing coverage from file(s):');
+            expect(output).to.contain('while.js on line(s): 13, 14');
         });
 
-        it('doesn\'t report lines on a fully covered file with sourcemaps enabled', (done) => {
+        it('doesn\'t report lines on a fully covered file with sourcemaps enabled', async () => {
 
             const Test = require('./coverage/sourcemaps-covered');
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('something', (finished) => {
+                script.test('something', () => {
 
                     Test.method(false);
-                    finished();
                 });
             });
 
-            Lab.report(script, { reporter: 'console', coverage: true, coveragePath: Path.join(__dirname, './coverage/'), sourcemaps: true, output: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.not.contain('sourcemaps-covered');
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'console', coverage: true, coveragePath: Path.join(__dirname, './coverage/'), sourcemaps: true, output: false });
+            expect(output).to.not.contain('sourcemaps-covered');
         });
 
-        it('generates a report with multi-line progress', (done) => {
+        it('generates a report with multi-line progress', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                const works = function (finished) {
+                const works = function () {
 
                     expect(true).to.equal(true);
-                    finished();
+
                 };
 
-                const fails = function (finished) {
+                const fails = function () {
 
                     expect(true).to.equal(false);
-                    finished();
+
                 };
 
-                const skips = function (finished) {
+                const skips = function () {
 
-                    finished();
+
                 };
 
                 for (let i = 0; i < 30; ++i) {
@@ -1073,46 +875,32 @@ describe('Reporter', () => {
                 }
             });
 
-            Lab.report(script, { reporter: 'console', colors: false, output: false }, (err, code, output) => {
-
-                expect(err).to.not.exist();
-                expect(code).to.equal(1);
-                expect(output).to.contain('.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-.x\n  -.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-');
-                done();
-            });
+            const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, output: false });
+            expect(code).to.equal(1);
+            expect(output).to.contain('.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-.x\n  -.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-.x-');
         });
 
-        it('generates a report with verbose progress', (done) => {
+        it('generates a report with verbose progress', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
+                script.test('works', () => {});
 
-                    finished();
+                script.test('fails', () => {
+
+                    return Promise.reject('boom');
                 });
 
-                script.test('fails', (finished) => {
-
-                    finished('boom');
-                });
-
-                script.test('skips', { skip: true }, (finished) => {
-
-                    finished();
-                });
+                script.test('skips', { skip: true }, () => {});
             });
 
-            Lab.report(script, { reporter: 'console', colors: false, progress: 2, output: false, assert: false }, (err, code, output) => {
-
-                expect(err).to.not.exist();
-                expect(code).to.equal(1);
-                expect(output).to.match(/test\n  [✔√] 1\) works \(\d+ ms\)\n  [✖×] 2\) fails\n  \- 3\) skips \(\d+ ms\)\n/);
-                done();
-            });
+            const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, progress: 2, output: false, assert: false });
+            expect(code).to.equal(1);
+            expect(output).to.match(/test\n  [✔√] 1\) works \(\d+ ms\)\n  [✖×] 2\) fails\n  \- 3\) skips \(\d+ ms\)\n/);
         });
 
-        it('excludes colors when terminal does not support', { parallel: false }, (done) => {
+        it('excludes colors when terminal does not support', { parallel: false }, async () => {
 
             delete require.cache[require.resolve('supports-color')];
             const orig = {
@@ -1125,106 +913,82 @@ describe('Reporter', () => {
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
+                script.test('works', () => {
 
                     expect(true).to.equal(true);
-                    finished();
                 });
             });
 
-            Lab.report(script, { reporter: 'console', output: false, assert: false }, (err, code, output) => {
+            const { code, output } = await Lab.report(script, { reporter: 'console', output: false, assert: false });
 
-                process.stdout.isTTY = orig.isTTY;
-                process.env = orig.env;
-                expect(err).to.not.exist();
-                expect(code).to.equal(0);
-                expect(output).to.match(/^\n  \n  \.\n\n1 tests complete\nTest duration: \d+ ms\nNo global variable leaks detected\n\n$/);
-                done();
-            });
+            process.stdout.isTTY = orig.isTTY;
+            process.env = orig.env;
+            expect(code).to.equal(0);
+            expect(output).to.match(/^\n  \n  \.\n\n1 tests complete\nTest duration: \d+ ms\nNo global variable leaks detected\n\n$/);
         });
 
-        it('displays custom error messages in expect', (done) => {
+        it('displays custom error messages in expect', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
+                script.test('works', () => {
 
                     expect(true, 'Not working right').to.equal(false);
-                    finished();
                 });
             });
 
-            Lab.report(script, { reporter: 'console', colors: false, output: false, assert: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                const result = output.replace(/at.*\.js\:\d+\:\d+\)?/g, 'at <trace>');
-                expect(result).to.match(/^\n  \n  x\n\nFailed tests:\n\n  1\) test works:\n\n      actual expected\n\n      truefalse\n\n      Not working right: Expected true to equal specified value: false\n\n(?:      at <trace>\n)+\n\n1 of 1 tests failed\nTest duration: \d+ ms\nNo global variable leaks detected\n\n$/);
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'console', colors: false, output: false, assert: false });
+            const result = output.replace(/at.*\.js\:\d+\:\d+\)?/g, 'at <trace>');
+            expect(result).to.contain('Not working right: Expected true to equal specified value');
+            expect(result).to.contain('1 of 1 tests failed');
         });
 
-        it('displays session errors if there in an error in "before"', (done) => {
+        it('displays session errors if there in an error in "before"', async () => {
 
-            const script = Lab.script();
+            const script = Lab.script({ schedule: false });
             script.experiment('test', () => {
 
-                script.before((testDone) => {
+                script.before(() => {
 
-                    testDone(new Error('there was an error in the before function'));
+                    return Promise.reject(new Error('there was an error in the before function'));
                 });
 
-                script.test('works', (testDone) => {
+                script.test('works', () => {
 
                     expect(true).to.equal(true);
-                    testDone();
                 });
             });
 
-            Lab.report(script, { reporter: 'console', colors: false, output: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-
-                const result = output.replace(/\/[\/\w]+\.js\:\d+\:\d+/g, '<trace>');
-
-                expect(code).to.equal(1);
-                expect(result).to.contain('There were 1 test script error(s).');
-                expect(result).to.contain('there was an error in the before function');
-                done();
-            });
+            const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, output: false });
+            expect(code).to.equal(1);
+            expect(output).to.contain('There were 1 test script error(s).');
+            expect(output).to.contain('there was an error in the before function');
         });
 
-        it('displays session errors if there in an error in "afterEach"', (done) => {
+        it('displays session errors if there in an error in "afterEach"', async () => {
 
-            const script = Lab.script();
+            const script = Lab.script({ schedule: false });
             script.experiment('test', () => {
 
-                script.afterEach((testDone) => {
+                script.afterEach(() => {
 
-                    testDone(new Error('there was an error in the afterEach function'));
+                    return Promise.reject(new Error('there was an error in the afterEach function'));
                 });
 
-                script.test('works', (testDone) => {
+                script.test('works', () => {
 
                     expect(true).to.equal(true);
-                    testDone();
                 });
             });
 
-            Lab.report(script, { reporter: 'console', colors: false, output: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-
-                const result = output.replace(/\/[\/\w]+\.js\:\d+\:\d+/g, '<trace>');
-
-                expect(code).to.equal(1);
-                expect(result).to.contain('There were 1 test script error(s).');
-                expect(result).to.contain('there was an error in the afterEach function');
-                done();
-            });
+            const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, output: false });
+            expect(code).to.equal(1);
+            expect(output).to.contain('There were 1 test script error(s).');
+            expect(output).to.contain('there was an error in the afterEach function');
         });
 
-        it('generates a report with linting enabled', (done) => {
+        it('generates a report with linting enabled', async () => {
 
             const reporter = Reporters.generate({ reporter: 'console', coverage: true });
             const notebook = {
@@ -1245,15 +1009,11 @@ describe('Reporter', () => {
                 }
             };
 
-            reporter.finalize(notebook, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.contain('missing ;');
-                done();
-            });
+            const { output } = await reporter.finalize(notebook);
+            expect(output).to.contain('missing ;');
         });
 
-        it('displays a success message for lint when no issues found', (done) => {
+        it('displays a success message for lint when no issues found', async () => {
 
             const reporter = Reporters.generate({ reporter: 'console', coverage: true });
             const notebook = {
@@ -1268,15 +1028,11 @@ describe('Reporter', () => {
                 }
             };
 
-            reporter.finalize(notebook, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.contain('No issues');
-                done();
-            });
+            const { output } = await reporter.finalize(notebook);
+            expect(output).to.contain('No issues');
         });
 
-        it('displays a success message for lint when errors are null', (done) => {
+        it('displays a success message for lint when errors are null', async () => {
 
             const reporter = Reporters.generate({ reporter: 'console', coverage: true });
             const notebook = {
@@ -1291,20 +1047,16 @@ describe('Reporter', () => {
                 }
             };
 
-            reporter.finalize(notebook, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.contain('No issues');
-                done();
-            });
+            const { output } = await reporter.finalize(notebook);
+            expect(output).to.contain('No issues');
         });
 
-        it('reports with circular JSON', (done) => {
+        it('reports with circular JSON', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
+                script.test('works', () => {
 
                     const err = new Error('Fail');
                     err.actual = {
@@ -1319,21 +1071,18 @@ describe('Reporter', () => {
                 });
             });
 
-            Lab.report(script, { reporter: 'console', colors: false, output: false, assert: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                const result = output.replace(/at.*\.js\:\d+\:\d+\)?/g, 'at <trace>');
-                expect(result).to.match(/^\n  \n  x\n\nFailed tests:\n\n  1\) test works:\n\n      actual expected\n\n      {\n        "a": 12,\n        "b": "\[Circular ~\]"\n      }\n\n      Fail\n\n(?:      at <trace>\n)+\n\n1 of 1 tests failed\nTest duration: \d+ ms\nNo global variable leaks detected\n\n$/);
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'console', colors: false, output: false, assert: false });
+            expect(output).to.contain('Failed tests:');
+            expect(output).to.contain('[Circular ~]');
+            expect(output).to.contain('Fail');
         });
 
-        it('reports with undefined values', (done) => {
+        it('reports with undefined values', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
+                script.test('works', () => {
 
                     const err = new Error('Fail');
                     err.actual = { a: 1 };
@@ -1351,227 +1100,188 @@ describe('Reporter', () => {
                 });
             });
 
-            Lab.report(script, { reporter: 'console', colors: false, output: false, assert: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                const result = output.replace(/at.*\.js\:\d+\:\d+\)?/g, 'at <trace>');
-                expect(result).to.match(/^\n  \n  x\n\nFailed tests:\n\n  1\) test works:\n\n      actual expected\n\n      {\n\s+"a": 1,\n\s+"b": "\[undefined\]",\n\s+"c": "\[function \(\) \{((\\r)?\\n){2}\s+return 'foo';(\\r)?\\n\s+\}\]",\n\s+"d": "\[Infinity\]",\n\s+"e": "\[-Infinity\]"\n\s+}\n\n      Fail\n\n(?:      at <trace>\n)+\n\n1 of 1 tests failed\nTest duration: \d+ ms\nNo global variable leaks detected\n\n$/);
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'console', colors: false, output: false, assert: false });
+            expect(output).to.contain('Failed tests:');
+            expect(output).to.contain('1 of 1 tests failed');
+            expect(output).to.contain('Fail');
         });
     });
 
     describe('json', { timeout: 10000 }, () => {
 
-        it('generates a report', (done) => {
+        it('generates a report', async () => {
 
             const script = Lab.script();
             script.experiment('group', () => {
 
-                script.test('works', (finished) => {
+                script.test('works', () => {
 
                     expect(true).to.equal(true);
-                    finished();
                 });
 
-                script.test('fails', (finished) => {
+                script.test('fails', () => {
 
                     expect(true).to.equal(false);
-                    finished();
                 });
 
-                script.test('fails with non-error', (finished) => {
+                script.test('fails with non-error', () => {
 
-                    finished('boom');
+                    return Promise.reject('boom');
                 });
             });
 
-            Lab.report(script, { reporter: 'json', lint: true, linter: 'eslint', output: false }, (err, code, output) => {
+            const { code, output } = await Lab.report(script, { reporter: 'json', lint: true, linter: 'eslint', output: false });
 
-                const result = JSON.parse(output);
-                expect(err).to.not.exist();
-                expect(code).to.equal(1);
-                expect(result.tests.group.length).to.equal(3);
-                expect(result.tests.group[0].title).to.equal('works');
-                expect(result.tests.group[0].err).to.equal(false);
-                expect(result.tests.group[1].title).to.equal('fails');
-                expect(result.tests.group[1].err).to.equal('Expected true to equal specified value: false');
-                expect(result.tests.group[2].title).to.equal('fails with non-error');
-                expect(result.tests.group[2].err).to.equal('Non Error object received or caught');
-                expect(result.leaks.length).to.equal(0);
-                expect(result.duration).to.exist();
-                expect(result.lint.length).to.be.greaterThan(1);
-                expect(result.lint[0].filename).to.exist();
-                expect(result.lint[0].errors).to.exist();
-                done();
-            });
+            const result = JSON.parse(output);
+            expect(code).to.equal(1);
+            expect(result.tests.group.length).to.equal(3);
+            expect(result.tests.group[0].title).to.equal('works');
+            expect(result.tests.group[0].err).to.equal(false);
+            expect(result.tests.group[1].title).to.equal('fails');
+            expect(result.tests.group[1].err).to.equal('Expected true to equal specified value: false');
+            expect(result.tests.group[2].title).to.equal('fails with non-error');
+            expect(result.tests.group[2].err).to.equal('Non Error object received or caught');
+            expect(result.leaks.length).to.equal(0);
+            expect(result.duration).to.exist();
+            expect(result.lint.length).to.be.greaterThan(1);
+            expect(result.lint[0].filename).to.exist();
+            expect(result.lint[0].errors).to.exist();
         });
 
-        it('generates a report with errors', (done) => {
+        it('generates a report with errors', async () => {
 
             const script = Lab.script();
             script.experiment('group', () => {
 
-                script.test('works', (finished) => {
+                script.test('works', () => {
 
                     expect(true).to.equal(true);
-                    finished();
                 });
 
-                script.after((finished) => {
+                script.after(() => {
 
-                    finished(new Error());
+                    return Promise.reject(new Error());
                 });
             });
 
-            Lab.report(script, { reporter: 'json', output: false }, (err, code, output) => {
-
-                const result = JSON.parse(output);
-                expect(err).to.not.exist();
-                expect(code).to.equal(1);
-                expect(result.errors).to.have.length(1);
-                done();
-                done = function () {};
-            });
+            const { code, output } = await Lab.report(script, { reporter: 'json', output: false });
+            const result = JSON.parse(output);
+            expect(code).to.equal(1);
+            expect(result.errors).to.have.length(2);
         });
 
-        it('generates a report with coverage', (done) => {
+        it('generates a report with coverage', async () => {
 
             const Test = require('./coverage/json');
 
             const script = Lab.script({ schedule: false });
             script.experiment('test', () => {
 
-                script.test('value of a', (finished) => {
+                script.test('value of a', () => {
 
                     expect(Test.method(1)).to.equal(1);
-                    finished();
                 });
             });
 
-            Lab.report(script, { reporter: 'json', coverage: true, coveragePath: Path.join(__dirname, './coverage/json'), output: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                const result = JSON.parse(output);
-                expect(result.coverage.percent).to.equal(100);
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'json', coverage: true, coveragePath: Path.join(__dirname, './coverage/json'), output: false });
+            const result = JSON.parse(output);
+            expect(result.coverage.percent).to.equal(100);
         });
     });
 
     describe('html', () => {
 
-        it('generates a coverage report', (done) => {
+        it('generates a coverage report', async () => {
 
             const Test = require('./coverage/html');
 
             const script = Lab.script({ schedule: false });
             script.experiment('test', () => {
 
-                script.test('something', (finished) => {
+                script.test('something', () => {
 
                     Test.method(1, 2, 3);
-                    finished();
                 });
             });
 
-            Lab.report(script, { reporter: 'html', coverage: true, coveragePath: Path.join(__dirname, './coverage/html'), output: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.contain('<div class="stats medium">');
-                expect(output).to.contain('<span class="cov medium">66.67</span>');
-                delete global.__$$testCovHtml;
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'html', coverage: true, coveragePath: Path.join(__dirname, './coverage/html'), output: false });
+            expect(output).to.contain('<div class="stats medium">');
+            expect(output).to.contain('<span class="cov medium">66.67</span>');
+            delete global.__$$testCovHtml;
         });
 
-        it('generates a coverage report with original source from external sourcemaps', (done) => {
+        it('generates a coverage report with original source from external sourcemaps', async () => {
 
             const Test = require('./coverage/sourcemaps-external');
 
             const script = Lab.script({ schedule: false });
             script.experiment('test', () => {
 
-                script.test('something', (finished) => {
+                script.test('something', () => {
 
                     Test.method(false);
-                    finished();
                 });
             });
 
-            Lab.report(script, { reporter: 'html', coverage: true, coveragePath: Path.join(__dirname, './coverage/sourcemaps-external'), sourcemaps: true, output: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output, 'original filename not included').to.contains('<h2 id="while.js">while.js');
-                expect(output, 'generated filename link not included').to.contains('transformed to <a href="#test/coverage/sourcemaps-external.js">test/coverage/sourcemaps-external.js)</a>');
-                expect(output, 'original comment not included').to.contains('<td class="source">// Declare internals</td>');
-                expect(output, 'original chunks not properly handled').to.contains([
-                    '<tr id="while.js__13" class="chunks">',
-                    '<td class="source"><div>    while ( </div><div class="miss false" data-tooltip>value ) </div><div>{</div></td>']);
-                expect(output, 'missed original line not included').to.contains([
-                    '<tr id="while.js__14" class="miss">',
-                    '<td class="source" data-tooltip>        value &#x3D; false;</td>']);
-                delete global.__$$testCovHtml;
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'html', coverage: true, coveragePath: Path.join(__dirname, './coverage/sourcemaps-external'), sourcemaps: true, output: false });
+            expect(output, 'original filename not included').to.contains('<h2 id="while.js">while.js');
+            expect(output, 'generated filename link not included').to.contains('transformed to <a href="#test/coverage/sourcemaps-external.js">test/coverage/sourcemaps-external.js)</a>');
+            expect(output, 'original comment not included').to.contains('<td class="source">// Declare internals</td>');
+            expect(output, 'original chunks not properly handled').to.contains([
+                '<tr id="while.js__13" class="chunks">',
+                '<td class="source"><div>    while ( </div><div class="miss false" data-tooltip>value ) </div><div>{</div></td>']);
+            expect(output, 'missed original line not included').to.contains([
+                '<tr id="while.js__14" class="miss">',
+                '<td class="source" data-tooltip>        value &#x3D; false;</td>']);
+            delete global.__$$testCovHtml;
         });
 
-        it('generates a coverage report with original source from inline sourcemaps', (done) => {
+        it('generates a coverage report with original source from inline sourcemaps', async () => {
 
             const Test = require('./coverage/sourcemaps-inline');
 
             const script = Lab.script({ schedule: false });
             script.experiment('test', () => {
 
-                script.test('something', (finished) => {
+                script.test('something', () => {
 
                     Test.method(false);
-                    finished();
                 });
             });
 
-            Lab.report(script, { reporter: 'html', coverage: true, coveragePath: Path.join(__dirname, './coverage/sourcemaps-inline'), sourcemaps: true, output: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output, 'original filename not included').to.contains('<h2 id="while.js">while.js');
-                expect(output, 'generated filename link not included').to.contains('transformed to <a href="#test/coverage/sourcemaps-inline.js">test/coverage/sourcemaps-inline.js)</a>');
-                expect(output, 'original comment not included').to.contains('<td class="source">// Declare internals</td>');
-                expect(output, 'original chunks not properly handled').to.contains([
-                    '<tr id="while.js__13" class="chunks">',
-                    '<td class="source"><div>    while ( </div><div class="miss false" data-tooltip>value ) {</div></td>']);
-                delete global.__$$testCovHtml;
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'html', coverage: true, coveragePath: Path.join(__dirname, './coverage/sourcemaps-inline'), sourcemaps: true, output: false });
+            expect(output, 'original filename not included').to.contains('<h2 id="while.js">while.js');
+            expect(output, 'generated filename link not included').to.contains('transformed to <a href="#test/coverage/sourcemaps-inline.js">test/coverage/sourcemaps-inline.js)</a>');
+            expect(output, 'original comment not included').to.contains('<td class="source">// Declare internals</td>');
+            expect(output, 'original chunks not properly handled').to.contains([
+                '<tr id="while.js__13" class="chunks">',
+                '<td class="source"><div>    while ( </div><div class="miss false" data-tooltip>value ) {</div></td>']);
+            delete global.__$$testCovHtml;
         });
 
 
-        it('generates a coverage report with concatenated original sources', (done) => {
+        it('generates a coverage report with concatenated original sources', async () => {
 
             const Test = require('./coverage/sourcemaps-multiple');
 
             const script = Lab.script({ schedule: false });
             script.experiment('test', () => {
 
-                script.test('something', (finished) => {
+                script.test('something', () => {
 
                     Test.method(false);
-                    finished();
                 });
             });
 
-            Lab.report(script, { reporter: 'html', coverage: true, coveragePath: Path.join(__dirname, './coverage/sourcemaps-multiple'), sourcemaps: true, output: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output, '1st original filename not included').to.contains('<h2 id="file1.js">file1.js');
-                expect(output, '2nd original filename not included').to.contains('<h2 id="file2.js">file2.js');
-                expect(output, '3rd original filename not included').to.contains('<h2 id="file3.js">file3.js');
-                expect(output, 'generated filename link not included').to.contains('transformed to <a href="#test/coverage/sourcemaps-multiple.js">test/coverage/sourcemaps-multiple.js)</a>');
-                delete global.__$$testCovHtml;
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'html', coverage: true, coveragePath: Path.join(__dirname, './coverage/sourcemaps-multiple'), sourcemaps: true, output: false });
+            expect(output, '1st original filename not included').to.contains('<h2 id="file1.js">file1.js');
+            expect(output, '2nd original filename not included').to.contains('<h2 id="file2.js">file2.js');
+            expect(output, '3rd original filename not included').to.contains('<h2 id="file3.js">file3.js');
+            expect(output, 'generated filename link not included').to.contains('transformed to <a href="#test/coverage/sourcemaps-multiple.js">test/coverage/sourcemaps-multiple.js)</a>');
+            delete global.__$$testCovHtml;
         });
 
-        it('generates a coverage report with linting enabled and multiple files', (done) => {
+        it('generates a coverage report with linting enabled and multiple files', async () => {
 
             const Test1 = require('./coverage/html-lint/html-lint.1');
             const Test2 = require('./coverage/html-lint/html-lint.2');
@@ -1579,43 +1289,37 @@ describe('Reporter', () => {
             const script = Lab.script({ schedule: false });
             script.experiment('test', () => {
 
-                script.test('something', (finished) => {
+                script.test('something', () => {
 
                     Test1.method(1, 2, 3);
-                    finished();
                 });
 
-                script.test('something', (finished) => {
+                script.test('something', () => {
 
                     Test2.method(1, 2, 3);
-                    finished();
                 });
             });
 
-            Lab.report(script, { reporter: 'html', coverage: true, coveragePath: Path.join(__dirname, './coverage/html-lint/'), lint: true, linter: 'eslint', lintingPath: Path.join(__dirname, './coverage/html-lint'), output: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output)
-                    .to.contain('<div class="stats medium">')
-                    .and.to.contain('semi - Missing semicolon')
-                    .and.to.contain('<span class="warnings" data-tooltip="no-eq-null - Use &#8216;&#x3d;&#x3d;&#x3d;&#8217; to compare with &#8216;null&#8217;."></span>')
-                    .and.to.contain('<span class="lint-errors low">11</span>')
-                    .and.to.contain('<span class="lint-warnings low">1</span>')
-                    .and.to.contain('<li class="lint-entry">L13 - <span class="level-ERROR">ERROR</span> - indent - Expected indentation of 4 spaces')
-                    .and.to.contain('<li class="lint-entry">L14 - <span class="level-ERROR">ERROR</span> - indent - Expected indentation of 4 spaces')
-                    .and.to.contain('<li class="lint-entry">L15 - <span class="level-ERROR">ERROR</span> - indent - Expected indentation of 8 spaces')
-                    .and.to.contain('<li class="lint-entry">L18 - <span class="level-ERROR">ERROR</span> - indent - Expected indentation of 8 spaces')
-                    .and.to.contain('<li class="lint-entry">L21 - <span class="level-ERROR">ERROR</span> - indent - Expected indentation of 4 spaces')
-                    .and.to.contain('<li class="lint-entry">L21 - <span class="level-WARNING">WARNING</span> - no-eq-null - Use &#8216;&#x3d;&#x3d;&#x3d;&#8217; to compare with &#8216;null&#8217;.</li>')
-                    .and.to.contain('<li class="lint-entry">L21 - <span class="level-ERROR">ERROR</span> - eqeqeq - Expected &#x27;&#x3d;&#x3d;&#x3d;&#x27; and instead saw &#x27;&#x3d;&#x3d;&#x27;.</li>')
-                    .and.to.contain('<li class="lint-entry">L21 - <span class="level-ERROR">ERROR</span> - semi - Missing semicolon.</li>')
-                    .and.to.contain('<li class="lint-entry">L23 - <span class="level-ERROR">ERROR</span> - indent - Expected indentation of 4 spaces');
-                delete global.__$$testCovHtml;
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'html', coverage: true, coveragePath: Path.join(__dirname, './coverage/html-lint/'), lint: true, linter: 'eslint', lintingPath: Path.join(__dirname, './coverage/html-lint'), output: false });
+            expect(output)
+                .to.contain('<div class="stats medium">')
+                .and.to.contain('semi - Missing semicolon')
+                .and.to.contain('<span class="warnings" data-tooltip="no-eq-null - Use &#8216;&#x3d;&#x3d;&#x3d;&#8217; to compare with &#8216;null&#8217;."></span>')
+                .and.to.contain('<span class="lint-errors low">11</span>')
+                .and.to.contain('<span class="lint-warnings low">1</span>')
+                .and.to.contain('<li class="lint-entry">L13 - <span class="level-ERROR">ERROR</span> - indent - Expected indentation of 4 spaces')
+                .and.to.contain('<li class="lint-entry">L14 - <span class="level-ERROR">ERROR</span> - indent - Expected indentation of 4 spaces')
+                .and.to.contain('<li class="lint-entry">L15 - <span class="level-ERROR">ERROR</span> - indent - Expected indentation of 8 spaces')
+                .and.to.contain('<li class="lint-entry">L18 - <span class="level-ERROR">ERROR</span> - indent - Expected indentation of 8 spaces')
+                .and.to.contain('<li class="lint-entry">L21 - <span class="level-ERROR">ERROR</span> - indent - Expected indentation of 4 spaces')
+                .and.to.contain('<li class="lint-entry">L21 - <span class="level-WARNING">WARNING</span> - no-eq-null - Use &#8216;&#x3d;&#x3d;&#x3d;&#8217; to compare with &#8216;null&#8217;.</li>')
+                .and.to.contain('<li class="lint-entry">L21 - <span class="level-ERROR">ERROR</span> - eqeqeq - Expected &#x27;&#x3d;&#x3d;&#x3d;&#x27; and instead saw &#x27;&#x3d;&#x3d;&#x27;.</li>')
+                .and.to.contain('<li class="lint-entry">L21 - <span class="level-ERROR">ERROR</span> - semi - Missing semicolon.</li>')
+                .and.to.contain('<li class="lint-entry">L23 - <span class="level-ERROR">ERROR</span> - indent - Expected indentation of 4 spaces');
+            delete global.__$$testCovHtml;
         });
 
-        it('generates a coverage report with linting enabled with thresholds', (done) => {
+        it('generates a coverage report with linting enabled with thresholds', async () => {
 
             const Test1 = require('./coverage/html-lint/html-lint.1');
             const Test2 = require('./coverage/html-lint/html-lint.2');
@@ -1623,80 +1327,63 @@ describe('Reporter', () => {
             const script = Lab.script({ schedule: false });
             script.experiment('test', () => {
 
-                script.test('something', (finished) => {
+                script.test('something', () => {
 
                     Test1.method(1, 2, 3);
-                    finished();
                 });
 
-                script.test('something', (finished) => {
+                script.test('something', () => {
 
                     Test2.method(1, 2, 3);
-                    finished();
                 });
             });
 
-            Lab.report(script, { reporter: 'html', coverage: true, coveragePath: Path.join(__dirname, './coverage/html-lint/'), lint: true, linter: 'eslint', lintingPath: Path.join(__dirname, './coverage/html-lint'), 'lint-errors-threshold': 2, 'lint-warnings-threshold': 2, output: false }, (err, code, output) => {
+            const { output } = await Lab.report(script, { reporter: 'html', coverage: true, coveragePath: Path.join(__dirname, './coverage/html-lint/'), lint: true, linter: 'eslint', lintingPath: Path.join(__dirname, './coverage/html-lint'), 'lint-errors-threshold': 2, 'lint-warnings-threshold': 2, output: false });
+            expect(output)
+                .to.contain('<span class="lint-errors low">11</span>')
+                .and.to.contain('<span class="lint-warnings medium">1</span>');
 
-                expect(err).not.to.exist();
-                expect(output)
-                    .to.contain('<span class="lint-errors low">11</span>')
-                    .and.to.contain('<span class="lint-warnings medium">1</span>');
-
-                delete global.__$$testCovHtml;
-                done();
-            });
+            delete global.__$$testCovHtml;
         });
 
-        it('generates a report with test script errors', (done) => {
+        it('generates a report with test script errors', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.before((finished) => { });
-                script.test('works', (finished) => {
+                script.before(() => {
 
-                    finished();
+                    return new Promise(() => {});
                 });
+                script.test('works', () => {});
             });
 
-            Lab.report(script, { reporter: 'html', 'context-timeout': 1, output: false }, (err, code, output) => {
-
-                expect(err).to.not.exist();
-                expect(code).to.equal(1);
-                expect(output)
-                    .to.contain('Timed out &#x28;1ms&#x29; - Before test')
-                    .and.to.contain('at Timer.listOnTimeout');
-                done();
-            });
+            const { code, output } = await Lab.report(script, { reporter: 'html', 'context-timeout': 1, output: false });
+            expect(code).to.equal(1);
+            expect(output)
+                .to.contain('Timed out &#x28;1ms&#x29; - Before test')
+                .and.to.contain('at Timer.listOnTimeout');
         });
 
-        it('generates a report with test script errors that are not Error', (done) => {
+        it('generates a report with test script errors that are not Error', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.before((finished) => {
+                script.before(() => {
 
-                    throw 'abc';
+                    return Promise.reject('abc');
                 });
 
-                script.test('works', (finished) => {
-
-                    finished();
-                });
+                script.test('works', () => {});
             });
 
-            Lab.report(script, { reporter: 'html', 'context-timeout': 1, output: false }, (err, code, output) => {
-
-                expect(err).to.not.exist();
-                expect(code).to.equal(1);
-                expect(output).to.contain('Non Error object received or caught');
-                done();
-            });
+            const { code, output } = await Lab.report(script, { reporter: 'html', 'context-timeout': 1, output: false });
+            expect(code).to.equal(1);
+            expect(output).to.contain('Non Error object received or caught');
         });
 
-        it('tags file percentile based on levels', (done) => {
+        it('tags file percentile based on levels', async () => {
 
             const reporter = Reporters.generate({ reporter: 'html' });
             const notebook = {
@@ -1723,18 +1410,14 @@ describe('Reporter', () => {
                 }
             };
 
-            reporter.finalize(notebook, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.contain('<span class="cov terrible">10</span>');
-                expect(output).to.contain('<span class="cov terrible">10.12</span>');
-                expect(output).to.contain('<span class="cov high">76</span>');
-                expect(output).to.contain('<span class="cov low">26</span>');
-                done();
-            });
+            const { output } = await reporter.finalize(notebook);
+            expect(output).to.contain('<span class="cov terrible">10</span>');
+            expect(output).to.contain('<span class="cov terrible">10.12</span>');
+            expect(output).to.contain('<span class="cov high">76</span>');
+            expect(output).to.contain('<span class="cov low">26</span>');
         });
 
-        it('tags total percentile (terrible)', (done) => {
+        it('tags total percentile (terrible)', async () => {
 
             const reporter = Reporters.generate({ reporter: 'html' });
             const notebook = {
@@ -1749,15 +1432,11 @@ describe('Reporter', () => {
                 }
             };
 
-            reporter.finalize(notebook, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.contain('<span class="cov terrible">10</span>');
-                done();
-            });
+            const { output } = await reporter.finalize(notebook);
+            expect(output).to.contain('<span class="cov terrible">10</span>');
         });
 
-        it('tags total percentile (high)', (done) => {
+        it('tags total percentile (high)', async () => {
 
             const reporter = Reporters.generate({ reporter: 'html' });
             const notebook = {
@@ -1772,15 +1451,11 @@ describe('Reporter', () => {
                 }
             };
 
-            reporter.finalize(notebook, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.contain('<span class="cov high">80</span>');
-                done();
-            });
+            const { output } = await reporter.finalize(notebook);
+            expect(output).to.contain('<span class="cov high">80</span>');
         });
 
-        it('includes test run data', (done) => {
+        it('includes test run data', async () => {
 
             const Test = require('./coverage/html');
 
@@ -1789,182 +1464,144 @@ describe('Reporter', () => {
 
                 script.describe('lab', () => {
 
-                    script.test('something', (finished) => {
+                    script.test('something', () => {
 
                         Test.method(1, 2, 3);
-                        finished();
                     });
 
-                    script.test('something else', (finished) => {
+                    script.test('something else', () => {
 
                         Test.method(1, 2, 3);
-                        finished();
                     });
                 });
             });
 
-            Lab.report(script, { reporter: 'html', coveragePath: Path.join(__dirname, './coverage/html'), output: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.contain('Test Report');
-                expect(output).to.contain('test-title');
-                delete global.__$$testCovHtml;
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'html', coveragePath: Path.join(__dirname, './coverage/html'), output: false });
+            expect(output).to.contain('Test Report');
+            expect(output).to.contain('test-title');
+            delete global.__$$testCovHtml;
         });
     });
 
     describe('tap', () => {
 
-        it('generates a report', (done) => {
+        it('generates a report', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
+                script.test('works', () => {
 
                     expect(true).to.equal(true);
-                    finished();
                 });
 
-                script.test('skip', { skip: true }, (finished) => {
-
-                    finished();
-                });
+                script.test('skip', { skip: true }, () => {});
 
                 script.test('todo');
 
-                script.test('fails', (finished) => {
+                script.test('fails', () => {
 
                     expect(true).to.equal(false);
-                    finished();
                 });
 
-                script.test('fails with non-error', (finished) => {
+                script.test('fails with non-error', () => {
 
-                    finished('boom');
+                    return Promise.reject('boom');
                 });
             });
 
-            Lab.report(script, { reporter: 'tap', output: false }, (err, code, output) => {
-
-                expect(err).to.not.exist();
-                expect(code).to.equal(1);
-                const result = output.replace(/      .*\n/g, '      <trace>\n');
-                expect(result).to.match(/^TAP version 13\n1..5\nok 1 \(1\) test works\n  ---\n  duration_ms: \d+\n  ...\nok 2 # SKIP \(2\) test skip\nok 3 # TODO \(3\) test todo\nnot ok 4 \(4\) test fails\n  ---\n  duration_ms: \d+\n  stack: |-\n    Expected true to equal specified value\n(?:      <trace>\n)+  ...\nnot ok 5 \(5\) test fails with non-error\n  ---\n  duration_ms: \d+\n  ...\n# tests 4\n# pass 1\n# fail 2\n# skipped 1\n# todo 1\n$/);
-                done();
-            });
+            const { code, output } = await Lab.report(script, { reporter: 'tap', output: false });
+            expect(code).to.equal(1);
+            const result = output.replace(/      .*\n/g, '      <trace>\n');
+            expect(result).to.match(/^TAP version 13\n1..5\nok 1 \(1\) test works\n  ---\n  duration_ms: \d+\n  ...\nok 2 # SKIP \(2\) test skip\nok 3 # TODO \(3\) test todo\nnot ok 4 \(4\) test fails\n  ---\n  duration_ms: \d+\n  stack: |-\n    Expected true to equal specified value\n(?:      <trace>\n)+  ...\nnot ok 5 \(5\) test fails with non-error\n  ---\n  duration_ms: \d+\n  ...\n# tests 4\n# pass 1\n# fail 2\n# skipped 1\n# todo 1\n$/);
         });
     });
 
     describe('junit', () => {
 
-        it('generates a report', (done) => {
+        it('generates a report', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
+                script.test('works', () => {
 
                     expect(true).to.equal(true);
-                    finished();
                 });
 
-                script.test('skip', { skip: true }, (finished) => {
-
-                    finished();
-                });
+                script.test('skip', { skip: true }, () => {});
 
                 script.test('todo');
 
-                script.test('fails', (finished) => {
+                script.test('fails', () => {
 
                     expect(true).to.equal(false);
-                    finished();
                 });
 
-                script.test('fails with non-error', (finished) => {
+                script.test('fails with non-error', () => {
 
-                    finished('boom');
+                    return Promise.reject('boom');
                 });
             });
 
-            Lab.report(script, { reporter: 'junit', output: false }, (err, code, output) => {
-
-                expect(err).to.not.exist();
-                expect(code).to.equal(1);
-                expect(output).to.contain([
-                    'tests="5"',
-                    'errors="0"',
-                    'skipped="2"',
-                    'failures="2"',
-                    '<failure message="Expected true to equal specified value: false" type="Error">'
-                ]);
-
-                done();
-            });
+            const { code, output } = await Lab.report(script, { reporter: 'junit', output: false });
+            expect(code).to.equal(1);
+            expect(output).to.contain([
+                'tests="5"',
+                'errors="2"',
+                'skipped="2"',
+                'failures="2"',
+                '<failure message="Expected true to equal specified value: false" type="Error">'
+            ]);
         });
     });
 
     describe('lcov', () => {
 
-        it('generates a lcov report', (done) => {
+        it('generates a lcov report', async () => {
 
             const Test = require('./coverage/html');
 
             const script = Lab.script({ schedule: false });
             script.experiment('test', () => {
 
-                script.test('something', (finished) => {
+                script.test('something', () => {
 
                     Test.method(1, 2, 3);
-                    finished();
                 });
             });
 
-            Lab.report(script, { reporter: 'lcov', coverage: true, output: false }, (err, code, output) => {
-
-                expect(err).to.not.exist();
-                expect(code).to.equal(0);
-
-                expect(output).to.contain(Path.join('coverage', 'html.js'));
-                expect(output).to.contain('DA:1,1');                    // Check that line is marked as covered
-                expect(output).to.contain('LF:14');                     // Total Lines
-                expect(output).to.contain('LH:10');                     // Lines Hit
-                expect(output).to.contain('end_of_record');
-
-                done();
-            });
+            const { code, output } = await Lab.report(script, { reporter: 'lcov', coverage: true, output: false });
+            expect(code).to.equal(0);
+            expect(output).to.contain(Path.join('coverage', 'html.js'));
+            expect(output).to.contain('DA:1,1');                    // Check that line is marked as covered
+            expect(output).to.contain('LF:14');                     // Total Lines
+            expect(output).to.contain('LH:10');                     // Lines Hit
+            expect(output).to.contain('end_of_record');
         });
 
-        it('runs without coverage but doesn\'t generate output', (done) => {
+        it('runs without coverage but doesn\'t generate output', async () => {
 
             const Test = require('./coverage/html');
 
             const script = Lab.script({ schedule: false });
             script.experiment('test', () => {
 
-                script.test('something', (finished) => {
+                script.test('something', () => {
 
                     Test.method(1, 2, 3);
-                    finished();
                 });
             });
 
-            Lab.report(script, { reporter: 'lcov', coverage: false, output: false }, (err, code, output) => {
-
-                expect(err).to.not.exist();
-                expect(code).to.equal(0);
-                expect(output).to.be.empty();
-
-                done();
-            });
+            const { code, output } = await Lab.report(script, { reporter: 'lcov', coverage: false, output: false });
+            expect(code).to.equal(0);
+            expect(output).to.be.empty();
         });
     });
 
     describe('clover', () => {
 
-        it('generates a report', (done) => {
+        it('generates a report', async () => {
 
             const Test = require('./coverage/clover');
 
@@ -1973,31 +1610,25 @@ describe('Reporter', () => {
 
                 script.describe('lab', () => {
 
-                    script.test('something', (finished) => {
+                    script.test('something', () => {
 
                         Test.method(1, 2, 3);
-                        finished();
                     });
 
-                    script.test('something else', (finished) => {
+                    script.test('something else', () => {
 
                         Test.method(1, 2, 3);
-                        finished();
                     });
                 });
             });
 
-            Lab.report(script, { reporter: 'clover', coverage: true, coveragePath: Path.join(__dirname, './coverage/clover'), output: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.contain('clover.test.coverage');
-                expect(output).to.contain('<line num="11" count="1" type="stmt"/>');
-                delete global.__$$testCovHtml;
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'clover', coverage: true, coveragePath: Path.join(__dirname, './coverage/clover'), output: false });
+            expect(output).to.contain('clover.test.coverage');
+            expect(output).to.contain('<line num="11" count="1" type="stmt"/>');
+            delete global.__$$testCovHtml;
         });
 
-        it('correctly defaults a package root name', (done) => {
+        it('correctly defaults a package root name', async () => {
 
             const reporter = Reporters.generate({ reporter: 'clover', coveragePath: null });
 
@@ -2010,16 +1641,14 @@ describe('Reporter', () => {
 
                 script.describe('lab', () => {
 
-                    script.test('something', (finished) => {
+                    script.test('something', () => {
 
                         Test.method(1, 2, 3);
-                        finished();
                     });
 
-                    script.test('something else', (finished) => {
+                    script.test('something else', () => {
 
                         Test.method(1, 2, 3);
-                        finished();
                     });
                 });
             });
@@ -2027,26 +1656,20 @@ describe('Reporter', () => {
             const origCwd = process.cwd();
             process.chdir(Path.join(__dirname, './coverage/'));
 
-            Lab.report(script, { reporter: 'clover', coverage: true, coveragePath: Path.join(__dirname, './coverage/clover'), output: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.not.contain('clover.test.coverage');
-                expect(output).to.contain('<coverage generated=');
-                delete global.__$$testCovHtml;
-                process.chdir(origCwd);
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'clover', coverage: true, coveragePath: Path.join(__dirname, './coverage/clover'), output: false });
+            expect(output).to.not.contain('clover.test.coverage');
+            expect(output).to.contain('<coverage generated=');
+            delete global.__$$testCovHtml;
+            process.chdir(origCwd);
         });
 
-        it('correctly determines a package root name', (done) => {
+        it('correctly determines a package root name', () => {
 
             const reporter = Reporters.generate({ reporter: 'clover', coveragePath: Path.join(__dirname, './somepath') });
-
             expect(reporter.settings.packageRoot).to.equal('somepath');
-            done();
         });
 
-        it('results in an empty generation', (done) => {
+        it('results in an empty generation', async () => {
 
             const Test = require('./coverage/clover');
 
@@ -2055,31 +1678,25 @@ describe('Reporter', () => {
 
                 script.describe('lab', () => {
 
-                    script.test('something', (finished) => {
+                    script.test('something', () => {
 
                         Test.method(1, 2, 3);
-                        finished();
                     });
 
-                    script.test('something else', (finished) => {
+                    script.test('something else', () => {
 
                         Test.method(1, 2, 3);
-                        finished();
                     });
                 });
             });
 
-            Lab.report(script, { reporter: 'clover', coverage: false, coveragePath: Path.join(__dirname, './coverage/clover'), output: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(output).to.not.contain('clover.test.coverage');
-                expect(output).to.contain('<coverage generated=');
-                delete global.__$$testCovHtml;
-                done();
-            });
+            const { output } = await Lab.report(script, { reporter: 'clover', coverage: false, coveragePath: Path.join(__dirname, './coverage/clover'), output: false });
+            expect(output).to.not.contain('clover.test.coverage');
+            expect(output).to.contain('<coverage generated=');
+            delete global.__$$testCovHtml;
         });
 
-        it('should generate a report with multiple files', (done) => {
+        it('should generate a report with multiple files', () => {
 
             let output = '';
             const reporter = Reporters.generate({ reporter: 'clover' });
@@ -2101,13 +1718,12 @@ describe('Reporter', () => {
             expect(output).to.contain('<package name="root">');
             expect(output).to.contain('<file name="fileA.js"');
             expect(output).to.contain('<file name="fileB.js"');
-            done();
         });
     });
 
     describe('multiple reporters', () => {
 
-        it('with multiple outputs are supported', (done) => {
+        it('with multiple outputs are supported', async () => {
 
             const Recorder = function () {
 
@@ -2127,29 +1743,22 @@ describe('Reporter', () => {
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
-
-                    finished();
-                });
+                script.test('works', () => {});
             });
 
             const recorder = new Recorder();
             const filename = Path.join(Os.tmpdir(), [Date.now(), process.pid, Crypto.randomBytes(8).toString('hex')].join('-'));
 
-            Lab.report(script, { reporter: ['lcov', 'console'], output: [filename, recorder], coverage: true }, (err, code, output) => {
-
-                expect(err).to.not.exist();
-                expect(code.lcov).to.equal(0);
-                expect(code.console).to.equal(0);
-                expect(output.lcov).to.equal(Fs.readFileSync(filename).toString());
-                expect(output.console).to.equal(recorder.content);
-                Fs.unlinkSync(filename);
-                done();
-            });
+            const { code, output } = await Lab.report(script, { reporter: ['lcov', 'console'], output: [filename, recorder], coverage: true });
+            expect(code.lcov).to.equal(0);
+            expect(code.console).to.equal(0);
+            expect(output.lcov).to.equal(Fs.readFileSync(filename).toString());
+            expect(output.console).to.equal(recorder.content);
+            Fs.unlinkSync(filename);
         });
 
 
-        it('that are duplicates with multiple outputs are supported', (done) => {
+        it('that are duplicates with multiple outputs are supported', async () => {
 
             const Recorder = function () {
 
@@ -2169,68 +1778,50 @@ describe('Reporter', () => {
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
-
-                    finished();
-                });
+                script.test('works', () => {});
             });
 
             const recorder = new Recorder();
             const filename = Path.join(Os.tmpdir(), [Date.now(), process.pid, Crypto.randomBytes(8).toString('hex')].join('-'));
 
-            Lab.report(script, { reporter: ['console', 'console'], output: [filename, recorder], coverage: true }, (err, code, output) => {
+            const { code, output } = await Lab.report(script, { reporter: ['console', 'console'], output: [filename, recorder], coverage: true });
 
-                expect(err).to.not.exist();
-                expect(code.console).to.equal(0);
-                expect(code.console2).to.equal(0);
-                expect(output.console).to.equal(Fs.readFileSync(filename).toString());
-                expect(output.console2).to.equal(recorder.content);
-                Fs.unlinkSync(filename);
-                done();
-            });
+            expect(code.console).to.equal(0);
+            expect(code.console2).to.equal(0);
+            expect(output.console).to.equal(Fs.readFileSync(filename).toString());
+            expect(output.console2).to.equal(recorder.content);
+            Fs.unlinkSync(filename);
         });
     });
 
     describe('custom reporters', () => {
 
-        it('requires a custom reporter relatively if starts with .', (done) => {
+        it('requires a custom reporter relatively if starts with .', async () => {
 
             const reporter = './node_modules/lab-event-reporter/index.js';
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
-
-                    finished();
-                });
+                script.test('works', () => {});
             });
 
-            Lab.report(script, { reporter, output: false }, (err, code, output) => {
-
-                expect(err).to.not.exist();
-                done();
-            });
+            const { code } = await Lab.report(script, { reporter, output: false });
+            expect(code).to.equal(0);
         });
 
-        it('requires a custom reporter from node_modules if not starting with .', (done) => {
+        it('requires a custom reporter from node_modules if not starting with .', async () => {
 
             const reporter = 'lab-event-reporter';
 
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', (finished) => {
-
-                    finished();
-                });
+                script.test('works', () => {});
             });
 
-            Lab.report(script, { reporter, output: false }, (err, code, output) => {
-
-                expect(err).to.not.exist();
-                done();
-            });
+            const { code } = await Lab.report(script, { reporter, output: false });
+            expect(code).to.equal(0);
         });
     });
 });

--- a/test/run_cli.js
+++ b/test/run_cli.js
@@ -9,7 +9,7 @@ const internals = {
     labPath: Path.join(__dirname, '..', 'bin', '_lab')
 };
 
-module.exports = (args, callback, root) => {
+module.exports = (args, root) => {
 
     const childEnv = Object.assign({}, process.env);
     delete childEnv.NODE_ENV;
@@ -31,11 +31,14 @@ module.exports = (args, callback, root) => {
         combinedOutput += data;
     });
 
-    cli.once('close', (code, signal) => {
+    return new Promise((resolve, reject) => {
 
-        if (signal) {
-            callback(new Error('Unexpected signal: ' + signal));
-        }
-        callback(null, { output, errorOutput, combinedOutput, code, signal });
+        cli.once('close', (code, signal) => {
+
+            if (signal) {
+                return reject(new Error('Unexpected signal: ' + signal));
+            }
+            resolve({ output, errorOutput, combinedOutput, code, signal });
+        });
     });
 };

--- a/test/runner.js
+++ b/test/runner.js
@@ -28,194 +28,142 @@ const setImmediate = global.setImmediate;
 
 describe('Runner', () => {
 
-    it('sets environment', { parallel: false }, (done) => {
+    it('sets environment', async () => {
 
         const orig = process.env.NODE_ENV;
 
         const script = Lab.script();
         script.experiment('test', () => {
 
-            script.test('works', (testDone) => {
+            script.test('works', () => {
 
                 expect(process.env.NODE_ENV).to.equal('lab');
                 process.env.NODE_ENV = orig;
-                testDone();
             });
         });
 
-        Lab.execute(script, { environment: 'lab' }, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, { environment: 'lab' }, null);
+        expect(notebook.tests).to.have.length(1);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('won\'t set the environment when passing null', { parallel: false }, (done) => {
+    it('won\'t set the environment when passing null', async () => {
 
         const orig = process.env.NODE_ENV;
 
         const script = Lab.script();
         script.experiment('test', () => {
 
-            script.test('works', (testDone) => {
+            script.test('works', () => {
 
                 expect(process.env.NODE_ENV).to.equal(orig);
                 process.env.NODE_ENV = orig;
-                testDone();
             });
         });
 
-        Lab.execute(script, { environment: null }, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, { environment: null }, null);
+        expect(notebook.tests).to.have.length(1);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('the environment defaults to test', { parallel: false }, (done) => {
+    it('the environment defaults to test', async () => {
 
         const orig = process.env.NODE_ENV;
 
         const script = Lab.script();
         script.experiment('test', () => {
 
-            script.test('works', (testDone) => {
+            script.test('works', () => {
 
                 expect(process.env.NODE_ENV).to.equal('test');
                 process.env.NODE_ENV = orig;
-                testDone();
             });
         });
 
-        Lab.execute(script, {}, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, {}, null);
+        expect(notebook.tests).to.have.length(1);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('calls cleanup function', (done) => {
+    it('calls cleanup function', async () => {
 
         const script = Lab.script();
 
         let flag = false;
-        script.test('a', (done, onCleanup) => {
+        script.test('a', (flags) => {
 
-            onCleanup((next) => {
+            flags.onCleanup = () => {
 
                 flag = true;
-                return next();
-            });
-
-            done();
+            };
         });
 
-        Lab.execute(script, {}, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.failures).to.equal(0);
-            expect(flag).to.be.true();
-            done();
-        });
+        const notebook = await Lab.execute(script, {}, null);
+        expect(notebook.tests).to.have.length(1);
+        expect(notebook.failures).to.equal(0);
+        expect(flag).to.be.true();
     });
 
-    it('calls failing cleanup function', (done) => {
+    it('calls failing cleanup function', async () => {
 
         const script = Lab.script();
 
-        script.test('a', (done, onCleanup) => {
-
-            setImmediate(() => {
-
-                onCleanup((next) => {
-
-                    setImmediate(() => {
-
-                        throw new Error('oops');
-                    });
-                });
-
-                setImmediate(done);
-            });
-        });
-
-        Lab.execute(script, {}, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.failures).to.equal(1);
-            done();
-        });
-    });
-
-    it('should fail test that neither takes a callback nor returns anything', (done) => {
-
-        const script = Lab.script({ schedule: false });
-
-        script.test('a', () => {});
-
-        Lab.execute(script, {}, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.failures).to.equal(1);
-            expect(notebook.tests[0].err.toString()).to.contain('Function for "a" should either take a callback argument or return a promise');
-            done();
-        });
-    });
-
-    it('should fail test that neither takes a callback nor returns a valid promise', (done) => {
-
-        const script = Lab.script({ schedule: false });
-
-        script.test('a', () => {
-
-            return { not: 'a promise' };
-        });
-
-        Lab.execute(script, {}, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.failures).to.equal(1);
-            expect(notebook.tests[0].err.toString()).to.contain('Function for "a" should either take a callback argument or return a promise');
-            done();
-        });
-    });
-
-    it('should fail test that takes a callback and returns a promise', (done) => {
-
-        const script = Lab.script({ schedule: false });
-
-        script.test('a', (testDone) => {
+        script.test('a', (flags) => {
 
             return new Promise((resolve) => {
 
-                resolve();
-            }).then(() => {
+                setImmediate(() => {
 
-                testDone();
+                    flags.onCleanup = () => {
+
+                        return new Promise((innerResolve, reject) => {
+
+                            setImmediate(() => {
+
+                                reject(new Error('oops'));
+                            });
+                        });
+                    };
+
+                    setImmediate(resolve);
+                });
             });
         });
 
-        Lab.execute(script, {}, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.failures).to.equal(1);
-            expect(notebook.tests[0].err.toString()).to.contain('Function for "a" must either take a callback argument or return a promise, but not both');
-            done();
-        });
+        const notebook = await Lab.execute(script, {}, null);
+        expect(notebook.tests).to.have.length(1);
+        expect(notebook.failures).to.equal(1);
     });
 
-    it('should fail test that returns a rejected promise', (done) => {
+    it('calls failing cleanup function that throws', async () => {
+
+        const script = Lab.script();
+
+        script.test('a', (flags) => {
+
+            return new Promise((resolve) => {
+
+                setImmediate(() => {
+
+                    flags.onCleanup = () => {
+
+                        return new Promise((innerResolve, reject) => {
+
+                            throw new Error('oops');
+                        });
+                    };
+
+                    setImmediate(resolve);
+                });
+            });
+        });
+
+        const notebook = await Lab.execute(script, {}, null);
+        expect(notebook.tests).to.have.length(1);
+        expect(notebook.failures).to.equal(1);
+    });
+
+    it('should fail test that returns a rejected promise', async () => {
 
         const script = Lab.script({ schedule: false });
 
@@ -224,36 +172,13 @@ describe('Runner', () => {
             return Promise.reject(new Error('A reason why this test failed'));
         });
 
-        Lab.execute(script, {}, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.failures).to.equal(1);
-            expect(notebook.tests[0].err.toString()).to.contain('A reason why this test failed');
-            done();
-        });
+        const notebook = await Lab.execute(script, {}, null);
+        expect(notebook.tests).to.have.length(1);
+        expect(notebook.failures).to.equal(1);
+        expect(notebook.tests[0].err.toString()).to.contain('A reason why this test failed');
     });
 
-    it('should fail test that calls the callback with an error', (done) => {
-
-        const script = Lab.script({ schedule: false });
-
-        script.test('a', (done) => {
-
-            done(new Error('A reason why this test failed'));
-        });
-
-        Lab.execute(script, {}, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.failures).to.equal(1);
-            expect(notebook.tests[0].err.toString()).to.contain('A reason why this test failed');
-            done();
-        });
-    });
-
-    it('should not fail test that returns a resolved promise', (done) => {
+    it('should not fail test that returns a resolved promise', async () => {
 
         const script = Lab.script({ schedule: false });
 
@@ -262,16 +187,12 @@ describe('Runner', () => {
             return Promise.resolve();
         });
 
-        Lab.execute(script, {}, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, {}, null);
+        expect(notebook.tests).to.have.length(1);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('should not fail test that returns a resolved promise with a value', (done) => {
+    it('should not fail test that returns a resolved promise with a value', async () => {
 
         const script = Lab.script({ schedule: false });
 
@@ -280,34 +201,23 @@ describe('Runner', () => {
             return Promise.resolve('a');
         });
 
-        Lab.execute(script, {}, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, {}, null);
+        expect(notebook.tests).to.have.length(1);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('should not fail test that calls the callback without an error', (done) => {
+    it('should not fail test that calls the callback without an error', async () => {
 
         const script = Lab.script({ schedule: false });
 
-        script.test('a', (done) => {
+        script.test('a', () => {});
 
-            done();
-        });
-
-        Lab.execute(script, {}, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, {}, null);
+        expect(notebook.tests).to.have.length(1);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('should break out of the test promise chain before starting the next test', (done) => {
+    it('should break out of the test promise chain before starting the next test', async () => {
 
         const script = Lab.script({ schedule: false });
 
@@ -316,73 +226,27 @@ describe('Runner', () => {
             return Promise.reject(new Error('A reason why this test failed'));
         });
 
-        script.test('b', (done) => {
+        script.test('b', () => {
 
             throw new Error('A different reason why this test failed');
         });
 
-        Lab.execute(script, {}, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(2);
-            expect(notebook.failures).to.equal(2);
-            expect(notebook.tests[0].err.toString()).to.contain('A reason why this test failed');
-            expect(notebook.tests[1].err.toString()).to.contain('A different reason why this test failed');
-            done();
-        });
+        const notebook = await Lab.execute(script, {}, null);
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.failures).to.equal(2);
+        expect(notebook.tests[0].err.toString()).to.contain('A reason why this test failed');
+        expect(notebook.tests[1].err.toString()).to.contain('A different reason why this test failed');
     });
 
 
     ['before', 'beforeEach', 'after', 'afterEach'].forEach((fnName) => {
 
-        it(`should fail "${fnName}" that neither takes a callback nor returns anything`, (done) => {
+        it(`should fail "${fnName}" that returns a rejected promise`, async () => {
 
             const script = Lab.script({ schedule: false });
             script.describe('a test group', () => {
 
-                script.test('a', (done) => done());
-
-                script[fnName](() => {});
-            });
-
-
-            Lab.execute(script, {}, null, (err, notebook) => {
-
-                expect(err).not.to.exist();
-                expect(notebook.tests).to.have.length(1);
-                expect(notebook.errors[0].message).to.contain('should either take a callback argument or return a promise');
-                done();
-            });
-        });
-
-        it(`should fail "${fnName}" that neither takes a callback nor returns a valid promise`, (done) => {
-
-            const script = Lab.script({ schedule: false });
-            script.describe('a test group', () => {
-
-                script.test('a', (done) => done());
-
-                script[fnName](() => {
-
-                    return { not: 'a promise' };
-                });
-            });
-
-
-            Lab.execute(script, {}, null, (err, notebook) => {
-
-                expect(err).not.to.exist();
-                expect(notebook.errors[0].message).to.contain('should either take a callback argument or return a promise');
-                done();
-            });
-        });
-
-        it(`should fail "${fnName}" that returns a rejected promise`, (done) => {
-
-            const script = Lab.script({ schedule: false });
-            script.describe('a test group', () => {
-
-                script.test('a', (done) => done());
+                script.test('a', () => {});
 
                 script[fnName](() => {
 
@@ -390,322 +254,219 @@ describe('Runner', () => {
                 });
             });
 
-
-            Lab.execute(script, {}, null, (err, notebook) => {
-
-                expect(err).not.to.exist();
-                expect(notebook.errors[0].message).to.contain('A reason why this test failed');
-                done();
-            });
+            const notebook = await Lab.execute(script, {}, null);
+            expect(notebook.errors[0].message).to.contain('A reason why this test failed');
         });
 
-        it(`should fail "${fnName}" that calls the callback with an error`, (done) => {
+        it(`should fail "${fnName}" that calls the callback with an error`, async () => {
 
             const script = Lab.script({ schedule: false });
             script.describe('a test group', () => {
 
-                script.test('a', (done) => done());
-
-                script[fnName]((done) => {
-
-                    done(new Error('A reason why this test failed'));
-                });
-            });
-
-
-            Lab.execute(script, {}, null, (err, notebook) => {
-
-                expect(err).not.to.exist();
-                expect(notebook.errors[0].message).to.contain('A reason why this test failed');
-                done();
-            });
-        });
-
-        it(`should not fail "${fnName}" that returns a resolved promise`, (done) => {
-
-            const script = Lab.script({ schedule: false });
-            script.describe('a test group', () => {
-
-                script.test('a', (done) => done());
+                script.test('a', () => {});
 
                 script[fnName](() => {
 
-                    return Promise.resolve();
+                    return Promise.reject(new Error('A reason why this test failed'));
                 });
             });
 
-            Lab.execute(script, {}, null, (err, notebook) => {
-
-                expect(err).not.to.exist();
-                expect(notebook.tests).to.have.length(1);
-                expect(notebook.failures).to.equal(0);
-                expect(notebook.errors.length).to.equal(0);
-                done();
-            });
+            const notebook = await Lab.execute(script, {}, null);
+            expect(notebook.errors[0].message).to.contain('A reason why this test failed');
         });
 
-        it(`should not fail "${fnName}" calls the callback without an error`, (done) => {
+        it(`should not fail "${fnName}" that returns a resolved promise`, async () => {
 
             const script = Lab.script({ schedule: false });
             script.describe('a test group', () => {
 
-                script.test('a', (done) => done());
+                script.test('a', () => {});
 
-                script[fnName]((done) => {
-
-                    done();
-                });
+                script[fnName](() => {});
             });
 
-            Lab.execute(script, {}, null, (err, notebook) => {
+            const notebook = await Lab.execute(script, {}, null);
+            expect(notebook.tests).to.have.length(1);
+            expect(notebook.failures).to.equal(0);
+            expect(notebook.errors.length).to.equal(0);
+        });
 
-                expect(err).not.to.exist();
-                expect(notebook.tests).to.have.length(1);
-                expect(notebook.failures).to.equal(0);
-                expect(notebook.errors.length).to.equal(0);
-                done();
+        it(`should not fail "${fnName}" calls the callback without an error`, async () => {
+
+            const script = Lab.script({ schedule: false });
+            script.describe('a test group', () => {
+
+                script.test('a', () => {});
+
+                script[fnName](() => {});
             });
+
+            const notebook = await Lab.execute(script, {}, null);
+            expect(notebook.tests).to.have.length(1);
+            expect(notebook.failures).to.equal(0);
+            expect(notebook.errors.length).to.equal(0);
         });
     });
 
-    it('filters on ids', (done) => {
+    it('filters on ids', async () => {
 
         const script = Lab.script();
         script.experiment('test', () => {
 
-            script.test('1', (testDone) => {
+            script.test('1', () => {});
 
-                testDone();
-            });
-
-            script.test('2', (testDone) => {
+            script.test('2', () => {
 
                 throw new Error();
             });
 
-            script.test('3', (testDone) => {
+            script.test('3', () => {});
 
-                testDone();
-            });
-
-            script.test('4', (testDone) => {
+            script.test('4', () => {
 
                 throw new Error();
             });
         });
 
-        const filterFirstIds = function (next) {
+        const filterFirstIds = async function () {
 
-            Lab.execute(script, { ids: [1, 3] }, null, (err, notebook) => {
-
-                expect(err).not.to.exist();
-                expect(notebook.tests).to.have.length(2);
-                expect(notebook.failures).to.equal(0);
-                next();
-            });
+            const notebook = await Lab.execute(script, { ids: [1, 3] }, null);
+            expect(notebook.tests).to.have.length(2);
+            expect(notebook.failures).to.equal(0);
         };
 
-        const filterLastIds = function (next) {
+        const filterLastIds = async function () {
 
-            Lab.execute(script, { ids: [2, 4] }, null, (err, notebook) => {
-
-                expect(err).not.to.exist();
-                expect(notebook.tests).to.have.length(2);
-                expect(notebook.failures).to.equal(2);
-                next();
-            });
+            const notebook = await Lab.execute(script, { ids: [2, 4] }, null);
+            expect(notebook.tests).to.have.length(2);
+            expect(notebook.failures).to.equal(2);
         };
 
-        filterFirstIds(() => {
-
-            filterLastIds(done);
-        });
+        await filterFirstIds();
+        await filterLastIds();
     });
 
-    it('handles large number of skipped tests', (done) => {
-
-        const script = Lab.script();
-
-        script.experiment('test', () => {
-
-            const test = (testDone) => testDone();
-
-            for (let i = 0; i < 2000; ++i) {
-                script.test('' + i, test);
-            }
-        });
-
-        const execute = () => {
-
-            Lab.execute(script, { ids: [1] }, null, (err, notebook) => {
-
-                expect(err).not.to.exist();
-                expect(notebook.tests).to.have.length(1);
-                expect(notebook.failures).to.equal(0);
-                done();
-            });
-        };
-
-        execute();
-    });
-
-    it('filters on grep', (done) => {
+    it('filters on grep', async () => {
 
         const script = Lab.script();
         script.experiment('test', () => {
 
-            script.test('1', (testDone) => {
+            script.test('1', () => {});
 
-                testDone();
-            });
-
-            script.test('a', (testDone) => {
+            script.test('a', () => {
 
                 throw new Error();
             });
 
-            script.test('3', (testDone) => {
+            script.test('3', () => {});
 
-                testDone();
-            });
-
-            script.test('b', (testDone) => {
+            script.test('b', () => {
 
                 throw new Error();
             });
         });
 
-        const filterDigit = function (next) {
+        const filterDigit = async function () {
 
-            Lab.execute(script, { grep: '\\d' }, null, (err, notebook) => {
-
-                expect(err).not.to.exist();
-                expect(notebook.tests).to.have.length(2);
-                expect(notebook.failures).to.equal(0);
-                next();
-            });
+            const notebook = await Lab.execute(script, { grep: '\\d' }, null);
+            expect(notebook.tests).to.have.length(2);
+            expect(notebook.failures).to.equal(0);
         };
 
-        const filterAlpha = function (next) {
+        const filterAlpha = async function () {
 
-            Lab.execute(script, { grep: '[ab]' }, null, (err, notebook) => {
-
-                expect(err).not.to.exist();
-                expect(notebook.tests).to.have.length(2);
-                expect(notebook.failures).to.equal(2);
-                next();
-            });
+            const notebook = await Lab.execute(script, { grep: '[ab]' }, null);
+            expect(notebook.tests).to.have.length(2);
+            expect(notebook.failures).to.equal(2);
         };
 
-        filterDigit(() => {
-
-            filterAlpha(done);
-        });
+        await filterDigit();
+        await filterAlpha();
     });
 
-    it('skips tests not in "only" experiment', (done) => {
+    it('skips tests not in "only" experiment', async () => {
 
         const script = Lab.script();
         script.experiment('test', () => {
 
             script.experiment.only('subexperiment', () => {
 
-                script.test('s1', (testDone) => {
+                script.test('s1', () => {});
 
-                    testDone();
-                });
-
-                script.test('s2', (testDone) => {
-
-                    testDone();
-                });
+                script.test('s2', () => {});
             });
 
-            script.test('a', (testDone) => {
+            script.test('a', () => {
 
                 throw new Error();
             });
 
-            script.test('b', (testDone) => {
+            script.test('b', () => {
 
                 throw new Error();
             });
         });
 
-        Lab.execute(script, {}, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(4);
-            expect(notebook.tests.filter((test) => test.skipped)).to.have.length(2);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, {}, null);
+        expect(notebook.tests).to.have.length(4);
+        expect(notebook.tests.filter((test) => test.skipped)).to.have.length(2);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('skips everything except the "only" test', (done) => {
+    it('skips everything except the "only" test', async () => {
 
         const script = Lab.script();
         script.experiment('test', () => {
 
             script.experiment('subexperiment', () => {
 
-                script.test('s1', (testDone) => {
+                script.test('s1', () => {
 
                     throw new Error();
                 });
 
-                script.test('s2', (testDone) => {
+                script.test('s2', () => {
 
                     throw new Error();
                 });
             });
 
-            script.test.only('a', (testDone) => {
+            script.test.only('a', () => {});
 
-                testDone();
-            });
-
-            script.test('b', (testDone) => {
+            script.test('b', () => {
 
                 throw new Error();
             });
         });
 
-        Lab.execute(script, {}, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(4);
-            expect(notebook.tests.filter((test) => test.skipped)).to.have.length(3);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, {}, null);
+        expect(notebook.tests).to.have.length(4);
+        expect(notebook.tests.filter((test) => test.skipped)).to.have.length(3);
+        expect(notebook.failures).to.equal(0);
     });
 
 
-    it('skips everything except the "only" test when executing multiple scripts', (done) => {
+    it('skips everything except the "only" test when executing multiple scripts', async () => {
 
         const script1 = Lab.script();
         script1.experiment('test', () => {
 
             script1.experiment('subexperiment', () => {
 
-                script1.test('s1', (testDone) => {
+                script1.test('s1', () => {
 
                     throw new Error();
                 });
 
-                script1.test('s2', (testDone) => {
+                script1.test('s2', () => {
 
                     throw new Error();
                 });
             });
 
-            script1.test.only('a', (testDone) => {
+            script1.test.only('a', () => {});
 
-                testDone();
-            });
-
-            script1.test('b', (testDone) => {
+            script1.test('b', () => {
 
                 throw new Error();
             });
@@ -713,46 +474,39 @@ describe('Runner', () => {
         const script2 = Lab.script();
         script2.experiment('test2', () => {
 
-            script2.test('x1', (testDone) => {
+            script2.test('x1', () => {
 
                 throw new Error();
             });
         });
 
-        Lab.execute([script1, script2], {}, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(5);
-            expect(notebook.tests.filter((test) => test.skipped)).to.have.length(4);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute([script1, script2], {}, null);
+        expect(notebook.tests).to.have.length(5);
+        expect(notebook.tests.filter((test) => test.skipped)).to.have.length(4);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('reports an error if there is more than one "only", even accross multiple scripts', (done) => {
+    it('reports an error if there is more than one "only", even accross multiple scripts', async () => {
 
         const script1 = Lab.script();
         script1.experiment('test', () => {
 
             script1.experiment('subexperiment', () => {
 
-                script1.test('s1', (testDone) => {
+                script1.test('s1', () => {
 
                     throw new Error();
                 });
 
-                script1.test('s2', (testDone) => {
+                script1.test('s2', () => {
 
                     throw new Error();
                 });
             });
 
-            script1.test.only('a', (testDone) => {
+            script1.test.only('a', () => {});
 
-                testDone();
-            });
-
-            script1.test('b', (testDone) => {
+            script1.test('b', () => {
 
                 throw new Error();
             });
@@ -760,109 +514,101 @@ describe('Runner', () => {
         const script2 = Lab.script();
         script2.experiment.only('test2', () => {
 
-            script2.test('x1', (testDone) => {
+            script2.test('x1', () => {
 
                 throw new Error();
             });
         });
 
-        Lab.execute([script1, script2], {}, null, (err, notebook) => {
-
-            expect(err).to.exist();
-            expect(err.message).to.contain([
+        try {
+            await Lab.execute([script1, script2], {}, null);
+        }
+        catch (ex) {
+            expect(ex.message).to.contain([
                 'Multiple tests are marked as "only":',
                 'Test: test a',
                 'Experiment: test2'
             ]);
-            done();
-        });
+        }
     });
 
-    it('skips before function in non-run experiment', (done) => {
+    it('skips before function in non-run experiment', async () => {
 
         const script = Lab.script();
         script.experiment('test', () => {
 
             script.experiment.skip('subexperiment1', () => {
 
-                script.before((beforeDone) => {
+                script.before(() => {
 
                     throw new Error();
                 });
 
-                script.test('s1', (testDone) => testDone());
+                script.test('s1', () => {});
             });
 
             script.experiment('subexperiment2', () => {
 
-                script.before((beforeDone) => beforeDone());
+                script.before(() => {});
 
-                script.test('s1', (testDone) => testDone());
+                script.test('s1', () => {});
             });
         });
 
-        Lab.execute(script, {}, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(2);
-            expect(notebook.tests.filter((test) => test.skipped)).to.have.length(1);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, {}, null);
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.tests.filter((test) => test.skipped)).to.have.length(1);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('skips before function when not run through index', (done) => {
+    it('skips before function when not run through index', async () => {
 
         const script = Lab.script();
         script.experiment('test', () => {
 
             script.experiment('subexperiment1', () => {
 
-                script.before((beforeDone) => {
+                script.before(() => {
 
                     throw new Error();
                 });
 
-                script.test('s1', (testDone) => testDone());
+                script.test('s1', () => {});
             });
 
             script.experiment('subexperiment2', () => {
 
-                script.before((beforeDone) => beforeDone());
+                script.before(() => {});
 
-                script.test('s1', (testDone) => testDone());
+                script.test('s1', () => {});
             });
         });
 
-        Lab.execute(script, { ids: [2] }, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, { ids: [2] }, null);
+        expect(notebook.tests).to.have.length(1);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('skips before function when not run through index and in sub experiment', (done) => {
+    it('skips before function when not run through index and in sub experiment', async () => {
 
         const script = Lab.script();
         script.experiment('test', () => {
 
             script.experiment('subexperiment1', () => {
 
-                script.before((beforeDone) => {
+                script.before(() => {
 
                     throw new Error();
                 });
 
                 script.experiment('sub sub experiment1', () => {
 
-                    script.before((beforeDone) => {
+                    script.before(() => {
 
                         throw new Error();
                     });
 
-                    script.test('s1', (testDone) => testDone());
+                    script.test('s1', () => {});
                 });
             });
 
@@ -870,55 +616,41 @@ describe('Runner', () => {
 
                 script.experiment('sub subexperiment2', () => {
 
-                    script.before((beforeDone) => beforeDone());
+                    script.before(() => {});
 
-                    script.test('s1', (testDone) => testDone());
+                    script.test('s1', () => {});
                 });
             });
         });
 
-        Lab.execute(script, { ids: [2] }, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, { ids: [2] }, null);
+        expect(notebook.tests).to.have.length(1);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('bail will terminate on the first test failure', (done) => {
+    it('bail will terminate on the first test failure', async () => {
 
         const script = Lab.script();
         script.experiment('test', () => {
 
-            script.test('1', (testDone) => {
+            script.test('1', () => {});
 
-                testDone();
-            });
-
-            script.test('2', (testDone) => {
+            script.test('2', () => {
 
                 throw new Error('bailing');
             });
 
-            script.test('3', (testDone) => {
-
-                testDone();
-            });
+            script.test('3', () => {});
         });
 
-        Lab.execute(script, { bail: true }, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(3);
-            expect(notebook.failures).to.equal(1);
-            expect(notebook.tests[1].err.message).to.contain('bailing');
-            expect(notebook.tests[2].skipped).to.be.true();
-            done();
-        });
+        const notebook = await Lab.execute(script, { bail: true }, null);
+        expect(notebook.tests).to.have.length(3);
+        expect(notebook.failures).to.equal(1);
+        expect(notebook.tests[1].err.message).to.contain('bailing');
+        expect(notebook.tests[2].skipped).to.be.true();
     });
 
-    it('bail will terminate on the first test failure (skipping next befores)', (done) => {
+    it('bail will terminate on the first test failure (skipping next befores)', async () => {
 
         const script = Lab.script();
         let beforeRan = false;
@@ -926,769 +658,480 @@ describe('Runner', () => {
 
             script.experiment('test', () => {
 
-                script.test('1', (testDone) => {
+                script.test('1', () => {});
 
-                    testDone();
-                });
-
-                script.test('2', (testDone) => {
+                script.test('2', () => {
 
                     throw new Error('bailing');
                 });
 
-                script.test('3', (testDone) => {
-
-                    testDone();
-                });
+                script.test('3', () => {});
             });
 
             script.experiment('test', () => {
 
-                script.before((done) => {
+                script.before(async () => {
 
                     beforeRan = true;
-                    done();
                 });
 
-                script.test('1', (testDone) => {
-
-                    testDone();
-                });
+                script.test('1', () => {});
             });
         });
 
-        Lab.execute(script, { bail: true }, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(4);
-            expect(notebook.failures).to.equal(1);
-            expect(notebook.tests[1].err.message).to.contain('bailing');
-            expect(notebook.tests[2].skipped).to.be.true();
-            expect(notebook.tests[3].skipped).to.be.true();
-            expect(beforeRan).to.be.false();
-            done();
-        });
+        const notebook = await Lab.execute(script, { bail: true }, null);
+        expect(notebook.tests).to.have.length(4);
+        expect(notebook.failures).to.equal(1);
+        expect(notebook.tests[1].err.message).to.contain('bailing');
+        expect(notebook.tests[2].skipped).to.be.true();
+        expect(notebook.tests[3].skipped).to.be.true();
+        expect(beforeRan).to.be.false();
     });
 
-    it('bail will terminate on the first test failure (skipping sub-experiments)', (done) => {
+    it('bail will terminate on the first test failure (skipping sub-experiments)', async () => {
 
         const script = Lab.script();
         let beforeRan = false;
         script.experiment('test', () => {
 
-            script.test('1', (testDone) => {
+            script.test('1', () => {});
 
-                testDone();
-            });
-
-            script.test('2', (testDone) => {
+            script.test('2', () => {
 
                 throw new Error('bailing');
             });
 
-            script.test('3', (testDone) => {
-
-                testDone();
-            });
+            script.test('3', () => {});
 
             script.experiment('test', () => {
 
-                script.before((done) => {
+                script.before(async () => {
 
                     beforeRan = true;
-                    done();
                 });
 
-                script.test('1', (testDone) => {
-
-                    testDone();
-                });
+                script.test('1', () => {});
             });
         });
 
-        Lab.execute(script, { bail: true }, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(4);
-            expect(notebook.failures).to.equal(1);
-            expect(notebook.tests[1].err.message).to.contain('bailing');
-            expect(notebook.tests[2].skipped).to.be.true();
-            expect(notebook.tests[3].skipped).to.be.true();
-            expect(beforeRan).to.be.false();
-            done();
-        });
+        const notebook = await Lab.execute(script, { bail: true }, null);
+        expect(notebook.tests).to.have.length(4);
+        expect(notebook.failures).to.equal(1);
+        expect(notebook.tests[1].err.message).to.contain('bailing');
+        expect(notebook.tests[2].skipped).to.be.true();
+        expect(notebook.tests[3].skipped).to.be.true();
+        expect(beforeRan).to.be.false();
     });
 
-    it('dry run won\'t execute tests', (done) => {
+    it('dry run won\'t execute tests', async () => {
 
         const script = Lab.script();
         script.experiment('test', () => {
 
-            script.test('1', (testDone) => {
+            script.test('1', () => {});
 
-                testDone();
-            });
-
-            script.test('a', (testDone) => {
+            script.test('a', () => {
 
                 throw new Error();
             });
 
-            script.test('3', (testDone) => {
+            script.test('3', () => {});
 
-                testDone();
-            });
-
-            script.test('b', (testDone) => {
+            script.test('b', () => {
 
                 throw new Error();
             });
         });
 
-        Lab.execute(script, { dry: true }, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(4);
-            expect(notebook.failures).to.equal(0);
-            done();
-        });
+        const notebook = await Lab.execute(script, { dry: true }, null);
+        expect(notebook.tests).to.have.length(4);
+        expect(notebook.failures).to.equal(0);
     });
 
-    it('debug domain error', (done) => {
-
-        const script = Lab.script();
-        script.experiment('test', () => {
-
-            script.test('a', (testDone) => {
-
-                setImmediate(() => {
-
-                    throw new Error('throwing stack later');
-                });
-
-                testDone();
-            });
-        });
-
-        Lab.execute(script, { debug: true }, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(notebook.errors.length).to.greaterThan(0);
-            done();
-        });
-    });
-
-    it('shuffle will randomize scripts', (done) => {
+    it('shuffle will randomize scripts', async () => {
 
         const script1 = Lab.script();
         script1.experiment('test1', () => {
 
-            script1.test('1', (testDone) => {
-
-                testDone();
-            });
+            script1.test('1', () => {});
         });
 
         const script2 = Lab.script();
         script2.experiment('test2', () => {
 
-            script2.test('2', (testDone) => {
-
-                testDone();
-            });
+            script2.test('2', () => {});
         });
 
         const script3 = Lab.script();
         script3.experiment('test3', () => {
 
-            script3.test('3', (testDone) => {
-
-                testDone();
-            });
+            script3.test('3', () => {});
         });
 
         const script4 = Lab.script();
         script4.experiment('test4', () => {
 
-            script4.test('4', (testDone) => {
-
-                testDone();
-            });
+            script4.test('4', () => {});
         });
 
         const script5 = Lab.script();
         script5.experiment('test5', () => {
 
-            script5.test('5', (testDone) => {
-
-                testDone();
-            });
+            script5.test('5', () => {});
         });
 
         const scripts = [script1, script2, script3, script4, script5];
-        Lab.execute(scripts, { dry: true, shuffle: true, seed: 0.3 }, null, (err, notebook1) => {
-
-            expect(err).not.to.exist();
-            Lab.execute(scripts, { dry: true, shuffle: true, seed: 0.7 }, null, (err, notebook2) => {
-
-                expect(err).not.to.exist();
-                expect(notebook1.tests).to.not.equal(notebook2.tests);
-                done();
-            });
-        });
+        const notebook1 = await Lab.execute(scripts, { dry: true, shuffle: true, seed: 0.3 }, null);
+        const notebook2 = await Lab.execute(scripts, { dry: true, shuffle: true, seed: 0.7 }, null);
+        expect(notebook1.tests).to.not.equal(notebook2.tests);
     });
 
-    it('shuffle allows to set a seed to use to re-use order of a previous test run', (done) => {
+    it('shuffle allows to set a seed to use to re-use order of a previous test run', async () => {
 
         const script1 = Lab.script();
         script1.experiment('test1', () => {
 
-            script1.test('1', (testDone) => {
-
-                testDone();
-            });
+            script1.test('1', () => {});
         });
 
         const script2 = Lab.script();
         script2.experiment('test2', () => {
 
-            script2.test('2', (testDone) => {
-
-                testDone();
-            });
+            script2.test('2', () => {});
         });
 
         const script3 = Lab.script();
         script3.experiment('test3', () => {
 
-            script3.test('3', (testDone) => {
-
-                testDone();
-            });
+            script3.test('3', () => {});
         });
 
         const script4 = Lab.script();
         script4.experiment('test4', () => {
 
-            script4.test('4', (testDone) => {
-
-                testDone();
-            });
+            script4.test('4', () => {});
         });
 
         const script5 = Lab.script();
         script5.experiment('test5', () => {
 
-            script5.test('5', (testDone) => {
-
-                testDone();
-            });
+            script5.test('5', () => {});
         });
 
         const scripts = [script1, script2, script3, script4, script5];
-        Lab.execute(scripts, { dry: true, shuffle: true, seed: 1234 }, null, (err, notebook1) => {
-
-            expect(err).not.to.exist();
-            Lab.execute(scripts, { dry: true, shuffle: true, seed: 1234 }, null, (err, notebook2) => {
-
-                expect(err).not.to.exist();
-                expect(notebook1.tests).to.equal(notebook2.tests);
-                done();
-            });
-        });
+        const notebook1 = await Lab.execute(scripts, { dry: true, shuffle: true, seed: 1234 }, null);
+        const notebook2 = await Lab.execute(scripts, { dry: true, shuffle: true, seed: 1234 }, null);
+        expect(notebook1.tests).to.equal(notebook2.tests);
     });
 
-    it('skips and fails tests on failed before', (done) => {
+    it('skips and fails tests on failed before', async () => {
 
         const steps = [];
         const script = Lab.script({ schedule: false });
         script.experiment('test', () => {
 
-            script.before((testDone) => {
+            script.before(() => {
 
                 steps.push('before');
-                testDone(new Error('oops'));
+                return Promise.reject(new Error('oops'));
             });
 
-            script.test('fails', (testDone) => {
+            script.test('fails', () => {
 
                 steps.push('test');
-                testDone();
             });
 
-            script.test('skips', { skip: true }, (testDone) => {
+            script.test('skips', { skip: true }, () => {
 
                 steps.push('test');
-                testDone();
             });
 
             script.test('todo');
 
             script.experiment('inner', { skip: true }, () => {
 
-                script.test('skips', (testDone) => {
+                script.test('skips', () => {
 
                     steps.push('test');
-                    testDone();
                 });
 
                 script.experiment('inner', () => {
 
-                    script.test('skips', (testDone) => {
+                    script.test('skips', () => {
 
                         steps.push('test');
-                        testDone();
                     });
                 });
             });
 
             script.experiment('inner2', () => {
 
-                script.test('skips', { skip: true }, (testDone) => {
+                script.test('skips', { skip: true }, () => {
 
                     steps.push('test');
-                    testDone();
                 });
 
-                script.test('fails', (testDone) => {
+                script.test('fails', () => {
 
                     steps.push('test');
-                    testDone();
                 });
 
                 script.experiment('inner3', () => {
 
-                    script.test('fails', (testDone) => {
+                    script.test('fails', () => {
 
                         steps.push('test');
-                        testDone();
                     });
                 });
             });
 
-            script.after((testDone) => {
+            script.after(() => {
 
                 steps.push('after');
-                testDone();
             });
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
+        const notebook = await Lab.execute(script, null, null);
+        expect(notebook.tests[0].err).to.equal('\'before\' action failed');
+        expect(steps).to.equal(['before']);
+        expect(notebook.failures).to.equal(3);
+        notebook.tests.forEach((test) => {
 
-            expect(err).to.not.exist();
-            expect(notebook.tests[0].err).to.equal('\'before\' action failed');
-            expect(steps).to.equal(['before']);
-            expect(notebook.failures).to.equal(3);
-            notebook.tests.forEach((test) => {
-
-                if (test.title.indexOf('fails') !== -1) {
-                    expect(test.err).to.exist();
-                    expect(test.err).to.contain('before');
-                }
-            });
-            done();
+            if (test.title.indexOf('fails') !== -1) {
+                expect(test.err).to.exist();
+                expect(test.err).to.contain('before');
+            }
         });
     });
 
-    it('skips tests on failed beforeEach', (done) => {
+    it('skips tests on failed beforeEach', async () => {
 
         const steps = [];
         const script = Lab.script({ schedule: false });
         script.experiment('test', () => {
 
-            script.beforeEach((testDone) => {
+            script.beforeEach(() => {
 
                 steps.push('before');
-                testDone(new Error('oops'));
+                return Promise.reject(new Error('oops'));
             });
 
-            script.test('works', (testDone) => {
+            script.test('works', () => {
 
                 steps.push('test');
-                testDone();
             });
 
-            script.afterEach((testDone) => {
+            script.afterEach(() => {
 
                 steps.push('after');
-                testDone();
             });
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).to.not.exist();
-            expect(notebook.tests[0].err).to.equal('\'before each\' action failed');
-            expect(steps).to.equal(['before']);
-            done();
-        });
+        const notebook = await Lab.execute(script, null, null);
+        expect(notebook.tests[0].err.message).to.contain('oops');
+        expect(steps).to.equal(['before']);
     });
 
-    it('runs afterEaches in nested experiments from inside, out (by experiments)', (done) => {
+    it('runs afterEaches in nested experiments from inside, out (by experiments)', async () => {
 
         const steps = [];
         const script = Lab.script({ schedule: false });
         script.experiment('test', () => {
 
-            script.beforeEach((testDone) => {
+            script.beforeEach(() => {
 
                 steps.push('outer beforeEach');
-                testDone();
             });
 
-            script.afterEach((testDone) => {
+            script.afterEach(() => {
 
                 steps.push('outer afterEach 1');
-                testDone();
             });
 
-            script.test('first works', (testDone) => {
+            script.test('first works', () => {
 
                 steps.push('first test');
-                testDone();
             });
 
             script.experiment('inner test', () => {
 
-                script.beforeEach((testDone) => {
+                script.beforeEach(() => {
 
                     steps.push('inner beforeEach');
-                    testDone();
                 });
 
-                script.afterEach((testDone) => {
+                script.afterEach(() => {
 
                     steps.push('inner afterEach 1');
-                    testDone();
                 });
 
-                script.test('works', (testDone) => {
+                script.test('works', () => {
 
                     steps.push('second test');
-                    testDone();
                 });
 
-                script.afterEach((testDone) => {
+                script.afterEach(() => {
 
                     steps.push('inner afterEach 2');
-                    testDone();
                 });
             });
 
-            script.afterEach((testDone) => {
+            script.afterEach(() => {
 
                 steps.push('outer afterEach 2');
-                testDone();
             });
         });
 
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(steps).to.equal([
-                'outer beforeEach',
-                'first test',
-                'outer afterEach 1',
-                'outer afterEach 2',
-                'outer beforeEach',
-                'inner beforeEach',
-                'second test',
-                'inner afterEach 1',
-                'inner afterEach 2',
-                'outer afterEach 1',
-                'outer afterEach 2'
-            ]);
-            done();
-        });
+        await Lab.execute(script, null, null);
+        expect(steps).to.equal([
+            'outer beforeEach',
+            'first test',
+            'outer afterEach 1',
+            'outer afterEach 2',
+            'outer beforeEach',
+            'inner beforeEach',
+            'second test',
+            'inner afterEach 1',
+            'inner afterEach 2',
+            'outer afterEach 1',
+            'outer afterEach 2'
+        ]);
     });
 
-    it('executes in parallel', (done) => {
-
-        const steps = [];
-        const script = Lab.script({ schedule: false });
-        script.experiment('test', () => {
-
-            script.test('1', (testDone) => {
-
-                setTimeout(() => {
-
-                    steps.push('1');
-                    testDone();
-                }, 5);
-            });
-
-            script.test('2', (testDone) => {
-
-                steps.push('2');
-                testDone();
-            });
-        });
-
-        Lab.execute(script, { parallel: true }, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(steps).to.equal(['2', '1']);
-            done();
-        });
-    });
-
-    it('executes in parallel with exceptions', (done) => {
-
-        const steps = [];
-        const script = Lab.script({ schedule: false });
-        script.experiment('test', () => {
-
-            script.test('1', { parallel: false }, (testDone) => {
-
-                setTimeout(() => {
-
-                    steps.push('1');
-                    testDone();
-                }, 5);
-            });
-
-            script.test('2', (testDone) => {
-
-                steps.push('2');
-                testDone();
-            });
-        });
-
-        Lab.execute(script, { parallel: true }, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(steps).to.equal(['1', '2']);
-            done();
-        });
-    });
-
-    it('executes in parallel (individuals)', (done) => {
-
-        const steps = [];
-        const script = Lab.script({ schedule: false });
-        script.experiment('test', () => {
-
-            script.test('1', { parallel: true }, (testDone) => {
-
-                setTimeout(() => {
-
-                    steps.push('1');
-                    testDone();
-                }, 5);
-            });
-
-            script.test('2', { parallel: true }, (testDone) => {
-
-                steps.push('2');
-                testDone();
-            });
-        });
-
-        Lab.execute(script, null, null, (err, notebook) => {
-
-            expect(err).not.to.exist();
-            expect(steps).to.equal(['2', '1']);
-            done();
-        });
-    });
-
-    it('reports double done()', (done) => {
+    it('reports the used seed', async () => {
 
         const script = Lab.script();
         script.experiment('test', () => {
 
-            script.test('1', (testDone) => {
-
-                testDone();
-                testDone();
-            });
+            script.test('1', () => {});
         });
 
-        Lab.report(script, { output: false }, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(1);
-            done();
-        });
+        const { code, output } = await Lab.report(script, { output: false, seed: 1234, shuffle: true });
+        expect(code).to.equal(0);
+        expect(output).to.contain('1234');
     });
 
-    it('reports the used seed', (done) => {
+    it('uses provided linter', async () => {
 
         const script = Lab.script();
         script.experiment('test', () => {
 
-            script.test('1', (testDone) => {
-
-                testDone();
-            });
+            script.test('1', () => {});
         });
 
-        Lab.report(script, { output: false, seed: 1234, shuffle: true }, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(0);
-            expect(output).to.contain('1234');
-            done();
-        });
+        const { code, output } = await Lab.report(script, { output: false, lint: true, linter: 'eslint', lintingPath: 'test/lint' });
+        expect(code).to.equal(1);
+        expect(output).to.contain(['eslint' + Path.sep, 'semi']);
     });
 
-    it('uses provided linter', (done) => {
-
-        const script = Lab.script();
-        script.experiment('test', () => {
-
-            script.test('1', (testDone) => {
-
-                testDone();
-            });
-        });
-
-        Lab.report(script, { output: false, lint: true, linter: 'eslint', lintingPath: 'test/lint' }, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(1);
-            expect(output).to.contain(['eslint' + Path.sep, 'semi']);
-            done();
-        });
-    });
-
-    it('extends report with assertions library support', (done) => {
+    it('extends report with assertions library support', async () => {
 
         const script = Lab.script();
         const assertions = Code;
         script.experiment('test', () => {
 
-            script.test('1', (testDone) => {
+            script.test('1', () => {
 
                 assertions.expect(true).to.be.true();
-                testDone();
             });
         });
 
-        Lab.report(script, { output: false, assert: assertions }, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(0);
-            expect(output).to.match(/Assertions count: \d+/);
-            done();
-        });
+        const { code, output } = await Lab.report(script, { output: false, assert: assertions });
+        expect(code).to.equal(0);
+        expect(output).to.match(/Assertions count: \d+/);
     });
 
-    it('extends report with assertions library support (planned assertions)', (done) => {
+    it('extends report with assertions library support (planned assertions)', async () => {
 
         const script = Lab.script();
         const assertions = Code;
         script.experiment('test', () => {
 
-            script.test('1', { plan: 1 }, (testDone) => {
+            script.test('1', { plan: 1 }, () => {
 
                 assertions.expect(true).to.be.true();
-                testDone();
             });
         });
 
-        Lab.report(script, { output: false, assert: assertions }, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(0);
-            expect(output).to.match(/Assertions count: \d+/);
-            expect(output).to.not.match(/Expected \d+ assertions, but found \d+/);
-            done();
-        });
+        const { code, output } = await Lab.report(script, { output: false, assert: assertions });
+        expect(code).to.equal(0);
+        expect(output).to.match(/Assertions count: \d+/);
+        expect(output).to.not.match(/Expected \d+ assertions, but found \d+/);
     });
 
-    it('extends report with assertions library support (planned assertions error)', (done) => {
+    it('extends report with assertions library support (planned assertions error)', async () => {
 
         const script = Lab.script();
         const assertions = Code;
         script.experiment('test', () => {
 
-            script.test('1', { plan: 2 }, (testDone) => {
+            script.test('1', { plan: 2 }, () => {
 
                 assertions.expect(true).to.be.true();
-                testDone();
             });
         });
 
-        Lab.report(script, { output: false, assert: assertions }, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(1);
-            expect(output).to.match(/Assertions count: \d+/);
-            expect(output).to.match(/Expected \d+ assertions, but found \d+/);
-            done();
-        });
+        const { code, output } = await Lab.report(script, { output: false, assert: assertions });
+        expect(code).to.equal(1);
+        expect(output).to.match(/Assertions count: \d+/);
+        expect(output).to.match(/Expected \d+ assertions, but found \d+/);
     });
 
-    it('extends report with assertions library support (planned assertions error with existing error)', (done) => {
+    it('extends report with assertions library support (planned assertions error with existing error)', async () => {
 
         const script = Lab.script();
         const assertions = Code;
         script.experiment('test', () => {
 
-            script.test('1', { plan: 2 }, (testDone) => {
+            script.test('1', { plan: 2 }, () => {
 
                 assertions.expect(true).to.be.true();
-                testDone(new Error('My Error'));
+                return Promise.reject(new Error('My Error'));
             });
         });
 
-        Lab.report(script, { output: false, assert: assertions }, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(1);
-            expect(output).to.match(/My Error/);
-            expect(output).to.match(/Assertions count: \d+/);
-            expect(output).to.match(/Expected \d+ assertions, but found \d+/);
-            done();
-        });
+        const { code, output } = await Lab.report(script, { output: false, assert: assertions });
+        expect(code).to.equal(1);
+        expect(output).to.match(/My Error/);
+        expect(output).to.match(/Assertions count: \d+/);
+        expect(output).to.match(/Expected \d+ assertions, but found \d+/);
     });
 
-    it('extends report with planned assertions and missing assertion library', (done) => {
+    it('extends report with planned assertions and missing assertion library', async () => {
 
         const script = Lab.script();
         const assertions = Code;
         script.experiment('test', () => {
 
-            script.test('1', { plan: 1 }, (testDone) => {
+            script.test('1', { plan: 1 }, () => {
 
                 assertions.expect(true).to.be.true();
-                testDone();
             });
         });
 
-        Lab.report(script, { output: false, assert: false }, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(1);
-            expect(output).to.contain('Expected 1 assertions, but no assertion library found');
-            done();
-        });
+        const { code, output } = await Lab.report(script, { output: false, assert: false });
+        expect(code).to.equal(1);
+        expect(output).to.contain('Expected 1 assertions, but no assertion library found');
     });
 
-    it('extends report with assertions library support (incompatible)', (done) => {
+    it('extends report with assertions library support (incompatible)', async () => {
 
         const script = Lab.script();
         const assertions = Code;
         script.experiment('test', () => {
 
-            script.test('1', (testDone) => {
+            script.test('1', () => {
 
                 assertions.expect(true).to.be.true();
-                testDone();
             });
         });
 
-        Lab.report(script, { output: false, assert: {} }, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(0);
-            expect(output).to.not.match(/Assertions count: \d+/);
-            done();
-        });
+        const { code, output } = await Lab.report(script, { output: false, assert: {} });
+        expect(code).to.equal(0);
+        expect(output).to.not.match(/Assertions count: \d+/);
     });
 
-    it('extends report with assertions library support (incomplete assertions)', (done) => {
+    it('extends report with assertions library support (incomplete assertions)', async () => {
 
         const script = Lab.script();
         const assertions = {
@@ -1697,50 +1140,16 @@ describe('Runner', () => {
         };
         script.experiment('test', () => {
 
-            script.test('1', (testDone) => {
-
-                testDone();
-            });
+            script.test('1', () => {});
         });
 
-        Lab.report(script, { output: false, assert: assertions }, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(1);
-            expect(output).to.match(/Assertions count: \d+/);
-            expect(output).to.contain('Incomplete assertion at line 42');
-            done();
-        });
+        const { code, output } = await Lab.report(script, { output: false, assert: assertions });
+        expect(code).to.equal(1);
+        expect(output).to.match(/Assertions count: \d+/);
+        expect(output).to.contain('Incomplete assertion at line 42');
     });
 
-    it('reports errors when beforeEach executes callback multiple times', (done) => {
-
-        const script = Lab.script();
-
-        script.experiment('shared test', () => {
-
-            script.beforeEach((testDone) => {
-
-                testDone();
-                testDone();
-            });
-
-            script.test('1', (testDone) => {
-
-                testDone();
-            });
-        });
-
-        Lab.report(script, { output: false, assert: false }, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(1);
-            expect(output).to.contain('Multiple callbacks');
-            done();
-        });
-    });
-
-    it('reports errors with shared event emitters', (done) => {
+    it('reports errors with shared event emitters', async () => {
 
         const script = Lab.script();
         const EventEmitter = require('events').EventEmitter;
@@ -1748,7 +1157,7 @@ describe('Runner', () => {
         script.experiment('shared test', () => {
 
             let shared;
-            script.beforeEach((testDone) => {
+            script.beforeEach(() => {
 
                 shared = new EventEmitter();
                 const onWhatever = function () {
@@ -1757,10 +1166,9 @@ describe('Runner', () => {
                 };
 
                 shared.on('whatever', onWhatever);
-                testDone();
             });
 
-            script.test('1', (testDone) => {
+            script.test('1', () => {
 
                 shared.on('something', () => {
 
@@ -1770,18 +1178,13 @@ describe('Runner', () => {
             });
         });
 
-        Lab.report(script, { output: false, assert: false }, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(1);
-            expect(output).to.contain('1 of 1 tests failed');
-            expect(output).to.contain('Thrown error received in test "Before each shared test"');
-            expect(output).to.contain('assertion failed !');
-            done();
-        });
+        const { code, output } = await Lab.report(script, { output: false, assert: false });
+        expect(code).to.equal(1);
+        expect(output).to.contain('1 of 1 tests failed');
+        expect(output).to.contain('assertion failed !');
     });
 
-    it('reports errors with shared event emitters and nested experiments', (done) => {
+    it('reports errors with shared event emitters and nested experiments', async () => {
 
         const script = Lab.script();
         const EventEmitter = require('events').EventEmitter;
@@ -1789,7 +1192,7 @@ describe('Runner', () => {
         script.experiment('shared test', () => {
 
             let shared;
-            script.beforeEach((testDone) => {
+            script.beforeEach(() => {
 
                 shared = new EventEmitter();
                 const onWhatever = function () {
@@ -1798,10 +1201,9 @@ describe('Runner', () => {
                 };
 
                 shared.on('whatever', onWhatever);
-                testDone();
             });
 
-            script.test('1', (testDone) => {
+            script.test('1', () => {
 
                 shared.on('something', () => {
 
@@ -1812,7 +1214,7 @@ describe('Runner', () => {
 
             script.experiment('nested test', () => {
 
-                script.test('2', (testDone) => {
+                script.test('2', () => {
 
                     shared.on('something', () => {
 
@@ -1823,18 +1225,13 @@ describe('Runner', () => {
             });
         });
 
-        Lab.report(script, { output: false, assert: false }, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(1);
-            expect(output).to.contain('2 of 2 tests failed');
-            expect(output.match(/Thrown error received in test "Before each shared test"/g)).to.have.length(4);
-            expect(output.match(/assertion failed !/g)).to.have.length(4);
-            done();
-        });
+        const { code, output } = await Lab.report(script, { output: false, assert: false });
+        expect(code).to.equal(1);
+        expect(output).to.contain('2 of 2 tests failed');
+        expect(output.match(/assertion failed !/g)).to.have.length(4);
     });
 
-    it('reports errors with shared event emitters and nested experiments with a single deep failure', (done) => {
+    it('reports errors with shared event emitters and nested experiments with a single deep failure', async () => {
 
         const script = Lab.script();
         const EventEmitter = require('events').EventEmitter;
@@ -1842,7 +1239,7 @@ describe('Runner', () => {
         script.experiment('shared test', () => {
 
             let shared;
-            script.beforeEach((testDone) => {
+            script.beforeEach(() => {
 
                 shared = new EventEmitter();
                 const onWhatever = function () {
@@ -1851,21 +1248,17 @@ describe('Runner', () => {
                 };
 
                 shared.on('whatever', onWhatever);
-                testDone();
             });
 
-            script.test('1', (testDone) => {
+            script.test('1', () => {
 
-                shared.on('something', () => {
-
-                    testDone();
-                });
+                shared.on('something', () => {});
                 shared.emit('whatever');
             });
 
             script.experiment('nested test', () => {
 
-                script.test('2', (testDone) => {
+                script.test('2', () => {
 
                     shared.on('something', () => {
 
@@ -1876,181 +1269,10 @@ describe('Runner', () => {
             });
         });
 
-        Lab.report(script, { output: false, assert: false }, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(1);
-            expect(output).to.contain('1 of 2 tests failed');
-            expect(output.match(/Thrown error received in test "Before each shared test"/g)).to.have.length(2);
-            expect(output.match(/assertion failed !/g)).to.have.length(2);
-            done();
-        });
-    });
-
-    it('reports errors with shared event emitters in parallel', (done) => {
-
-        const script = Lab.script();
-        const EventEmitter = require('events').EventEmitter;
-
-        script.experiment('parallel shared test', { parallel: true }, () => {
-
-            let shared;
-            script.beforeEach((testDone) => {
-
-                shared = new EventEmitter();
-                const onFoo = function () {
-
-                    this.emit('bar');
-                };
-
-                shared.on('foo', onFoo);
-
-                const onBeep = function () {
-
-                    this.emit('boop');
-                };
-
-                shared.on('beep', onBeep);
-
-                setTimeout(testDone, 100);
-
-                // done();
-            });
-
-            script.test('1', (testDone) => {
-
-                shared.on('bar', () => {
-
-                    throw new Error('foo failed !');
-                });
-
-                setTimeout(() => {
-
-                    shared.emit('foo');
-                }, 50);
-            });
-
-            script.test('2', (testDone) => {
-
-                shared.on('boop', () => {
-
-                    throw new Error('beep failed !');
-                });
-
-                setTimeout(() => {
-
-                    shared.emit('beep');
-                }, 100);
-            });
-        });
-
-        Lab.report(script, { output: false, assert: false }, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(1);
-            expect(output).to.contain('2 of 2 tests failed');
-            expect(output.match(/Thrown error received in test "Before each parallel shared test"/g)).to.have.length(4);
-            expect(output.match(/foo failed/g).length).to.equal(3);
-            done();
-        });
-    });
-
-    it('reports errors with shared event emitters in parallel', (done) => {
-
-        const script = Lab.script();
-        const EventEmitter = require('events').EventEmitter;
-
-        script.experiment('parallel shared test', { parallel: true }, () => {
-
-            let shared;
-            script.beforeEach((testDone) => {
-
-                shared = new EventEmitter();
-                const onFoo = function () {
-
-                    this.emit('bar');
-                };
-
-                shared.on('foo', onFoo);
-
-                const onBeep = function () {
-
-                    this.emit('boop');
-                };
-
-                shared.on('beep', onBeep);
-
-                setTimeout(testDone, 100);
-
-                // done();
-            });
-
-            script.test('1', (testDone) => {
-
-                shared.on('bar', () => {
-
-                    throw new Error('foo failed !');
-                });
-
-                setTimeout(() => {
-
-                    shared.emit('foo');
-                }, 50);
-            });
-
-            script.test('2', (testDone) => {
-
-                shared.on('boop', () => {
-
-                    throw new Error('beep failed !');
-                });
-
-                setTimeout(() => {
-
-                    shared.emit('beep');
-                }, 100);
-            });
-
-            script.experiment('parallel shared test', () => {
-
-                script.test('3', (testDone) => {
-
-                    shared.on('bar', () => {
-
-                        throw new Error('foo failed !');
-                    });
-
-                    setTimeout(() => {
-
-                        shared.emit('foo');
-                    }, 100);
-                });
-
-                script.test('4', (testDone) => {
-
-                    shared.on('boop', () => {
-
-                        throw new Error('beep failed !');
-                    });
-
-                    setTimeout(() => {
-
-                        shared.emit('beep');
-                    }, 50);
-                });
-            });
-        });
-
-        Lab.report(script, { output: false, assert: false }, (err, code, output) => {
-
-            expect(err).not.to.exist();
-            expect(code).to.equal(1);
-            expect(output).to.contain('4 of 4 tests failed');
-            expect(output.match(/Thrown error received in test "Before each parallel shared test"/g)).to.have.length(8);
-            expect(output.match(/foo failed/g).length).to.equal(3);
-            expect(output.match(/beep failed/g).length).to.equal(3);
-            done();
-        });
+        const { code, output } = await  Lab.report(script, { output: false, assert: false });
+        expect(code).to.equal(1);
+        expect(output).to.contain('1 of 2 tests failed');
+        expect(output.match(/assertion failed !/g)).to.have.length(2);
     });
 
     describe('global timeout functions', () => {
@@ -2059,24 +1281,22 @@ describe('Runner', () => {
         // global.setTimeout uses it [1] so if the runnable.js keeps a copy of
         // global.setTimeout (like it's supposed to), that will blow up.
         // [1]: https://github.com/joyent/node/blob/7fc835afe362ebd30a0dbec81d3360bd24525222/lib/timers.js#L74
-        const overrideGlobals = function (testDone) {
+        const overrideGlobals = function () {
 
             const fn = function () {};
             global.setTimeout = fn;
             global.clearTimeout = fn;
             global.setImmediate = fn;
-            testDone();
         };
 
-        const resetGlobals = function (testDone) {
+        const resetGlobals = function () {
 
             global.setTimeout = setTimeout;
             global.clearTimeout = clearTimeout;
             global.setImmediate = setImmediate;
-            testDone();
         };
 
-        it('setImmediate still functions correctly', (done) => {
+        it('setImmediate still functions correctly', async () => {
 
             const script = Lab.script();
             script.before(overrideGlobals);
@@ -2085,21 +1305,20 @@ describe('Runner', () => {
 
             script.experiment('test', () => {
 
-                script.test('1', (testDone) => {
+                script.test('1', () => {
 
-                    setImmediate(testDone);
+                    return new Promise((resolve) => {
+
+                        setImmediate(resolve);
+                    });
                 });
             });
 
-            Lab.report(script, { output: false, assert: false }, (err, code, output) => {
-
-                expect(err).not.to.exist();
-                expect(code).to.equal(0);
-                done();
-            });
+            const { code } = await Lab.report(script, { output: false, assert: false });
+            expect(code).to.equal(0);
         });
 
-        it('test timeouts still function correctly', (done) => {
+        it('test timeouts still function correctly', async () => {
 
             const script = Lab.script();
             script.before(overrideGlobals);
@@ -2108,22 +1327,15 @@ describe('Runner', () => {
 
             script.experiment('test', () => {
 
-                script.test('timeout', { timeout: 5 }, (testDone) => {
-
-                    testDone();
-                });
+                script.test('timeout', { timeout: 5 }, () => {});
             });
 
             const now = Date.now();
-            Lab.execute(script, null, null, (err, notebook) => {
-
-                expect(err).not.to.exist();
-                expect(Date.now() - now).to.be.below(100);
-                done();
-            });
+            await Lab.execute(script, null, null);
+            expect(Date.now() - now).to.be.below(100);
         });
 
-        it('setTimeout still functions correctly', (done) => {
+        it('setTimeout still functions correctly', async () => {
 
             const script = Lab.script();
             script.before(overrideGlobals);
@@ -2132,25 +1344,21 @@ describe('Runner', () => {
 
             script.experiment('test', { timeout: 5 }, () => {
 
-                script.test('timeout', { timeout: 0 }, (testDone) => {
+                script.test('timeout', { timeout: 0 }, () => {
 
-                    setTimeout(() => {
+                    return new Promise((resolve) => {
 
-                        testDone();
-                    }, 10);
+                        setTimeout(resolve, 10);
+                    });
                 });
             });
 
             const now = Date.now();
-            Lab.execute(script, null, null, (err, notebook) => {
-
-                expect(err).not.to.exist();
-                expect(Date.now() - now).to.be.above(9);
-                done();
-            });
+            await Lab.execute(script, null, null);
+            expect(Date.now() - now).to.be.above(9);
         });
 
-        it('setTimeout still functions correctly with non-integer timeout', (done) => {
+        it('setTimeout still functions correctly with non-integer timeout', async () => {
 
             const script = Lab.script();
             script.before(overrideGlobals);
@@ -2159,41 +1367,48 @@ describe('Runner', () => {
 
             script.experiment('test', { timeout: 5 }, () => {
 
-                script.test('timeout', { timeout: 'a' }, (testDone) => {
+                script.test('timeout', { timeout: 'a' }, () => {
 
-                    setTimeout(() => {
+                    return new Promise((resolve) => {
 
-                        testDone();
-                    }, 10);
+                        setTimeout(resolve, 10);
+                    });
                 });
             });
 
-            Lab.execute(script, null, null, (err, notebook) => {
-
-                expect(err).not.to.exist();
-                expect(notebook.failures).to.equal(1);
-                done();
-            });
+            const notebook = await Lab.execute(script, null, null);
+            expect(notebook.failures).to.equal(1);
         });
     });
 
-    it('fails with an unhandled Promise rejection if the specified flag is set', (done) => {
+    it('fails with a thrown error', async () => {
 
-        const script = Lab.script();
-        script.test('handles a Promise rejection', (done) => {
+        const script = Lab.script({ schedule: false });
+        script.test('handles a thrown error', () => {
 
-            Promise.reject(new Error('Rejection!'));
-            setImmediate(done);
+            throw new Error('Rejection!');
         });
 
-        Lab.execute(script, { rejections: true }, null, (err, notebook) => {
+        const notebook = await Lab.execute(script, null);
+        expect(notebook.tests).to.have.length(1);
+        expect(notebook.failures).to.equal(1);
+        expect(notebook.tests[0].err.toString()).to.contain('Rejection!');
+    });
 
-            expect(err).not.to.exist();
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.failures).to.equal(1);
-            expect(notebook.tests[0].err.toString()).to.contain('Rejection!');
-            done();
+    it('handles multiple rejections', async () => {
+
+        const script = Lab.script({ schedule: false });
+        script.test('handles multiple Promise rejection', () => {
+
+            return new Promise((resolve, reject) => {
+
+                reject('first');
+                reject('second');
+            });
         });
 
+        const notebook = await Lab.execute(script, null);
+        expect(notebook.tests).to.have.length(1);
+        expect(notebook.failures).to.equal(1);
     });
 });

--- a/test/transform.js
+++ b/test/transform.js
@@ -45,27 +45,25 @@ describe('Transform', () => {
 
     Lab.coverage.instrument({ coveragePath: Path.join(__dirname, './transform/'), coverageExclude: 'exclude', transform: internals.transform });
 
-    it('instruments and measures coverage', (done) => {
+    it('instruments and measures coverage', () => {
 
         const Test = require('./transform/basic-transform');
         expect(Test.method(1)).to.equal(3);
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'transform/basic-transform') });
         expect(cov.percent).to.equal(100);
-        done();
     });
 
-    it('does not transform unneeded files', (done) => {
+    it('does not transform unneeded files', () => {
 
         const Test = require('./transform/basic');
         expect(Test.method(1)).to.equal('!NOCOMPILE!');
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'transform/basic') });
         expect(cov.percent).to.equal(100);
-        done();
     });
 
-    it('unit tests transform.retrieveFile', (done) => {
+    it('unit tests transform.retrieveFile', () => {
 
         let content = Transform.retrieveFile('test/transform/exclude/lab-noexport.js');
         expect(content).to.contain('// no code');
@@ -75,11 +73,9 @@ describe('Transform', () => {
 
         content = Transform.retrieveFile('doesnotexist');
         expect(content).to.equal(null);
-
-        done();
     });
 
-    it('should return transformed file through for relative (cwd-rooted) and absolute paths', (done) => {
+    it('should return transformed file through for relative (cwd-rooted) and absolute paths', () => {
 
         require('./transform/basic-transform'); // prime the cache
 
@@ -88,30 +84,26 @@ describe('Transform', () => {
 
         const abs = Transform.retrieveFile(process.cwd() + '/test/transform/basic-transform.new');
         expect(abs).to.not.contain('!NOCOMPILE!');
-
-        done();
     });
 });
 
 describe('Transform.install', () => {
 
-    lab.before((done) => {
+    lab.before(() => {
 
         internals.js = require.extensions['.js'];
         internals.new = require.extensions['.new'];
         internals.inl = require.extensions['.inl'];
-        done();
     });
 
-    lab.after((done) => {
+    lab.after(() => {
 
         require.extensions['.js'] = internals.js;
         require.extensions['.new'] = internals.new;
         require.extensions['.inl'] = internals.inl;
-        done();
     });
 
-    it('works correctly', (done) => {
+    it('works correctly', () => {
 
         Transform.install({ transform: internals.transform });
 
@@ -120,7 +112,5 @@ describe('Transform.install', () => {
 
         const Test2 = require('./transform/exclude/transform-basic');
         expect(Test2.method()).to.equal(1);
-
-        done();
     });
 });

--- a/test/transform/exclude/ext-test.new.js
+++ b/test/transform/exclude/ext-test.new.js
@@ -21,10 +21,9 @@ const expect = Code.expect;
 
 describe('Test a transformed file', () => {
 
-    it('that adds 2 to input', (done) => {
+    it('that adds 2 to input', () => {
 
     	// Test.method(5) will be replaced by Test.method(1) during transform
         expect(!Test.method(5)!).to.equal(3);
-        done();
     });
 });

--- a/test/transform/exclude/transform-test.js
+++ b/test/transform/exclude/transform-test.js
@@ -21,9 +21,8 @@ const expect = Code.expect;
 
 describe('Test a transformed file', () => {
 
-    it('that adds 2 to input', (done) => {
+    it('that adds 2 to input', () => {
 
         expect(Test.method(1)).to.equal(3);
-        done();
     });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -22,7 +22,7 @@ const expect = Code.expect;
 
 describe('Utils', () => {
 
-    it('merges options', (done) => {
+    it('merges options', () => {
 
         const parent = {
             a: 1,
@@ -36,10 +36,9 @@ describe('Utils', () => {
 
         const merged = Utils.mergeOptions(parent, child);
         expect(merged).to.equal({ a: 1, b: 3, c: 4 });
-        done();
     });
 
-    it('merges options (no child)', (done) => {
+    it('merges options (no child)', () => {
 
         const parent = {
             a: 1,
@@ -48,10 +47,9 @@ describe('Utils', () => {
 
         const merged = Utils.mergeOptions(parent, null);
         expect(merged).to.equal({ a: 1, b: 2 });
-        done();
     });
 
-    it('merges options (no parent)', (done) => {
+    it('merges options (no parent)', () => {
 
         const child = {
             b: 3,
@@ -60,10 +58,9 @@ describe('Utils', () => {
 
         const merged = Utils.mergeOptions(null, child);
         expect(merged).to.equal({ b: 3, c: 4 });
-        done();
     });
 
-    it('ignores parent options', (done) => {
+    it('ignores parent options', () => {
 
         const parent = {
             a: 1,
@@ -79,10 +76,9 @@ describe('Utils', () => {
 
         const merged = Utils.mergeOptions(parent, child, ['e', 'f']);
         expect(merged).to.equal({ a: 1, b: 3, c: 4 });
-        done();
     });
 
-    it('copy child keys onto parent', (done) => {
+    it('copy child keys onto parent', () => {
 
         const parent = {
             a: 1,
@@ -98,6 +94,5 @@ describe('Utils', () => {
 
         Utils.applyOptions(parent, child);
         expect(parent).to.equal({ a: 1, b: 3, c: 4, e: 5, f: 6 });
-        done();
     });
 });


### PR DESCRIPTION
Closes #752 
Closes #765 

* Remove support for `(done)` callback on tests
* Move to `flags` object passed into tests with `onCleanup` and `note` functions 
* Removed support for parallel mode
* Removed `debug` mode, this is now always on