### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Lead Maintainer: [Wyatt Preul](https://github.com/geek)
 ## Command Line
 
 **lab** supports the following command line options:
-- `-a`, `--assert` - name of assert library to use. To disable assertion library set to `false`. Defaults to `code`.
+- `-a`, `--assert` - name of assert library to use. To disable assertion library set to `false`.
 - `--bail` - terminate the process with a non-zero exit code on the first test failure. Defaults to `false`.
 - `-c`, `--coverage` - enables code coverage analysis.
 - `--coverage-path` - sets code coverage path.


### PR DESCRIPTION
remove sentence about defaulting to `code` as the default assertion library.