### PR TITLE
Fix test script error duplicates

### DIFF
--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -45,7 +45,13 @@ internals.Reporter.prototype.end = function (notebook) {
     };
 
     if (notebook.errors.length) {
-        report.errors = notebook.errors;
+        report.errors = notebook.errors.map((err) => {
+
+            return {
+                message: err.message,
+                stack: err.stack
+            };
+        });
     }
 
     if (notebook.coverage) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -263,9 +263,7 @@ internals.executeExperiments = async function (experiments, state, skip) {
             }
             catch (ex) {
                 internals.fail([experiment], state, skip, '\'before\' action failed');
-                if (!state.report.errors.includes(ex)) {
-                    state.report.errors.push(ex);
-                }
+                state.report.errors.push(ex);
 
                 // skip the tests and afters since the before fails
                 continue;
@@ -355,6 +353,7 @@ internals.executeTests = async function (experiment, state, skip) {
         }
         catch (ex) {
             internals.failTest(test, state, skip, ex);
+            state.report.errors.push(ex);
             return Promise.resolve();
         }
 
@@ -380,9 +379,8 @@ internals.executeTests = async function (experiment, state, skip) {
             await internals.executeDeps(afters, state);
         }
         catch (ex) {
-            if (!state.report.errors.includes(ex)) {
-                state.report.errors.push(ex);
-            }
+            state.report.failures++;
+            state.report.errors.push(ex);
         }
 
         return Promise.resolve();
@@ -569,7 +567,6 @@ internals.protect = function (item, state) {
                 finish();
             }
             catch (ex) {
-                state.report.errors.push(ex);
                 return finish(ex);
             }
         });

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -419,7 +419,7 @@ describe('Reporter', () => {
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', () => {
+                script.test('fails', () => {
 
                     const error = new Error('boom');
                     error.data = 'abc';
@@ -430,8 +430,7 @@ describe('Reporter', () => {
             const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, leaks: false, output: false, assert: false });
 
             expect(code).to.equal(1);
-            expect(output).to.contain('There were 1 test script error');
-            expect(output).to.contain('Additional error data');
+            expect(output).to.contain('1 of 1 tests failed');
             expect(output).to.contain('Failed tests');
         });
 
@@ -440,7 +439,7 @@ describe('Reporter', () => {
             const script = Lab.script();
             script.experiment('test', () => {
 
-                script.test('works', () => {
+                script.test('fails', () => {
 
                     const error = new Error('boom');
                     error.data = [1, 2, 3];
@@ -450,8 +449,10 @@ describe('Reporter', () => {
 
             const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, leaks: false, output: false, assert: false });
             expect(code).to.equal(1);
-            expect(output).to.contain('There were 1 test script error');
+            expect(output).to.contain('1 of 1 tests failed');
             expect(output).to.contain('Failed tests');
+            expect(output).to.contain('Additional error data:');
+            expect(output).to.contain('[1,2,3]');
         });
 
         it('generates a report with caught error (data object)', async () => {
@@ -1160,14 +1161,15 @@ describe('Reporter', () => {
 
                 script.after(() => {
 
-                    return Promise.reject(new Error());
+                    throw new Error('failed');
                 });
             });
 
             const { code, output } = await Lab.report(script, { reporter: 'json', output: false });
             const result = JSON.parse(output);
             expect(code).to.equal(1);
-            expect(result.errors).to.have.length(2);
+            expect(result.errors).to.have.length(1);
+            expect(result.errors[0].message).to.equal('failed');
         });
 
         it('generates a report with coverage', async () => {
@@ -1548,7 +1550,7 @@ describe('Reporter', () => {
             expect(code).to.equal(1);
             expect(output).to.contain([
                 'tests="5"',
-                'errors="2"',
+                'errors="0"',
                 'skipped="2"',
                 'failures="2"',
                 '<failure message="Expected true to equal specified value: false" type="Error">'

--- a/test/runner.js
+++ b/test/runner.js
@@ -255,43 +255,11 @@ describe('Runner', () => {
             });
 
             const notebook = await Lab.execute(script, {}, null);
-            expect(notebook.errors[0].message).to.contain('A reason why this test failed');
-        });
-
-        it(`should fail "${fnName}" that calls the callback with an error`, async () => {
-
-            const script = Lab.script({ schedule: false });
-            script.describe('a test group', () => {
-
-                script.test('a', () => {});
-
-                script[fnName](() => {
-
-                    return Promise.reject(new Error('A reason why this test failed'));
-                });
-            });
-
-            const notebook = await Lab.execute(script, {}, null);
+            expect(notebook.failures).to.equal(1);
             expect(notebook.errors[0].message).to.contain('A reason why this test failed');
         });
 
         it(`should not fail "${fnName}" that returns a resolved promise`, async () => {
-
-            const script = Lab.script({ schedule: false });
-            script.describe('a test group', () => {
-
-                script.test('a', () => {});
-
-                script[fnName](() => {});
-            });
-
-            const notebook = await Lab.execute(script, {}, null);
-            expect(notebook.tests).to.have.length(1);
-            expect(notebook.failures).to.equal(0);
-            expect(notebook.errors.length).to.equal(0);
-        });
-
-        it(`should not fail "${fnName}" calls the callback without an error`, async () => {
 
             const script = Lab.script({ schedule: false });
             script.describe('a test group', () => {
@@ -1228,7 +1196,7 @@ describe('Runner', () => {
         const { code, output } = await Lab.report(script, { output: false, assert: false });
         expect(code).to.equal(1);
         expect(output).to.contain('2 of 2 tests failed');
-        expect(output.match(/assertion failed !/g)).to.have.length(4);
+        expect(output.match(/assertion failed !/g)).to.have.length(2);
     });
 
     it('reports errors with shared event emitters and nested experiments with a single deep failure', async () => {
@@ -1272,7 +1240,7 @@ describe('Runner', () => {
         const { code, output } = await  Lab.report(script, { output: false, assert: false });
         expect(code).to.equal(1);
         expect(output).to.contain('1 of 2 tests failed');
-        expect(output.match(/assertion failed !/g)).to.have.length(2);
+        expect(output.match(/assertion failed !/g)).to.have.length(1);
     });
 
     describe('global timeout functions', () => {


### PR DESCRIPTION
* JSON reporter now maps error object fully
* Test errors are no longer reported with test script errors