### PR TITLE
Fix for node 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "4"
   - "6"
   - "8"
+  - "9"
   - "node"
 
 sudo: false

--- a/lib/leaks.js
+++ b/lib/leaks.js
@@ -88,6 +88,12 @@ exports.detect = function (customGlobals) {
         }
     }
 
+    // $lab:coverage:off$
+    if (global.Atomics) {
+        whitelist.Atomics = true;
+    }
+    // $lab:coverage:on$
+
     if (global.Proxy) {
         whitelist.Proxy = true;
     }
@@ -95,6 +101,12 @@ exports.detect = function (customGlobals) {
     if (global.Reflect) {
         whitelist.Reflect = true;
     }
+
+    // $lab:coverage:off$
+    if (global.SharedArrayBuffer) {
+        whitelist.SharedArrayBuffer = true;
+    }
+    // $lab:coverage:on$
 
     // $lab:coverage:off$
     if (global.WebAssembly) {


### PR DESCRIPTION
Backported from lab 15. Also created a new branch `v14.x.x` to be able to PR. Mind the npm tag when publishing not to override `latest`.