### PR TITLE
Added index.d.ts to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@
 !.npmignore
 !.eslintignore
 !README.md
+!index.d.ts


### PR DESCRIPTION
The index.d.ts was never added to the .npmignore file causing it to get stripped out during npm installs. This should restore typings when using typescript.