### PR TITLE
Support object rest/spread under eslint

### DIFF
--- a/lib/linter/.eslintrc.js
+++ b/lib/linter/.eslintrc.js
@@ -3,6 +3,9 @@
 module.exports = {
     extends: require.resolve('eslint-config-hapi'),
     parserOptions: {
-        ecmaVersion: 8
+        ecmaVersion: 8,
+        ecmaFeatures: {
+            experimentalObjectRestSpread: true
+        }
     }
 };

--- a/test/lint/eslint/object-rest-spread/success.js
+++ b/test/lint/eslint/object-rest-spread/success.js
@@ -1,0 +1,16 @@
+'use strict';
+
+// Load modules
+
+
+// Declare internals
+
+const internals = {};
+
+
+exports.method = function (value) {
+
+    const { a, ...rest } = { a: 1, b: 2, c: 3 };
+
+    return { a, ...rest };
+};

--- a/test/linters.js
+++ b/test/linters.js
@@ -114,6 +114,20 @@ describe('Linters - eslint', () => {
         expect(checkedFile.errors.length).to.equal(1);
     });
 
+    it('allows object rest/spread properties', async () => {
+
+        const path = Path.join(__dirname, 'lint', 'eslint', 'object-rest-spread');
+        const result = await Linters.lint({ lintingPath: path, linter: 'eslint' });
+
+        expect(result.lint).to.exist();
+
+        const eslintResults = result.lint;
+        expect(eslintResults).to.have.length(1);
+
+        const checkedFile = eslintResults[0];
+        expect(checkedFile.errors.length).to.equal(0);
+    });
+
     it('should pass options and not find any files', async () => {
 
         const lintOptions = JSON.stringify({ extensions: ['.jsx'] });


### PR DESCRIPTION
Object rest/spread has been supported in node since at least v8.6.0 ([here](http://node.green/#ESNEXT-candidate--stage-3--object-rest-spread-properties)), so I figured it may be appropriate to support that under our eslint config.  That is all :)

Here are the relevant eslint docs: https://eslint.org/docs/1.0.0/user-guide/configuring#specifying-language-options