### PR TITLE
Fail test if a falsy value is thrown by the test

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -578,7 +578,7 @@ internals.protect = function (item, state) {
                 finish();
             }
             catch (ex) {
-                return finish(ex);
+                return finish(ex || 'reject');
             }
         });
     });


### PR DESCRIPTION
This fixes #812 _awaiting a rejected promise can still pass test_. All the info can be found here.