### PR TITLE
Bump diff to 3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "bossy": "4.x.x",
-    "diff": "3.4.x",
+    "diff": "3.5.x",
     "eslint": "4.18.x",
     "eslint-config-hapi": "11.x.x",
     "eslint-plugin-hapi": "4.x.x",


### PR DESCRIPTION
Got an alert for a security issue on diff (https://snyk.io/vuln/npm:diff:20180305).

Unlikely lab would be the sole culprit but still, satisfying CI for worried people 🙃