### PR TITLE
Bump diff to 3.5 (v14.x.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "bossy": "3.x.x",
     "code": "4.1.x",
-    "diff": "3.3.x",
+    "diff": "3.5.x",
     "eslint": "4.7.x",
     "eslint-config-hapi": "10.x.x",
     "eslint-plugin-hapi": "4.x.x",


### PR DESCRIPTION
Got an alert for a security issue on diff (https://snyk.io/vuln/npm:diff:20180305).

This is the same as https://github.com/hapijs/lab/pull/816 but targets the `v14.x.x` branch as we are still in the process of moving over to the new hapi/lab setup.