### PR TITLE
Ignore default-plan-threshold for anything else than tests

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -533,7 +533,8 @@ internals.protect = function (item, state) {
                     }
                 }
             }
-            else if (state.options['default-plan-threshold'] &&
+            else if (item.path &&   // Only check the plan threshold for actual tests (ie. ignore befores and afters)
+                state.options['default-plan-threshold'] &&
                 (item.assertions === undefined ||
                 item.assertions < state.options['default-plan-threshold'])) {
                 const planMessage = (item.assertions === undefined)

--- a/test/runner.js
+++ b/test/runner.js
@@ -1202,6 +1202,26 @@ describe('Runner', () => {
         expect(output).to.not.match(/Expected at least \d+ assertions, but found \d+/);
     });
 
+    it('extends report with assertions library support (default minimum planned assertions)', async () => {
+
+        const script = Lab.script();
+        const assertions = Code;
+        script.experiment('test', () => {
+
+            script.before(() => {});
+
+            script.test('1', () => {
+
+                assertions.expect(true).to.be.true();
+            });
+        });
+
+        const { code, output } = await Lab.report(script, { output: false, assert: assertions, 'default-plan-threshold': 1 });
+        expect(code).to.equal(0);
+        expect(output).to.match(/Assertions count: \d+/);
+        expect(output).to.not.match(/Expected at least \d+ assertions, but found \d+/);
+    });
+
     it('extends report with assertions library support (local override and default minimum planned assertions error)', async () => {
 
         const script = Lab.script();


### PR DESCRIPTION
Follow-up to #819.

I don't think the default assertion threshold should apply to befores and afters, I didn't notice it in the initial PR but I don't think this part makes sense after using it. Would you agree ?