### PR TITLE
(v14.x.x) update eslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ Sometimes you want to disable code coverage for specific lines, and have the cov
 // There is no way to cover this in node 0.10
 /* $lab:coverage:off$ */
 if (typeof value === 'symbol') {
-    return '[' + value.toString() + ']';
+    // do something with value
 }
 /* $lab:coverage:on$ */
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "bossy": "3.x.x",
     "code": "4.1.x",
     "diff": "3.5.x",
-    "eslint": "4.7.x",
+    "eslint": "4.19.x",
     "eslint-config-hapi": "10.x.x",
     "eslint-plugin-hapi": "4.x.x",
     "espree": "3.5.x",
@@ -44,7 +44,7 @@
     "posttest": "npm run lint-md",
     "test-cov-html": "node ./bin/_lab -fL -r html -m 3000 -o coverage.html",
     "lint": "node ./bin/_lab -d -f -L",
-    "lint-md": "eslint --config hapi --rule 'strict: 0, eol-last: 0' --plugin markdown --ext md  ."
+    "lint-md": "eslint --config hapi --rule 'strict: 0, eol-last: 0' --plugin markdown --ext md --parser-options 'ecmaVersion: 6' ."
   },
   "license": "BSD-3-Clause"
 }

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -1598,7 +1598,7 @@ describe('Reporter', () => {
                 expect(output)
                     .to.contain('<div class="stats medium">')
                     .and.to.contain('semi - Missing semicolon')
-                    .and.to.contain('<span class="warnings" data-tooltip="no-eq-null - Use &#8216;&#x3d;&#x3d;&#x3d;&#8217; to compare with &#8216;null&#8217;."></span>')
+                    .and.to.contain('<span class="warnings" data-tooltip="no-eq-null - Use &#x27;&#x3d;&#x3d;&#x3d;&#x27; to compare with null."></span>')
                     .and.to.contain('<span class="lint-errors low">11</span>')
                     .and.to.contain('<span class="lint-warnings low">1</span>')
                     .and.to.contain('<li class="lint-entry">L13 - <span class="level-ERROR">ERROR</span> - indent - Expected indentation of 4 spaces')
@@ -1606,7 +1606,7 @@ describe('Reporter', () => {
                     .and.to.contain('<li class="lint-entry">L15 - <span class="level-ERROR">ERROR</span> - indent - Expected indentation of 8 spaces')
                     .and.to.contain('<li class="lint-entry">L18 - <span class="level-ERROR">ERROR</span> - indent - Expected indentation of 8 spaces')
                     .and.to.contain('<li class="lint-entry">L21 - <span class="level-ERROR">ERROR</span> - indent - Expected indentation of 4 spaces')
-                    .and.to.contain('<li class="lint-entry">L21 - <span class="level-WARNING">WARNING</span> - no-eq-null - Use &#8216;&#x3d;&#x3d;&#x3d;&#8217; to compare with &#8216;null&#8217;.</li>')
+                    .and.to.contain('<li class="lint-entry">L21 - <span class="level-WARNING">WARNING</span> - no-eq-null - Use &#x27;&#x3d;&#x3d;&#x3d;&#x27; to compare with null.</li>')
                     .and.to.contain('<li class="lint-entry">L21 - <span class="level-ERROR">ERROR</span> - eqeqeq - Expected &#x27;&#x3d;&#x3d;&#x3d;&#x27; and instead saw &#x27;&#x3d;&#x3d;&#x27;.</li>')
                     .and.to.contain('<li class="lint-entry">L21 - <span class="level-ERROR">ERROR</span> - semi - Missing semicolon.</li>')
                     .and.to.contain('<li class="lint-entry">L23 - <span class="level-ERROR">ERROR</span> - indent - Expected indentation of 4 spaces');


### PR DESCRIPTION
Addresses https://snyk.io/vuln/npm:eslint:20180222 and `npm WARN ajv-keywords@3.1.0 requires a peer of ajv@^6.0.0 but none is installed. You must install peer dependencies yourself.`

Don't think this is a breaking change?