### PR TITLE
Wait for stdout to stop writing to exit

### DIFF
--- a/bin/lab
+++ b/bin/lab
@@ -53,7 +53,19 @@ const main = async () => {
     if (typeof code !== 'number') {
         code = code[Object.keys(code)[0]];
     }
-    process.exit(code);
+
+    let exitTimeout;
+    const tryToStop = () => {
+
+        clearTimeout(exitTimeout);
+        exitTimeout = setTimeout(() => {
+
+            process.exit(code);
+        }, 5);
+    };
+
+    process.stdout.on('data', tryToStop);
+    tryToStop();
 };
 
 main();


### PR DESCRIPTION
Naive approach to prevent lab from exiting prematurely. It watches stdout until it stops emitting things. 5 seems to be a sweet spot but I guess it could be system dependent.