### PR TITLE
Fix coverage on transformed files. Fixes #826.

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -302,7 +302,7 @@ internals.instrument = function (filename) {
 
     // Store original source
 
-    const transformedFile = content.replace(/\/\/\#(.*)$/, '');
+    const transformedFile = content.replace(/\/\/\#(.*)\r?\n?$/, '');
     internals.sources[filename] = transformedFile.replace(/(\r\n|\n|\r)/gm, '\n').split('\n');
 
     // Setup global report container
@@ -372,6 +372,10 @@ internals.instrument = function (filename) {
                 }
                 return commented;
             }).reduce((a, b) => a + b, 0);
+
+        if (transformedFile !== content) {
+            record.sloc++;
+        }
     }
 
     return chunks.join('');

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -445,7 +445,7 @@ internals.createItemTimeout = (item, ms, finish) => {
 
     return setTimeout(() => {
 
-        const error = new Error('Timed out (' + ms + 'ms) - ' + item.title);
+        const error = new Error(`Timed out (${ms}ms) - ${item.title}`);
         error.timeout = true;
         finish(error, 'timeout');
     }, ms);
@@ -566,9 +566,6 @@ internals.protect = function (item, state) {
         };
 
         const ms = item.options.timeout !== undefined ? item.options.timeout : state.options.timeout;
-        if (ms) {
-            timeoutId = internals.createItemTimeout(item, ms, finish);
-        }
 
         // covered by test/cli_error/failure.js
         /* $lab:coverage:off$ */
@@ -588,6 +585,10 @@ internals.protect = function (item, state) {
         process.on('uncaughtException', processUncaughtExceptionHandler);
 
         setImmediate(async () => {
+
+            if (ms) {
+                timeoutId = internals.createItemTimeout(item, ms, finish);
+            }
 
             try {
                 await item.fn.call(null, flags);

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -36,6 +36,15 @@ describe('Coverage', () => {
         expect(cov.percent).to.equal(100);
     });
 
+    it('computes sloc without comments on transformed file', () => {
+
+        const Test = require('./coverage/transformed');
+        Test.method(1);
+
+        const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/transformed') });
+        expect(cov.percent).to.equal(100);
+    });
+
     it('computes sloc on script that has no comments', () => {
 
         const Test = require('./coverage/nocomment');

--- a/test/coverage/transformed.js
+++ b/test/coverage/transformed.js
@@ -1,0 +1,10 @@
+'use strict';
+exports.__esModule = true;
+// Load modules
+// Declare internals
+var internals = {};
+function method(value) {
+    return value;
+}
+exports.method = method;
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidC5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbInQudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsWUFBWSxDQUFDOztBQUViLGVBQWU7QUFHZixvQkFBb0I7QUFFcEIsSUFBTSxTQUFTLEdBQUcsRUFBRSxDQUFDO0FBR3JCLGdCQUF1QixLQUFLO0lBRXhCLE9BQU8sS0FBSyxDQUFDO0FBQ2pCLENBQUM7QUFIRCx3QkFHQyJ9


### PR DESCRIPTION
SLOC computations were slightly off on transformed files due to the removal of the final `//# sourceMap....` thingy.

Also moved the triggering of the test timeout, this was causing flaky tests on very short timeouts.