### PR TITLE
Revert "Wait for stdout to stop writing to exit"

### DIFF
--- a/bin/lab
+++ b/bin/lab
@@ -53,19 +53,7 @@ const main = async () => {
     if (typeof code !== 'number') {
         code = code[Object.keys(code)[0]];
     }
-
-    let exitTimeout;
-    const tryToStop = () => {
-
-        clearTimeout(exitTimeout);
-        exitTimeout = setTimeout(() => {
-
-            process.exit(code);
-        }, 5);
-    };
-
-    process.stdout.on('data', tryToStop);
-    tryToStop();
+    process.exit(code);
 };
 
 main();


### PR DESCRIPTION
Reverts hapijs/lab#829

This is causing the following error to occur on node 10:

```
events.js:167
      throw er; // Unhandled 'error' event
      ^

Error: read ENOTCONN
    at WriteStream.Socket._read (net.js:530:20)
    at WriteStream.Readable.read (_stream_readable.js:458:10)
    at resume_ (_stream_readable.js:897:12)
    at process._tickCallback (internal/process/next_tick.js:174:19)
Emitted 'error' event at:
    at emitErrorNT (internal/streams/destroy.js:92:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:59:3)
    at process._tickCallback (internal/process/next_tick.js:174:19)
```