### PR TITLE
DeprecationWarning: `node --inspect --debug-brk` is deprecated

### DIFF
--- a/bin/lab
+++ b/bin/lab
@@ -2,7 +2,7 @@
 
 'use strict';
 
-const inspectPattern = /^(--inspect|--inspect-brk)(=\d+)?$/;
+const inspectPattern = /^(--inspect|--inspect-brk|--debug|--debug-brk)(=\d+)?$/; // --debug and --debug-brk are deprecated
 const inspectArg = process.argv.find((argument) => {
 
     return inspectPattern.test(argument);
@@ -15,15 +15,12 @@ if (process.env.NODE_DEBUG_OPTION || inspectArg) {
     const lab = process.argv[1];
     const args = [];
 
-    if (process.env.NODE_DEBUG_OPTION) { // WebStorm debugger
+    if ( inspectArg ) args.push(inspectArg); // V8 inspector
+    else if ( process.env.NODE_DEBUG_OPTION ) {
         args.push.apply(args, process.env.NODE_DEBUG_OPTION.split(' '));
         delete process.env.NODE_DEBUG_OPTION;
     }
-    else { // V8 inspector
-        args.push(inspectArg);
-        args.push('--debug-brk');
-    }
-
+    
     args.push(lab);
 
     // Remove node, lab, and the --inspect that might have been provided in the options


### PR DESCRIPTION
I was receiving `(node:703) [DEP0062] DeprecationWarning: `node --inspect --debug-brk` is deprecated. Please use `node --inspect-brk` instead.` because --debug-brk was being added on like 24, but line 23 already ensures that either --inspect or --inspect-brk will already be passed because code only makes it here IF not null at like 11 and that is only set when matched from line 5 which I've updated in include matching for the legacy --debug-brk and --debug (for those not up to speed yet) and cleaned up the logic/code.