### PR TITLE
Add WHATWG Encoding API globals

### DIFF
--- a/lib/leaks.js
+++ b/lib/leaks.js
@@ -121,6 +121,18 @@ exports.detect = function (customGlobals) {
     }
     // $lab:coverage:on$
 
+    // $lab:coverage:off$
+    if (global.TextEncoder) {
+        whitelist.TextEncoder = true;
+    }
+    // $lab:coverage:on$
+
+    // $lab:coverage:off$
+    if (global.TextDecoder) {
+        whitelist.TextDecoder = true;
+    }
+    // $lab:coverage:on$
+
     if (global.DTRACE_HTTP_SERVER_RESPONSE) {
         whitelist.DTRACE_HTTP_SERVER_RESPONSE = true;
         whitelist.DTRACE_HTTP_SERVER_REQUEST = true;


### PR DESCRIPTION
`TextEncoder` and `TextDecoder` may become global variables in Node 11.

I don't expect this PR to be merged now, I'm just sending this as a tiny, early heads-up. 🙂 

Issue: https://github.com/nodejs/node/issues/20365
PR: https://github.com/nodejs/node/pull/20662