### PR TITLE
Update coverage ECMA version to 9 (2018).

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -270,7 +270,7 @@ internals.instrument = function (filename) {
         ecmaFeatures: {
             experimentalObjectRestSpread: true
         },
-        ecmaVersion: 8
+        ecmaVersion: 9
     });
 
     // Process comments


### PR DESCRIPTION
Close if wrong approach but with Node 10 we now have async iterators / generators. While I can have eslint use ecma 2018, running lab with coverage without this change pukes with `SyntaxError: Unexpected token await` errors.