### PR TITLE
update eslint-config-hapi dependency

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -112,6 +112,7 @@ internals.traverse = function (paths, options) {
         if (err.code !== 'ENOENT') {
             throw err;
         }
+
         console.error('Could not find test file or directory \'' + nextPath + '\'.');
         process.exit(1);
     }
@@ -143,6 +144,7 @@ internals.traverse = function (paths, options) {
         }
 
         const pkg = require(file);
+
         if (pkg.lab &&
             pkg.lab._root) {
 

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -111,6 +111,7 @@ internals.instrument = function (filename) {
         if (!(line in nodesByLine)) {
             nodesByLine[line] = [];
         }
+
         nodesByLine[line].push(node.type);
     };
 
@@ -147,6 +148,7 @@ internals.instrument = function (filename) {
         for (let i = node.range[0]; i <= node.range[1]; ++i) {
             bypassTests.push(bypass[i]);
         }
+
         if (bypassTests.every((test) => test)) {
             return;
         }
@@ -370,6 +372,7 @@ internals.instrument = function (filename) {
                         }
                     }
                 }
+
                 return commented;
             }).reduce((a, b) => a + b, 0);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,9 +17,13 @@ const internals = {};
 // Exports
 
 exports.report = Runner.report;
+
 exports.execute = Runner.execute;
+
 exports.coverage = Coverage;
+
 exports.leaks = Leaks;
+
 exports.assertions = null;                                              // Set by the -a command line option
 
 
@@ -101,10 +105,12 @@ exports.script = function (options) {
 };
 
 
-internals.experiment = function (title /*, options, fn */) {
+internals.experiment = function (title, options, fn) {
 
-    const options = arguments.length === 3 ? arguments[1] : {};
-    const fn = arguments.length === 3 ? arguments[2] : arguments[1];
+    if (arguments.length !== 3) {
+        fn = options;
+        options = {};
+    }
 
     const settings = Utils.mergeOptions(this._current.options, options, ['only']);
 
@@ -126,7 +132,7 @@ internals.experiment = function (title /*, options, fn */) {
         this.setOnly(child, null, this._path);
     }
 
-    fn.call(null);
+    fn.call(null);  // eslint-disable-line no-useless-call
 
     this._titles.pop();
     this._path = this._titles.concat();                      // Clone
@@ -135,10 +141,12 @@ internals.experiment = function (title /*, options, fn */) {
 };
 
 
-internals.before = function (/* options, */ fn) {
+internals.before = function (options, fn) {
 
-    const options = arguments.length === 2 ? arguments[0] : {};
-    fn = arguments.length === 2 ? arguments[1] : fn;
+    if (arguments.length !== 2) {
+        fn = options;
+        options = {};
+    }
 
     Hoek.assert(fn, `before in "${this._current.title}" requires a function argument`);
 
@@ -153,10 +161,12 @@ internals.before = function (/* options, */ fn) {
 };
 
 
-internals.after = function (/* options, */ fn) {
+internals.after = function (options, fn) {
 
-    const options = arguments.length === 2 ? arguments[0] : {};
-    fn = arguments.length === 2 ? arguments[1] : fn;
+    if (arguments.length !== 2) {
+        fn = options;
+        options = {};
+    }
 
     Hoek.assert(fn, `after in "${this._current.title}" requires a function argument`);
 
@@ -171,10 +181,12 @@ internals.after = function (/* options, */ fn) {
 };
 
 
-internals.beforeEach = function (/* options, */ fn) {
+internals.beforeEach = function (options, fn) {
 
-    const options = arguments.length === 2 ? arguments[0] : {};
-    fn = arguments.length === 2 ? arguments[1] : fn;
+    if (arguments.length !== 2) {
+        fn = options;
+        options = {};
+    }
 
     Hoek.assert(fn, `beforeEach in "${this._current.title}" requires a function argument`);
 
@@ -189,10 +201,12 @@ internals.beforeEach = function (/* options, */ fn) {
 };
 
 
-internals.afterEach = function (/* options, */ fn) {
+internals.afterEach = function (options, fn) {
 
-    const options = arguments.length === 2 ? arguments[0] : {};
-    fn = arguments.length === 2 ? arguments[1] : fn;
+    if (arguments.length !== 2) {
+        fn = options;
+        options = {};
+    }
 
     Hoek.assert(fn, `afterEach in "${this._current.title}" requires a function argument`);
 
@@ -207,10 +221,12 @@ internals.afterEach = function (/* options, */ fn) {
 };
 
 
-internals.test = function (title /*, options, fn */) {
+internals.test = function (title, options, fn) {
 
-    const options = arguments.length === 3 ? arguments[1] : {};
-    const fn = arguments.length === 3 ? arguments[2] : arguments[1];
+    if (arguments.length !== 3) {
+        fn = options;
+        options = {};
+    }
 
     const settings = Utils.mergeOptions(this._current.options, options, ['only']);
 
@@ -232,10 +248,12 @@ internals.test = function (title /*, options, fn */) {
 
 internals.skip = function (script, type) {
 
-    return function (title /*, options, fn */) {
+    return function (title, options, fn) {
 
-        const options = arguments.length === 3 ? arguments[1] : {};
-        const fn = arguments.length === 3 ? arguments[2] : arguments[1];
+        if (arguments.length !== 3) {
+            fn = options;
+            options = {};
+        }
 
         script[type](title, Utils.mergeOptions({ skip: true }, options), fn);
     };
@@ -244,10 +262,12 @@ internals.skip = function (script, type) {
 
 internals.only = function (script, type) {
 
-    return function (title /*, options, fn */) {
+    return function (title, options, fn) {
 
-        const options = arguments.length === 3 ? arguments[1] : {};
-        const fn = arguments.length === 3 ? arguments[2] : arguments[1];
+        if (arguments.length !== 3) {
+            fn = options;
+            options = {};
+        }
 
         script[type](title, Utils.mergeOptions({ only: true }, options), fn);
     };

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -241,9 +241,11 @@ internals.Reporter.prototype.end = function (notebook) {
     else {
         output += green(totalTests + ' tests complete');
     }
+
     if (skipped.length) {
         output += gray(` (${skipped.length} skipped)`);
     }
+
     output += '\n';
     output += 'Test duration: ' + notebook.ms + ' ms\n';
 

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -192,11 +192,13 @@ internals.Reporter.prototype.end = function (notebook) {
                 if (!(chunk.originalFilename in groupsByFiles)) {
                     groupsByFiles[chunk.originalFilename] = [];
                 }
+
                 const groups = groupsByFiles[chunk.originalFilename];
 
                 if (!(chunk.originalLine in groups)) {
                     groups[chunk.originalLine] = [];
                 }
+
                 groups[chunk.originalLine].push(chunk);
             });
 

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -27,6 +27,7 @@ internals.Reporter.prototype.insertYAMLBlock = function (test) {
         this.report('  stack: |-\n');
         this.report('    ' + test.err.stack.replace(/(\n|\r\n)/gm, '\n    ') + '\n');
     }
+
     this.report('  ...\n');
 };
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -96,6 +96,7 @@ exports.report = async (scripts, options) => {
             else {
                 console.error(ex.toString());
             }
+
             return process.exit(1);
             /* $lab:coverage:on$ */
         }
@@ -149,6 +150,7 @@ exports.execute = async function (scripts, options, reporter) {
             if (onlyNode.test) {
                 return `Test: ${onlyNode.test.title}`;
             }
+
             return `Experiment: ${onlyNode.path}`;
         });
         return Promise.reject(new Error('Multiple tests are marked as "only":\n\t' + paths.join('\n\t')));
@@ -372,6 +374,7 @@ internals.executeTests = async function (experiment, state, skip) {
             test.err = ex;
             test.timeout = ex.timeout;
         }
+
         test.duration = Date.now() - start;
 
         state.report.tests.push(test);
@@ -474,6 +477,7 @@ internals.protect = function (item, state) {
 
             flags.notes.push(note);
         };
+
         const willcall = new WillCall();
         flags.mustCall = willcall.expect.bind(willcall);
 
@@ -504,6 +508,7 @@ internals.protect = function (item, state) {
 
                     return reject(err);
                 };
+
                 /* $lab:coverage:on$ */
                 process.once('uncaughtException', onCleanupError);
 
@@ -555,6 +560,7 @@ internals.protect = function (item, state) {
                 const message = `Thrown error received in test "${item.title}" (${cause})`;
                 err = new Error(message);
             }
+
             isFirst = false;
 
             const callResults = willcall.check();
@@ -577,6 +583,7 @@ internals.protect = function (item, state) {
             failedWithUnhandledRejection = true;
             finish(err, 'unhandledRejection');
         };
+
         process.on('unhandledRejection', promiseRejectionHandler);
 
         const processUncaughtExceptionHandler = function (err) {
@@ -584,6 +591,7 @@ internals.protect = function (item, state) {
             failedWithUncaughtException = true;
             finish(err, 'uncaughtException');
         };
+
         /* $lab:coverage:on$ */
         process.on('uncaughtException', processUncaughtExceptionHandler);
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "bossy": "4.x.x",
     "diff": "3.5.x",
     "eslint": "4.19.x",
-    "eslint-config-hapi": "11.x.x",
+    "eslint-config-hapi": "12.x.x",
     "eslint-plugin-hapi": "4.x.x",
     "espree": "3.5.x",
     "find-rc": "3.0.x",

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -30,6 +30,7 @@ describe('Coverage', () => {
     it('computes sloc without comments', () => {
 
         const Test = require('./coverage/sloc');
+
         Test.method(1);
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/sloc') });
@@ -39,6 +40,7 @@ describe('Coverage', () => {
     it('computes sloc without comments on transformed file', () => {
 
         const Test = require('./coverage/transformed');
+
         Test.method(1);
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/transformed') });
@@ -48,6 +50,7 @@ describe('Coverage', () => {
     it('computes sloc on script that has no comments', () => {
 
         const Test = require('./coverage/nocomment');
+
         Test.method(1);
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/nocomment') });
@@ -57,6 +60,7 @@ describe('Coverage', () => {
     it('instruments and measures coverage', () => {
 
         const Test = require('./coverage/basic');
+
         Test.method(1);
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/basic') });
@@ -66,6 +70,7 @@ describe('Coverage', () => {
     it('measures coverage on an empty return statement', () => {
 
         const Test = require('./coverage/return');
+
         Test.method();
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/return') });
@@ -75,6 +80,7 @@ describe('Coverage', () => {
     it('identifies lines with partial coverage', () => {
 
         const Test = require('./coverage/partial');
+
         Test.method(1, 2, 3);
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/partial') });
@@ -87,6 +93,7 @@ describe('Coverage', () => {
     it('measures coverage of a file with test in the name', () => {
 
         const Test = require('./coverage/test-folder/test-name.js');
+
         Test.method();
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/test-folder'), coverageExclude: ['test', 'node_modules'] });
@@ -96,6 +103,7 @@ describe('Coverage', () => {
     it('can exclude individual files by name', () => {
 
         const Test = require('./coverage/test-folder/test-name.js');
+
         Test.method();
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/test-folder'), coverageExclude: ['test', 'node_modules', 'test-name.js'] });
@@ -105,6 +113,7 @@ describe('Coverage', () => {
     it('logs to stderr when coverageExclude file has fs.stat issue', () => {
 
         const Test = require('./coverage/test-folder/test-name.js');
+
         Test.method();
 
         const origStatSync = Fs.statSync;
@@ -131,6 +140,7 @@ describe('Coverage', () => {
     it('identifies lines with partial coverage when having external sourcemap', () => {
 
         const Test = require('./coverage/sourcemaps-external');
+
         Test.method(false);
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/sourcemaps-external'), sourcemaps: true });
@@ -158,6 +168,7 @@ describe('Coverage', () => {
     it('identifies lines with partial coverage when having inline sourcemap', () => {
 
         const Test = require('./coverage/sourcemaps-inline');
+
         Test.method(false);
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/sourcemaps-inline'), sourcemaps: true });
@@ -201,6 +212,7 @@ describe('Coverage', () => {
     it('bypasses marked code', () => {
 
         const Test = require('./coverage/bypass');
+
         Test.method(1, 2, 3);
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/bypass') });
@@ -213,6 +225,7 @@ describe('Coverage', () => {
     it('bypasses marked code and reports misses correctly', () => {
 
         const Test = require('./coverage/bypass-misses');
+
         Test.method(1);
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/bypass-misses') });
@@ -234,6 +247,7 @@ describe('Coverage', () => {
     it('measures missing while statement coverage', () => {
 
         const Test = require('./coverage/while');
+
         Test.method(false);
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/while') });
@@ -259,6 +273,7 @@ describe('Coverage', () => {
     it('retains original value of conditional result', () => {
 
         const Test = require('./coverage/conditional');
+
         const value = { a: 1 };
         expect(Test.method(value)).to.equal(value);
     });
@@ -266,6 +281,7 @@ describe('Coverage', () => {
     it('retains original value of conditional result with comma operator', () => {
 
         const Test = require('./coverage/conditional2');
+
         const value = 4711;
         expect(Test.method(value)).to.equal(value);
     });
@@ -273,6 +289,7 @@ describe('Coverage', () => {
     it('should not change use strict instructions', () => {
 
         const Test = require('./coverage/use-strict.js');
+
         expect(Test.method.toString()).to.not.contain('13'); // This is the line of the inner use strict
 
         const testFile = Path.join(__dirname, 'coverage/use-strict.js').replace(/\\/g, '/');
@@ -284,6 +301,7 @@ describe('Coverage', () => {
     it('should work with loop labels', () => {
 
         const Test = require('./coverage/loop-labels.js');
+
         expect(Test.method()).to.equal([1, 0]);
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/loop-labels') });
@@ -293,6 +311,7 @@ describe('Coverage', () => {
 
             const line = source[lineNumber];
             if (line.miss) {
+                // eslint-disable-next-line prefer-spread
                 missedChunks.push.apply(missedChunks, line.chunks.filter((chunk) => {
 
                     return !!chunk.miss;
@@ -306,6 +325,7 @@ describe('Coverage', () => {
     it('should measure missing coverage on single-line functions correctly', () => {
 
         const Test = require('./coverage/single-line-functions');
+
         const results = [];
         for (let i = 1; i <= 10; ++i) {
             results.push(Test[`method${i}`](3, 4));
@@ -325,6 +345,7 @@ describe('Coverage', () => {
     it('should measure missing coverage on trailing function declarations correctly', () => {
 
         const Test = require('./coverage/trailing-function-declarations');
+
         const result = Test.method(3, 4);
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/trailing-function-declarations') });
@@ -337,6 +358,7 @@ describe('Coverage', () => {
     it('should measure coverage on conditional value', () => {
 
         const Test = require('./coverage/conditional-value');
+
         expect(Test.method(false)).to.equal(false);
         expect(Test.method(true, 1, 0)).to.equal(1);
         expect(Test.method(true, 0, 1)).to.equal(1);
@@ -376,6 +398,7 @@ describe('Coverage', () => {
             const cacheBackup = require.cache; // backup require cache
             const filename = Path.resolve(__dirname, './coverage/basic.js');
             let file = require('./coverage/basic'); //eslint-disable-line no-unused-vars
+
             const fileCovBefore = global.__$$labCov.files[filename];
             require.cache = Module._cache = {}; // clear require cache before additional require
             file = require('./coverage/basic');

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -1775,6 +1775,7 @@ describe('Reporter', () => {
             };
 
             const Test = require('./coverage/basic');
+
             const script = Lab.script();
             script.experiment('test', () => {
 
@@ -1822,6 +1823,7 @@ describe('Reporter', () => {
             };
 
             const Test = require('./coverage/basic');
+
             const script = Lab.script();
             script.experiment('test', () => {
 

--- a/test/run_cli.js
+++ b/test/run_cli.js
@@ -38,6 +38,7 @@ module.exports = (args, root) => {
             if (signal) {
                 return reject(new Error('Unexpected signal: ' + signal));
             }
+
             resolve({ output, errorOutput, combinedOutput, code, signal });
         });
     });

--- a/test/transform.js
+++ b/test/transform.js
@@ -26,6 +26,7 @@ const internals = {
                 if (Buffer.isBuffer(content)) {
                     content = content.toString();
                 }
+
                 return content.concat(Os.EOL).concat('//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIkB0cmFjZXVyL2dlbmVyYXRlZC9UZW1wbGF0ZVBhcnNlci8xIiwiLi93aGlsZS5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiO0FBQUEsQUFBSSxFQUFBLENBQUEsWUFBVyxVQUFvQixDQUFDO0FDS3BDLEFBQUksRUFBQSxDQUFBLFNBQVEsRUFBSSxHQUFDLENBQUM7QUFHbEIsTUFBTSxPQUFPLEVBQUksVUFBVSxLQUFJLENBQUc7QUFFOUIsUUFBTSxLQUFJLENBQUc7QUFDVCxRQUFJLEVBQUksTUFBSSxDQUFDO0VBQ2pCO0FBQUEsQUFFQSxPQUFPLE1BQUksQ0FBQztBQUNoQixDQUFDIiwic291cmNlc0NvbnRlbnQiOlsidmFyIF9fbW9kdWxlTmFtZSA9ICRfX3BsYWNlaG9sZGVyX18wOyIsIi8vIExvYWQgbW9kdWxlc1xuXG5cbi8vIERlY2xhcmUgaW50ZXJuYWxzXG5cbnZhciBpbnRlcm5hbHMgPSB7fTtcblxuXG5leHBvcnRzLm1ldGhvZCA9IGZ1bmN0aW9uICh2YWx1ZSkge1xuXG4gICAgd2hpbGUodmFsdWUpIHtcbiAgICAgICAgdmFsdWUgPSBmYWxzZTtcbiAgICB9XG5cbiAgICByZXR1cm4gdmFsdWU7XG59O1xuIl19').concat(Os.EOL);
             }
         },
@@ -48,6 +49,7 @@ describe('Transform', () => {
     it('instruments and measures coverage', () => {
 
         const Test = require('./transform/basic-transform');
+
         expect(Test.method(1)).to.equal(3);
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'transform/basic-transform') });
@@ -57,6 +59,7 @@ describe('Transform', () => {
     it('does not transform unneeded files', () => {
 
         const Test = require('./transform/basic');
+
         expect(Test.method(1)).to.equal('!NOCOMPILE!');
 
         const cov = Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'transform/basic') });
@@ -108,9 +111,11 @@ describe('Transform.install', () => {
         Transform.install({ transform: internals.transform });
 
         const Test = require('./transform/sourcemaps');
+
         expect(Test.method(false)).to.equal(false);
 
         const Test2 = require('./transform/exclude/transform-basic');
+
         expect(Test2.method()).to.equal(1);
     });
 });


### PR DESCRIPTION
This is a major version bump of the linting config. A lot of code is likely to need updating, particularly around the use of `padding-line-between-statements`. See https://github.com/cjihrig/eslint-config-hapi/pull/52 for all of the fun details.