### PR TITLE
Update to eslint v5

### DIFF
--- a/lib/linter/index.js
+++ b/lib/linter/index.js
@@ -32,8 +32,17 @@ exports.lint = function () {
         Hoek.merge(configuration, options, true, false);
     }
 
-    const engine = new Eslint.CLIEngine(configuration);
-    const results = engine.executeOnFiles(['.']);
+    let results;
+    try {
+        const engine = new Eslint.CLIEngine(configuration);
+        results = engine.executeOnFiles(['.']);
+    }
+    catch (ex) {
+        results = {
+            results: [{ messages: [ex] }]
+        };
+    }
+
 
     return results.results.map((result) => {
 

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   "dependencies": {
     "bossy": "4.x.x",
     "diff": "3.5.x",
-    "eslint": "4.19.x",
+    "eslint": "5.4.x",
     "eslint-config-hapi": "12.x.x",
     "eslint-plugin-hapi": "4.x.x",
-    "espree": "3.5.x",
+    "espree": "4.0.x",
     "find-rc": "3.0.x",
     "handlebars": "4.x.x",
     "hoek": "5.x.x",

--- a/test/linters.js
+++ b/test/linters.js
@@ -137,7 +137,8 @@ describe('Linters - eslint', () => {
         expect(result).to.include('lint');
 
         const eslintResults = result.lint;
-        expect(eslintResults).to.have.length(0);
+        expect(eslintResults).to.have.length(1);
+        expect(eslintResults[0].errors[0].message).to.contain('No files');
     });
 
     it('should fix lint rules when --lint-fix used', async (flags) => {


### PR DESCRIPTION
The call to eslint now traps exceptions and reports them correctly.