### PR TITLE
Fixed skipped console output color

### DIFF
--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -135,6 +135,7 @@ internals.Reporter.prototype.end = function (notebook) {
     const yellow = this.colors.yellow;
     const whiteRedBg = this.colors.whiteRedBg;
     const blackGreenBg = this.colors.blackGreenBg;
+    const magenta = this.colors.magenta;
 
     // Tests
 
@@ -247,7 +248,7 @@ internals.Reporter.prototype.end = function (notebook) {
     }
 
     if (skipped.length) {
-        output += gray(` (${skipped.length} skipped)`);
+        output += magenta(` (${skipped.length} skipped)`);
     }
 
     output += '\n';


### PR DESCRIPTION
Changed color from gray (which actually printed green) to magenta to match `-` signs.