### PR TITLE
handle queueMicrotask global added in Node 11

### DIFF
--- a/lib/leaks.js
+++ b/lib/leaks.js
@@ -161,6 +161,12 @@ exports.detect = function (customGlobals) {
         whitelist.COUNTER_HTTP_CLIENT_RESPONSE = true;
     }
 
+    // $lab:coverage:off$
+    if ('queueMicrotask' in global) {
+        whitelist.queueMicrotask = true;
+    }
+    // $lab:coverage:on$
+
     const leaks = [];
     const globals = Object.getOwnPropertyNames(global);
     for (let i = 0; i < globals.length; ++i) {


### PR DESCRIPTION
`queueMicrotask` was added with an experimental warning in Node 11. To avoid the warning, which causes many tests to fail, use the `in` operator to detect `queueMicrotask` on the `global` object.