### PR TITLE
[ENHANCEMENT] Nullified test context on finish to prevent memory leaks

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -576,6 +576,8 @@ internals.protect = function (item, state) {
                 err.stack = callResult.stack;
             }
 
+            item.context = null;
+
             return err ? reject(err) : resolve();
         };
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -1608,22 +1608,20 @@ describe('Runner', () => {
                 context.testData = testContext.testData;
             });
 
-            script.test('success', ({ context }) => {
+            script.test('has test context', ({ context }) => {
 
                 expect(context,'has proper context').to.equal(testContext);
-                expect(true).to.be.true();
             });
 
-            script.test('fails', ({ context }) => {
+            script.test('still has test context', ({ context }) => {
 
                 expect(context,'has proper context').to.equal(testContext);
-                expect(true).to.be.false();
             });
         });
 
         const notebook = await Lab.execute(script, {}, null);
         expect(notebook.tests.length,'has 2 tests').to.equal(2);
-        expect(notebook.failures,'1 failures').to.equal(1);
+        expect(notebook.failures,'has 0 failures').to.equal(0);
 
         const assertNulledContext = (test) => {
 
@@ -1632,5 +1630,4 @@ describe('Runner', () => {
 
         notebook.tests.forEach(assertNulledContext);
     });
-
 });

--- a/test/runner.js
+++ b/test/runner.js
@@ -1592,4 +1592,45 @@ describe('Runner', () => {
         expect(notebook.tests).to.have.length(1);
         expect(notebook.failures).to.equal(1);
     });
+
+    it('nullifies test context on finish', async () => {
+
+        const script = Lab.script({ schedule: false });
+
+        const testContext = {
+            testData: { hello: 'there' }
+        };
+
+        script.experiment('test', () => {
+
+            script.beforeEach(({ context }) => {
+
+                context.testData = testContext.testData;
+            });
+
+            script.test('success', ({ context }) => {
+
+                expect(context,'has proper context').to.equal(testContext);
+                expect(true).to.be.true();
+            });
+
+            script.test('fails', ({ context }) => {
+
+                expect(context,'has proper context').to.equal(testContext);
+                expect(true).to.be.false();
+            });
+        });
+
+        const notebook = await Lab.execute(script, {}, null);
+        expect(notebook.tests.length,'has 2 tests').to.equal(2);
+        expect(notebook.failures,'1 failures').to.equal(1);
+
+        const assertNulledContext = (test) => {
+
+            expect(test.context,'nulled context').to.be.null();
+        };
+
+        notebook.tests.forEach(assertNulledContext);
+    });
+
 });


### PR DESCRIPTION
On the completion of a test, this update will nullify the context to prevent memory leaks

Fixes #868