### PR TITLE
Improve console coverage report readability

### DIFF
--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -318,11 +318,14 @@ internals.Reporter.prototype.end = function (notebook) {
 
                     if (missingLines.length) {
                         const lineReportLimit = 8;
+
+                        // Lines missing coverage are reported as a list of
+                        // spans, e.g. "1, 3-8, 10, 13-15".
+                        const missingLinesReport = [];
                         const span = {
                             start: missingLines[0],
                             end: missingLines[0]
                         };
-                        const missingLinesReport = [];
                         for (let i = 1; i <= missingLines.length; ++i) {
                             const line = missingLines[i];
                             if (line === span.end + 1) {
@@ -332,14 +335,14 @@ internals.Reporter.prototype.end = function (notebook) {
                             else {
                                 // Flush current span to output.
                                 if (span.start === span.end) {
-                                    missingLinesReport.push(span.start.toString());
+                                    missingLinesReport.push(span.start);
                                 }
                                 else if (span.start + 1 === span.end) {
-                                    missingLinesReport.push(span.start.toString());
-                                    missingLinesReport.push(span.end.toString());
+                                    missingLinesReport.push(span.start);
+                                    missingLinesReport.push(span.end);
                                 }
                                 else {
-                                    missingLinesReport.push(span.start.toString() + '-' + span.end.toString());
+                                    missingLinesReport.push(span.start + '-' + span.end);
                                 }
 
                                 // Start a new span.

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -312,12 +312,42 @@ internals.Reporter.prototype.end = function (notebook) {
 
                         const line = file.source[lineNumber];
                         if (line.miss) {
-                            missingLines.push(lineNumber);
+                            missingLines.push(parseInt(lineNumber, 10));
                         }
                     });
 
                     if (missingLines.length) {
-                        output += red('\n' + file.filename + ' missing coverage on line(s): ' + missingLines.join(', '));
+                        const span = {
+                            start: missingLines[0],
+                            end: missingLines[0]
+                        };
+                        const missingLinesReport = [];
+                        for (let i = 1; i <= missingLines.length; ++i) {
+                            const line = missingLines[i];
+                            if (line === span.end + 1) {
+                                // Extend the current span.
+                                span.end = line;
+                            }
+                            else {
+                                // Flush current span to output.
+                                if (span.start === span.end) {
+                                    missingLinesReport.push(span.start.toString());
+                                }
+                                else if (span.start + 1 === span.end) {
+                                    missingLinesReport.push(span.start.toString());
+                                    missingLinesReport.push(span.end.toString());
+                                }
+                                else {
+                                    missingLinesReport.push(span.start.toString() + '-' + span.end.toString());
+                                }
+
+                                // Start a new span.
+                                span.start = line;
+                                span.end = line;
+                            }
+                        }
+
+                        output += red('\n' + file.filename + ' missing coverage on line(s): ' + missingLinesReport.join(', '));
                     }
                 }
             });

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -317,6 +317,7 @@ internals.Reporter.prototype.end = function (notebook) {
                     });
 
                     if (missingLines.length) {
+                        const lineReportLimit = 8;
                         const span = {
                             start: missingLines[0],
                             end: missingLines[0]
@@ -344,6 +345,13 @@ internals.Reporter.prototype.end = function (notebook) {
                                 // Start a new span.
                                 span.start = line;
                                 span.end = line;
+                            }
+
+                            // If the report gets too long, truncate it.
+                            if (missingLinesReport.length >= lineReportLimit) {
+                                const remainingLines = missingLines.length - i;
+                                missingLinesReport.push('and ' + remainingLines + ' more');
+                                break;
                             }
                         }
 

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -355,7 +355,7 @@ internals.Reporter.prototype.end = function (notebook) {
                             }
                         }
 
-                        output += red('\n' + file.filename + ' missing coverage on line(s): ' + missingLinesReport.join(', '));
+                        output += yellow('\n' + file.filename + ' missing coverage on line(s): ' + missingLinesReport.join(', '));
                     }
                 }
             });

--- a/test/coverage/console-large-file.js
+++ b/test/coverage/console-large-file.js
@@ -1,0 +1,69 @@
+'use strict';
+
+// Load modules
+
+
+// Declare internals
+
+const internals = {};
+
+
+exports.method = function (value) {
+
+	if (value) {
+		value += 1;
+	}
+	else {
+		value -= 1;
+	}
+
+	if (value) {
+		value += 1;
+		value += 1;
+	}
+	else {
+		value -= 1;
+		value -= 1;
+	}
+
+	if (value) {
+		value += 1;
+		value += 1;
+		value += 1;
+	}
+	else {
+		value -= 1;
+		value -= 1;
+		value -= 1;
+	}
+
+	if (value) {
+		value += 1;
+		value += 1;
+		value += 1;
+		value += 1;
+	}
+	else {
+		value -= 1;
+		value -= 1;
+		value -= 1;
+		value -= 1;
+	}
+
+	if (value) {
+		value += 1;
+		value += 1;
+		value += 1;
+		value += 1;
+		value += 1;
+	}
+	else {
+		value -= 1;
+		value -= 1;
+		value -= 1;
+		value -= 1;
+		value -= 1;
+	}
+
+	return value;
+};

--- a/test/coverage/console.js
+++ b/test/coverage/console.js
@@ -16,7 +16,9 @@ exports.method = function (a, b, c) {
 	}
 	else if (c > 10) {
 		d += 1;
+		d += 1;
 	}
 
-	return d + (a || b || c);
+	const e = d ? a : b;
+	return d + (a || b || c) - e;
 };

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -849,8 +849,8 @@ describe('Reporter', () => {
             });
 
             const { output } = await Lab.report(script, { reporter: 'console', coverage: true, coveragePath: Path.join(__dirname, './coverage/console'), output: false });
-            expect(output).to.contain('Coverage: 76.47% (4/17)');
-            expect(output).to.contain('test/coverage/console.js missing coverage on line(s): 14, 17, 18, 21');
+            expect(output).to.contain('Coverage: 68.42% (6/19)');
+            expect(output).to.contain('test/coverage/console.js missing coverage on line(s): 14, 17-19, 22, 23');
             expect(output).to.not.contain('console-full');
         });
 

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -829,7 +829,8 @@ describe('Reporter', () => {
 
         it('generates a coverage report (verbose)', async () => {
 
-            const Test = require('./coverage/console');
+            const Test1 = require('./coverage/console');
+            const Test2 = require('./coverage/console-large-file');
             const Full = require('./coverage/console-full');
 
             const script = Lab.script();
@@ -837,7 +838,8 @@ describe('Reporter', () => {
 
                 script.test('something', () => {
 
-                    Test.method(1, 2, 3);
+                    Test1.method(1, 2, 3);
+                    Test2.method(1);
                     Full.method(1);
 
                 });
@@ -849,8 +851,9 @@ describe('Reporter', () => {
             });
 
             const { output } = await Lab.report(script, { reporter: 'console', coverage: true, coveragePath: Path.join(__dirname, './coverage/console'), output: false });
-            expect(output).to.contain('Coverage: 68.42% (6/19)');
+            expect(output).to.contain('Coverage: 64.86% (26/74)');
             expect(output).to.contain('test/coverage/console.js missing coverage on line(s): 14, 17-19, 22, 23');
+            expect(output).to.contain('test/coverage/console-large-file.js missing coverage on line(s): 13, 17, 20, 25, 26, 29, 35-37, 40, and 10 more');
             expect(output).to.not.contain('console-full');
         });
 


### PR DESCRIPTION
The way coverage reports were presented in the console made them hard to skim. I made a few tweaks to try and improve this:

- Report runs of contiguous lines as ranges (e.g. "7-11") instead of listing every line number.
- Truncate coverage reports when they get too long.
- Color the detail portion yellow instead of red.

### Before:
![screen shot 2018-10-30 at 3 36 28 pm](https://user-images.githubusercontent.com/35091/47755595-1f001080-dc5c-11e8-9d78-8f3155faaef6.png)

### After:
![screen shot 2018-10-30 at 3 38 46 pm](https://user-images.githubusercontent.com/35091/47755602-232c2e00-dc5c-11e8-898c-fb7c8c7afd8e.png)

Let me know what you think!