### PR TITLE
Add --coverage-all option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Lead Maintainer: [Wyatt Preul](https://github.com/geek)
 - `-c`, `--coverage` - enables code coverage analysis.
 - `--coverage-path` - sets code coverage path.
 - `--coverage-exclude` - sets code coverage excludes.
+- `--coverage-all` - report coverage for all matched files, not just those tested.
+- `--coverage-flat` - do not perform a recursive find of files for coverage report. Requires --coverage-all
 - `-C`, `--colors` - enables or disables color output. Defaults to console capabilities.
 - `-d`, `--dry` - dry run. Skips all tests. Use with `-v` to generate a test catalog. Defaults to `false`.
 - `-e`, `--environment` - value to set the `NODE_ENV` environment variable to, defaults to 'test'.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -207,6 +207,16 @@ internals.options = function () {
             multiple: true,
             default: null
         },
+        'coverage-all': {
+            type: 'boolean',
+            description: 'include all files in coveragePath in report',
+            default: null
+        },
+        'coverage-flat': {
+            type: 'boolean',
+            description: 'prevent recursive inclusion of all files in coveragePath in report',
+            default: null
+        },
         'default-plan-threshold': {
             alias: 'p',
             type: 'number',
@@ -423,7 +433,7 @@ internals.options = function () {
     options.paths = argv._ ? [].concat(argv._) : options.paths;
 
     const keys = ['assert', 'bail', 'colors', 'context-timeout', 'coverage', 'coverage-exclude',
-        'coverage-path', 'default-plan-threshold', 'dry', 'environment', 'flat', 'globals', 'grep',
+        'coverage-path', 'coverage-all', 'coverage-flat', 'default-plan-threshold', 'dry', 'environment', 'flat', 'globals', 'grep',
         'lint', 'lint-errors-threshold', 'lint-fix', 'lint-options', 'lint-warnings-threshold',
         'linter', 'output', 'pattern', 'reporter', 'seed', 'shuffle', 'silence',
         'silent-skips', 'sourcemaps', 'threshold', 'timeout', 'transform', 'verbose'];

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -493,7 +493,12 @@ internals.options = function () {
         options.pattern = new RegExp(options.pattern + '\\.(js)$');
     }
 
-    options.coverage = (options.coverage || options.threshold > 0 || options.reporter.indexOf('html') !== -1 || options.reporter.indexOf('lcov') !== -1 || options.reporter.indexOf('clover') !== -1);
+    options.coverage = (options.coverage || options.threshold > 0 || options['coverage-all'] || options.reporter.indexOf('html') !== -1 || options.reporter.indexOf('lcov') !== -1 || options.reporter.indexOf('clover') !== -1);
+
+    if (options['coverage-flat'] && !options['coverage-all']) {
+        console.error('The "coverage-flat" option can only be used with "coverage-all"');
+        process.exit(1);
+    }
 
     return options;
 };

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -385,6 +385,50 @@ internals.instrument = function (filename) {
 };
 
 
+internals.traverse = function (coveragePath, options) {
+
+    let nextPath = null;
+    const traverse = function (path) {
+
+        let files = [];
+        nextPath = path;
+
+        const pathStat = Fs.statSync(path);
+        if (pathStat.isFile()) {
+            return path;
+        }
+
+        Fs.readdirSync(path).forEach((filename) => {
+
+            nextPath = Path.join(path, filename);
+            const stat = Fs.statSync(nextPath);
+            if (stat.isDirectory() &&
+                !options.coverageFlat) {
+
+                files = files.concat(traverse(nextPath, options));
+                return;
+            }
+
+            if (stat.isFile() &&
+                Path.basename(nextPath)[0] !== '.') {
+
+                files.push(nextPath);
+            }
+        });
+
+        return files;
+    };
+
+    const coverageFiles = [].concat(traverse(coveragePath));
+
+    return coverageFiles.map((path) => {
+
+        return Path.resolve(path);
+    });
+
+};
+
+
 exports.analyze = async function (options) {
 
     // Process coverage  (global.__$$labCov needed when labCov isn't defined)
@@ -402,10 +446,22 @@ exports.analyze = async function (options) {
 
     // Filter files
 
-    const files = Object.keys(report.files);
+    let files;
+
+    if (!options.coverageAll) {
+        files = Object.keys(report.files);
+    }
+    else {
+        files = internals.traverse(options.coveragePath, options);
+    }
+
     for (let i = 0; i < files.length; ++i) {
         const filename = files[i];
         if (pattern.test(filename)) {
+            if (!report.files[filename]) {
+                internals.instrument(filename);
+            }
+
             report.files[filename].source = internals.sources[filename] || [];
             const data = await internals.file(filename, report.files[filename], options);
 

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -451,7 +451,6 @@ exports.analyze = async function (options) {
 
     if (options['coverage-all']) {
         files = internals.traverse(options.coveragePath, options);
-        console.log(files);
     }
     else {
         files = Object.keys(report.files);

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -403,7 +403,7 @@ internals.traverse = function (coveragePath, options) {
             nextPath = Path.join(path, filename);
             const stat = Fs.statSync(nextPath);
             if (stat.isDirectory() &&
-                !options.coverageFlat) {
+                !options['coverage-flat']) {
 
                 files = files.concat(traverse(nextPath, options));
                 return;
@@ -448,11 +448,13 @@ exports.analyze = async function (options) {
 
     let files;
 
-    if (!options.coverageAll) {
-        files = Object.keys(report.files);
+
+    if (options['coverage-all']) {
+        files = internals.traverse(options.coveragePath, options);
+        console.log(files);
     }
     else {
-        files = internals.traverse(options.coveragePath, options);
+        files = Object.keys(report.files);
     }
 
     for (let i = 0; i < files.length; ++i) {

--- a/test/cli.js
+++ b/test/cli.js
@@ -356,7 +356,7 @@ describe('CLI', () => {
         expect(result.output).to.not.contain('##before##');
     });
 
-    it('can include all files for coverage with the --coverage-path argument', async () => {
+    it('can include files for coverage with the --coverage-path argument', async () => {
 
         const result = await RunCli(['test/cli_coverage', '-t', '100', '--coverage-path', 'test/cli_coverage/include', '-a', 'code']);
 
@@ -394,6 +394,36 @@ describe('CLI', () => {
         expect(result.errorOutput).to.equal('');
         expect(result.code).to.equal(1);
         expect(result.output).to.contain('2 tests complete');
+        expect(result.output).to.contain('Coverage: 0.00%');
+    });
+
+    it('can include all files in coverage with the --coverage-all argument', async () => {
+
+        const result = await RunCli(['test/cli_coverage', '-t', '100', '--coverage-path', 'test/cli_coverage', '--coverage-all', '-a', 'code']);
+
+        expect(result.errorOutput).to.equal('');
+        expect(result.code).to.equal(1);
+        expect(result.output).to.contain('1 tests complete');
+        expect(result.output).to.contain('Coverage: 86.67%');
+    });
+
+    it('can prevent recursive coverage inclusion with the --coverage-flat argument', async () => {
+
+        const result = await RunCli(['test/cli_coverage', '-t', '100', '--coverage-path', 'test/cli_coverage', '--coverage-all', '--coverage-flat', '-a', 'code']);
+
+        expect(result.errorOutput).to.equal('');
+        expect(result.code).to.equal(1);
+        expect(result.output).to.contain('1 tests complete');
+        expect(result.output).to.contain('Coverage: 80.00%');
+    });
+
+    it('can still exclude files with the --coverage-all argument', async () => {
+
+        const result = await RunCli(['test/cli_coverage', '-t', '100', '--coverage-exclude', 'missing.js', '--coverage-path', 'test/cli_coverage', '--coverage-all', '--coverage-flat', '-a', 'code']);
+
+        expect(result.errorOutput).to.equal('');
+        expect(result.code).to.equal(1);
+        expect(result.output).to.contain('1 tests complete');
         expect(result.output).to.contain('Coverage: 0.00%');
     });
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -407,6 +407,16 @@ describe('CLI', () => {
         expect(result.output).to.contain('Coverage: 86.67%');
     });
 
+    it('reports coverage with --coverage-all and without -c or -t', async () => {
+
+        const result = await RunCli(['test/cli_coverage', '--coverage-path', 'test/cli_coverage', '--coverage-all', '-a', 'code']);
+
+        expect(result.errorOutput).to.equal('');
+        expect(result.code).to.equal(0);
+        expect(result.output).to.contain('1 tests complete');
+        expect(result.output).to.contain('Coverage: 86.67%');
+    });
+
     it('can prevent recursive coverage inclusion with the --coverage-flat argument', async () => {
 
         const result = await RunCli(['test/cli_coverage', '-t', '100', '--coverage-path', 'test/cli_coverage', '--coverage-all', '--coverage-flat', '-a', 'code']);
@@ -425,6 +435,13 @@ describe('CLI', () => {
         expect(result.code).to.equal(1);
         expect(result.output).to.contain('1 tests complete');
         expect(result.output).to.contain('Coverage: 0.00%');
+    });
+
+    it('outputs an error when --coverage-flat is used without --coverage-all', async () => {
+
+        const result = await RunCli(['test/cli_coverage', '-t', '100',  '--coverage-path', 'test/cli_coverage', '--coverage-flat', '-a', 'code']);
+
+        expect(result.errorOutput).to.include('The "coverage-flat" option can only be used with "coverage-all"');
     });
 
     it('defaults NODE_ENV environment variable to test', async () => {

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -420,6 +420,8 @@ describe('Coverage', () => {
             const cov = await Lab.coverage.analyze({ 'coverage-all': true, coveragePath: Path.join(__dirname, 'coverage/coverage-all') });
             expect(cov.percent).to.equal(70);
 
+            expect(cov.files).to.have.length(2);
+
             const filename = cov.files[1].filename;
             expect(filename).to.equal('test/coverage/coverage-all/nested-folder/uncovered.js');
 
@@ -435,6 +437,8 @@ describe('Coverage', () => {
             expect(Test.method(true)).to.equal(true);
 
             const cov = await Lab.coverage.analyze({ 'coverage-all': true, coveragePath: Path.join(__dirname, 'coverage/coverage-all/covered.js') });
+
+            expect(cov.files).to.have.length(1);
             expect(cov.percent).to.equal(100);
         });
 
@@ -444,7 +448,9 @@ describe('Coverage', () => {
 
             expect(Test.method(true)).to.equal(true);
 
-            const cov = await Lab.coverage.analyze({ 'coverage-all': true, 'coverage-flat': true, coveragePath: Path.join(__dirname, 'coverage/coverage-all/covered.js') });
+            const cov = await Lab.coverage.analyze({ 'coverage-all': true, 'coverage-flat': true, coveragePath: Path.join(__dirname, 'coverage/coverage-all') });
+
+            expect(cov.files).to.have.length(1);
             expect(cov.percent).to.equal(100);
         });
     });

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -408,4 +408,44 @@ describe('Coverage', () => {
             expect(fileCovAfter).to.equal(fileCovBefore);
         });
     });
+
+    describe('coverageAll option', () => {
+
+        it('reports coverage for all matching files', async () => {
+
+            const Test = require('./coverage/coverage-all/covered');
+
+            expect(Test.method(true)).to.equal(true);
+
+            const cov = await Lab.coverage.analyze({ coverageAll: true, coveragePath: Path.join(__dirname, 'coverage/coverage-all') });
+            expect(cov.percent).to.equal(70);
+
+            const filename = cov.files[1].filename;
+            expect(filename).to.equal('test/coverage/coverage-all/nested-folder/uncovered.js');
+
+            const source = cov.files[1].source;
+            const missedLines = Object.keys(source).filter((lineNumber) => source[lineNumber].miss);
+            expect(missedLines).to.equal(['8', '11', '13']);
+        });
+
+        it('reports coverage when the path is a single file', async () => {
+
+            const Test = require('./coverage/coverage-all/covered');
+
+            expect(Test.method(true)).to.equal(true);
+
+            const cov = await Lab.coverage.analyze({ coverageAll: true, coveragePath: Path.join(__dirname, 'coverage/coverage-all/covered.js') });
+            expect(cov.percent).to.equal(100);
+        });
+
+        it('respects the coverageFlat option', async () => {
+
+            const Test = require('./coverage/coverage-all/covered');
+
+            expect(Test.method(true)).to.equal(true);
+
+            const cov = await Lab.coverage.analyze({ coverageAll: true, coverageFlat: true, coveragePath: Path.join(__dirname, 'coverage/coverage-all/covered.js') });
+            expect(cov.percent).to.equal(100);
+        });
+    });
 });

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -444,7 +444,7 @@ describe('Coverage', () => {
 
             expect(Test.method(true)).to.equal(true);
 
-            const cov = await Lab.coverage.analyze({ 'coverage-all': true, ['coverage-flat']: true, coveragePath: Path.join(__dirname, 'coverage/coverage-all/covered.js') });
+            const cov = await Lab.coverage.analyze({ 'coverage-all': true, 'coverage-flat': true, coveragePath: Path.join(__dirname, 'coverage/coverage-all/covered.js') });
             expect(cov.percent).to.equal(100);
         });
     });

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -409,7 +409,7 @@ describe('Coverage', () => {
         });
     });
 
-    describe('coverageAll option', () => {
+    describe('coverage-all option', () => {
 
         it('reports coverage for all matching files', async () => {
 
@@ -417,7 +417,7 @@ describe('Coverage', () => {
 
             expect(Test.method(true)).to.equal(true);
 
-            const cov = await Lab.coverage.analyze({ coverageAll: true, coveragePath: Path.join(__dirname, 'coverage/coverage-all') });
+            const cov = await Lab.coverage.analyze({ 'coverage-all': true, coveragePath: Path.join(__dirname, 'coverage/coverage-all') });
             expect(cov.percent).to.equal(70);
 
             const filename = cov.files[1].filename;
@@ -434,17 +434,17 @@ describe('Coverage', () => {
 
             expect(Test.method(true)).to.equal(true);
 
-            const cov = await Lab.coverage.analyze({ coverageAll: true, coveragePath: Path.join(__dirname, 'coverage/coverage-all/covered.js') });
+            const cov = await Lab.coverage.analyze({ 'coverage-all': true, coveragePath: Path.join(__dirname, 'coverage/coverage-all/covered.js') });
             expect(cov.percent).to.equal(100);
         });
 
-        it('respects the coverageFlat option', async () => {
+        it('respects the coverage-flat option', async () => {
 
             const Test = require('./coverage/coverage-all/covered');
 
             expect(Test.method(true)).to.equal(true);
 
-            const cov = await Lab.coverage.analyze({ coverageAll: true, coverageFlat: true, coveragePath: Path.join(__dirname, 'coverage/coverage-all/covered.js') });
+            const cov = await Lab.coverage.analyze({ 'coverage-all': true, ['coverage-flat']: true, coveragePath: Path.join(__dirname, 'coverage/coverage-all/covered.js') });
             expect(cov.percent).to.equal(100);
         });
     });

--- a/test/coverage/coverage-all/covered.js
+++ b/test/coverage/coverage-all/covered.js
@@ -1,0 +1,14 @@
+'use strict';
+
+// Load modules
+
+
+// Declare internals
+
+const internals = {};
+
+
+exports.method = function (value) {
+
+	return value;
+};

--- a/test/coverage/coverage-all/nested-folder/uncovered.js
+++ b/test/coverage/coverage-all/nested-folder/uncovered.js
@@ -1,0 +1,14 @@
+'use strict';
+
+// Load modules
+
+
+// Declare internals
+
+const internals = {};
+
+
+exports.method = function (value) {
+
+	return value;
+};


### PR DESCRIPTION
Fixes https://github.com/hapijs/lab/issues/710

- Adds option to specify `--coverage-all` flag.
- Reports coverage for all files that match `--coverage-path`, regardless of a test touching them
- Respects `--coverage-exclude`
- Adds `--coverage-flat` to prevent recursive finding of files for coverage

One outstanding issue, which I am currently unsure how to resolve:
```
Coverage: 99.96% (1/2254)
lib/coverage.js missing coverage on line(s): 412
Code coverage below threshold: 99.96 < 100
```

which refers to: `if (stat.isFile() && Path.basename(nextPath)[0] !== '.') {` 🤷‍♀️ 

Feedback on the changes welcome and a suggestion of how to hit the code coverage would be helpful :+1: