### PR TITLE
Fix false-positive coverage of if statements (REDUCES REPORTED COVERAGE!)

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -242,7 +242,7 @@ internals.instrument = function (filename) {
         }
         else if (node.type === 'LogicalExpression') {
             const left = addStatement(line, node.left, true);
-            const right = addStatement(line, node.right, node.parent.type === 'LogicalExpression');
+            const right = addStatement(line, node.right, node.parent.type === 'LogicalExpression' || node.parent.type === 'IfStatement');
 
             node.set(`(global.__$$labCov._statement(\'${filename }\',${left},${line},${node.left.source()})${node.operator}global.__$$labCov._statement(\'${filename}\',${right},${line},${node.right.source()}))`);
         }

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -370,6 +370,20 @@ describe('Coverage', () => {
         expect(missedLines).to.be.empty();
     });
 
+    it('should measure missing coverage on conditional value', async () => {
+
+        const Test = require('./coverage/conditional-value2');
+
+        expect(Test.method(true, true, true)).to.equal(true);
+        expect(Test.method(false, true, true)).to.equal(false);
+        expect(Test.method(true, false, true)).to.equal(false);
+
+        const cov = await  Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/conditional-value') });
+        const source = cov.files[0].source;
+        const missedLines = Object.keys(source).filter((lineNumber) => source[lineNumber].miss);
+        expect(missedLines).to.equal(['7']);
+    });
+
     describe('#analyze', () => {
 
         it('sorts file paths in report', async () => {

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -374,11 +374,11 @@ describe('Coverage', () => {
 
         const Test = require('./coverage/conditional-value2');
 
-        expect(Test.method(true, true, true)).to.equal(true);
-        expect(Test.method(false, true, true)).to.equal(false);
-        expect(Test.method(true, false, true)).to.equal(false);
+        expect(Test.method(false, false, false)).to.equal(false);
+        expect(Test.method(true, false, false)).to.equal(true);
+        expect(Test.method(false, true, false)).to.equal(true);
 
-        const cov = await  Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/conditional-value') });
+        const cov = await Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/conditional-value2') });
         const source = cov.files[0].source;
         const missedLines = Object.keys(source).filter((lineNumber) => source[lineNumber].miss);
         expect(missedLines).to.equal(['7']);

--- a/test/coverage/conditional-value2.js
+++ b/test/coverage/conditional-value2.js
@@ -4,8 +4,8 @@
 
 
 exports.method = function (value1, value2, value3) {
-	if (!value1 || !value2 || !value3) {
-		return false;
+	if (value1 || value2 || value3) {
+		return true;
 	}
-	return true;
+	return false;
 };

--- a/test/coverage/conditional-value2.js
+++ b/test/coverage/conditional-value2.js
@@ -1,0 +1,11 @@
+'use strict';
+
+// Load modules
+
+
+exports.method = function (value1, value2, value3) {
+	if (!value1 || !value2 || !value3) {
+		return false;
+	}
+	return true;
+};


### PR DESCRIPTION
Lab currently reports the last part of a conditional within an if statement as covered even though one case might not have been covered!

For example, the following `if` statement is reported as fully covered, even if `value2` is always `false`:
```JavaScript
if (value1 || value2) {
…
}
```

**This PR causes the coverage of Lab itself to drop** because it exposes several uncovered conditionals within Lab  that have previously been incorrectly reported as covered.