### PR TITLE
Add coverage-pattern option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Lead Maintainer: [Wyatt Preul](https://github.com/geek)
 - `--coverage-path` - sets code coverage path.
 - `--coverage-exclude` - sets code coverage excludes.
 - `--coverage-all` - report coverage for all matched files, not just those tested.
-- `--coverage-flat` - do not perform a recursive find of files for coverage report. Requires --coverage-all
-- `--coverage-pattern` - only report coverage for files with the given pattern in the name. Requires --coverage-all
+- `--coverage-flat` - do not perform a recursive find of files for coverage report. Requires `--coverage-all`
+- `--coverage-pattern` - only report coverage for files with the given pattern in the name. Defaults to `pattern`. Requires `--coverage-all`
 - `-C`, `--colors` - enables or disables color output. Defaults to console capabilities.
 - `-d`, `--dry` - dry run. Skips all tests. Use with `-v` to generate a test catalog. Defaults to `false`.
 - `-e`, `--environment` - value to set the `NODE_ENV` environment variable to, defaults to 'test'.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Lead Maintainer: [Wyatt Preul](https://github.com/geek)
 - `--coverage-exclude` - sets code coverage excludes.
 - `--coverage-all` - report coverage for all matched files, not just those tested.
 - `--coverage-flat` - do not perform a recursive find of files for coverage report. Requires --coverage-all
+- `--coverage-pattern` - only report coverage for files with the given pattern in the name. Requires --coverage-all
 - `-C`, `--colors` - enables or disables color output. Defaults to console capabilities.
 - `-d`, `--dry` - dry run. Skips all tests. Use with `-v` to generate a test catalog. Defaults to `false`.
 - `-e`, `--environment` - value to set the `NODE_ENV` environment variable to, defaults to 'test'.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -217,6 +217,11 @@ internals.options = function () {
             description: 'prevent recursive inclusion of all files in coveragePath in report',
             default: null
         },
+        'coverage-pattern': {
+            type: 'string',
+            description: 'file pattern to use for locating files for coverage',
+            default: null
+        },
         'default-plan-threshold': {
             alias: 'p',
             type: 'number',
@@ -433,7 +438,7 @@ internals.options = function () {
     options.paths = argv._ ? [].concat(argv._) : options.paths;
 
     const keys = ['assert', 'bail', 'colors', 'context-timeout', 'coverage', 'coverage-exclude',
-        'coverage-path', 'coverage-all', 'coverage-flat', 'default-plan-threshold', 'dry', 'environment', 'flat', 'globals', 'grep',
+        'coverage-path', 'coverage-all', 'coverage-flat', 'coverage-pattern', 'default-plan-threshold', 'dry', 'environment', 'flat', 'globals', 'grep',
         'lint', 'lint-errors-threshold', 'lint-fix', 'lint-options', 'lint-warnings-threshold',
         'linter', 'output', 'pattern', 'reporter', 'seed', 'shuffle', 'silence',
         'silent-skips', 'sourcemaps', 'threshold', 'timeout', 'transform', 'verbose'];
@@ -478,7 +483,9 @@ internals.options = function () {
         options.progress = 2;
     }
 
-    options.pattern = options.pattern ? '.*' + options.pattern + '.*?' : '';
+    const pattern =  options.pattern ? '.*' + options.pattern + '.*?' : '';
+
+    let exts = '\\.(js)$';
     if (options.transform) {
         const transform = require(Path.resolve(options.transform));
 
@@ -486,14 +493,18 @@ internals.options = function () {
         options.transform = transform;
 
         const includes = 'js|' + transform.map(internals.mapTransform).join('|');
-        const regex = options.pattern + '\\.(' + includes + ')$';
-        options.pattern = new RegExp(regex);
-    }
-    else {
-        options.pattern = new RegExp(options.pattern + '\\.(js)$');
+        exts = '\\.(' + includes + ')$';
     }
 
+    options.pattern = new RegExp(pattern + exts);
+
     options.coverage = (options.coverage || options.threshold > 0 || options['coverage-all'] || options.reporter.indexOf('html') !== -1 || options.reporter.indexOf('lcov') !== -1 || options.reporter.indexOf('clover') !== -1);
+    options.coveragePattern = new RegExp(options['coverage-pattern'] || pattern + exts);
+
+    if (options['coverage-pattern'] && !options['coverage-all']) {
+        console.error('The "coverage-pattern" option can only be used with "coverage-all"');
+        process.exit(1);
+    }
 
     if (options['coverage-flat'] && !options['coverage-all']) {
         console.error('The "coverage-flat" option can only be used with "coverage-all"');

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -413,7 +413,7 @@ internals.traverse = function (coveragePath, options) {
 
             if (stat.isFile() &&
                 basename[0] !== '.' &&
-                options.pattern.test(nextPath)) {
+                options.coveragePattern.test(nextPath)) {
 
                 files.push(nextPath);
             }

--- a/test/cli.js
+++ b/test/cli.js
@@ -444,6 +444,33 @@ describe('CLI', () => {
         expect(result.errorOutput).to.include('The "coverage-flat" option can only be used with "coverage-all"');
     });
 
+    it('matches coverage files using --pattern', async () => {
+
+        const result = await RunCli(['test/cli_coverage', '-t', '100', '--coverage-path', 'test/cli_coverage', '--coverage-all', '--pattern', 'include', '-a', 'code']);
+
+        expect(result.errorOutput).to.equal('');
+        expect(result.code).to.equal(0);
+        expect(result.output).to.contain('1 tests complete');
+        expect(result.output).to.contain('Coverage: 100.00%');
+    });
+
+    it('matches coverage files using --coverage-pattern', async () => {
+
+        const result = await RunCli(['test/cli_coverage', '-t', '100', '--coverage-path', 'test/cli_coverage', '--coverage-all', '--coverage-pattern', '.*?', '--pattern', 'include', '-a', 'code']);
+
+        expect(result.errorOutput).to.equal('');
+        expect(result.code).to.equal(1);
+        expect(result.output).to.contain('1 tests complete');
+        expect(result.output).to.contain('Coverage: 60.00%');
+    });
+
+    it('outputs an error when --coverage-pattern is used without --coverage-all', async () => {
+
+        const result = await RunCli(['test/cli_coverage', '-t', '100',  '--coverage-path', 'test/cli_coverage', '--coverage-pattern', 'include', '-a', 'code']);
+
+        expect(result.errorOutput).to.include('The "coverage-pattern" option can only be used with "coverage-all"');
+    });
+
     it('defaults NODE_ENV environment variable to test', async () => {
 
         const result = await RunCli(['test/cli/environment.js']);

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -420,7 +420,7 @@ describe('Coverage', () => {
             const cov = await Lab.coverage.analyze({
                 'coverage-all': true,
                 coveragePath: Path.join(__dirname, 'coverage/coverage-all'),
-                pattern: /\.(js)$/
+                coveragePattern: /\.(js)$/
             });
             expect(cov.percent).to.equal(70);
 
@@ -456,7 +456,7 @@ describe('Coverage', () => {
                 'coverage-all': true,
                 'coverage-flat': true,
                 coveragePath: Path.join(__dirname, 'coverage/coverage-all'),
-                pattern: /\.(js)$/
+                coveragePattern: /\.(js)$/
             });
 
             expect(cov.files).to.have.length(1);


### PR DESCRIPTION
More coverage updates again 😄 

- Allows pattern used for coverage to be different (via `--coverage-pattern`) to that used for test file locating. For example, when using a `pattern` of `\.spec` or `\.test` (as I am) you can reset the `coverage-pattern` to `.*?`
- Additionally adds CLI test for using pattern with coverage