### PR TITLE
Fix coverage with sourcemaps inlined via Transform API.

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -297,8 +297,7 @@ internals.instrument = function (filename) {
 
     // Store original source
 
-    const transformedFile = content.replace(/\/\/\#(.*)\r?\n?$/, '');
-    internals.sources[filename] = transformedFile.replace(/(\r\n|\n|\r)/gm, '\n').split('\n');
+    internals.sources[filename] = content.replace(/(\r\n|\n|\r)/gm, '\n').split('\n');
 
     // Setup global report container
     // $lab:coverage:off$
@@ -368,10 +367,6 @@ internals.instrument = function (filename) {
 
                 return commented;
             }).reduce((a, b) => a + b, 0);
-
-        if (transformedFile !== content) {
-            record.sloc++;
-        }
     }
 
     return chunks.join('');
@@ -453,7 +448,7 @@ exports.analyze = async function (options) {
     }
 
     for (let i = 0; i < files.length; ++i) {
-        const filename = files[i];
+        const filename = files[i].replace(/\\/g, '/');
         if (pattern.test(filename)) {
             if (!report.files[filename]) {
                 internals.instrument(filename);
@@ -551,7 +546,32 @@ internals.file = async function (filename, data, options) {
     };
 
     // Use sourcemap consumer rather than SourceMapSupport.mapSourcePosition itself which perform path transformations
-    const sourcemap = options.sourcemaps ? SourceMapSupport.retrieveSourceMap(ret.filename) : null;
+    let sourcemap = null;
+    if (options.sourcemaps) {
+        sourcemap = SourceMapSupport.retrieveSourceMap(ret.filename);
+        if (!sourcemap) {
+            const smre = /\/\/\#.*data:application\/json[^,]+base64,.*\r?\n?$/;
+            let sourceIndex = data.source.length - 1;
+            while (sourceIndex >= 0 && !smre.test(data.source[sourceIndex])) {
+                sourceIndex--;
+            }
+
+            if (sourceIndex >= 0) {
+                const re = /(?:\/\/[@#][ \t]+sourceMappingURL=([^\s'"]+?)[ \t]*$)|(?:\/\*[@#][ \t]+sourceMappingURL=([^\*]+?)[ \t]*(?:\*\/)[ \t]*$)/mg;
+                let lastMatch;
+                let match;
+                while (match = re.exec(data.source[sourceIndex])) {
+                    lastMatch = match;
+                }
+
+                sourcemap = {
+                    url: lastMatch[1],
+                    map: Buffer.from(lastMatch[1].slice(lastMatch[1].indexOf(',') + 1), 'base64').toString()
+                };
+            }
+        }
+    }
+
     const smc = sourcemap ? await new SourceMapConsumer(sourcemap.map) : null;
 
     // Process each line of code

--- a/lib/reporters/multiple.js
+++ b/lib/reporters/multiple.js
@@ -2,7 +2,7 @@
 
 // Load modules
 
-const Hoek = require('hoek');
+const { cloneDeep } = require('lodash');
 const Reporters = require('./index');
 
 
@@ -17,7 +17,7 @@ exports = module.exports = internals.Reporter = function (options) {
 
     options.reporter.forEach((reporter, index) => {
 
-        const reporterOptions = Hoek.clone(options);
+        const reporterOptions = cloneDeep(options);
         reporterOptions.reporter = reporter;
 
         if (options.output[index] === 'stdout') {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -3,6 +3,7 @@
 // Load modules
 
 const Hoek = require('hoek');
+const { cloneDeep } = require('lodash');
 const Seedrandom = require('seedrandom');
 const WillCall = require('will-call');
 const Reporters = require('./reporters');
@@ -263,7 +264,7 @@ internals.executeExperiments = async function (experiments, state, skip, parentC
     for (const experiment of experiments) {
         const skipExperiment = skip || experiment.options.skip || !internals.experimentHasTests(experiment, state) || (state.options.bail && state.report.failures);
 
-        state.currentContext = parentContext ? Hoek.clone(parentContext) : {};
+        state.currentContext = parentContext ? cloneDeep(parentContext) : {};
 
         // Before
 
@@ -371,7 +372,7 @@ internals.executeTests = async function (experiment, state, skip) {
 
         const start = Date.now();
         try {
-            test.context = Hoek.clone(state.currentContext);
+            test.context = cloneDeep(state.currentContext);
             await internals.protect(test, state);
         }
         catch (ex) {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "hoek": "6.x.x",
     "json-stable-stringify": "1.x.x",
     "json-stringify-safe": "5.x.x",
+    "lodash": "^4.17.x",
     "mkdirp": "0.5.x",
     "seedrandom": "2.4.x",
     "source-map": "0.7.x",

--- a/test/cli.js
+++ b/test/cli.js
@@ -103,7 +103,7 @@ describe('CLI', () => {
         const result = await RunCli(['test/cli_error/parse.js']);
         expect(result.code).to.equal(1);
         expect(result.errorOutput).to.contain('Error requiring file');
-        expect(result.errorOutput).to.contain('cli_error/parse_invalid.js:5');
+        expect(result.errorOutput).to.contain(Path.normalize('cli_error/parse_invalid.js') + ':5');
         expect(result.errorOutput).to.not.contain('UnhandledPromiseRejectionWarning');
     });
 

--- a/test/coverage/sourcemaps-transformed.inl
+++ b/test/coverage/sourcemaps-transformed.inl
@@ -1,0 +1,3 @@
+'use strict';// Load modules
+// Declare internals
+const internals={};exports.method=function(value){while(value){value=false;}return value;};

--- a/test/runner.js
+++ b/test/runner.js
@@ -201,7 +201,7 @@ describe('Runner', () => {
         const notebook = await Lab.execute(script, {}, null);
         expect(notebook.tests).to.have.length(1);
         expect(notebook.failures).to.equal(1);
-        expect(notebook.tests[0].err.stack).to.contain('test/runner.js');
+        expect(notebook.tests[0].err.stack).to.contain(Path.normalize('test/runner.js'));
     });
 
     it('should fail test that returns a rejected promise', async () => {

--- a/test/transform.js
+++ b/test/transform.js
@@ -82,10 +82,10 @@ describe('Transform', () => {
 
         require('./transform/basic-transform'); // prime the cache
 
-        const rel = Transform.retrieveFile('test/transform/basic-transform.new');
+        const rel = Transform.retrieveFile(Path.normalize('test/transform/basic-transform.new'));
         expect(rel).to.not.contain('!NOCOMPILE!');
 
-        const abs = Transform.retrieveFile(process.cwd() + '/test/transform/basic-transform.new');
+        const abs = Transform.retrieveFile(Path.normalize(process.cwd() + '/test/transform/basic-transform.new'));
         expect(abs).to.not.contain('!NOCOMPILE!');
     });
 });
@@ -112,7 +112,7 @@ describe('Transform.install', () => {
 
         const Test = require('./transform/sourcemaps');
 
-        expect(Test.method(false)).to.equal(false);
+        expect(Test.method(true)).to.equal(false);
 
         const Test2 = require('./transform/exclude/transform-basic');
 


### PR DESCRIPTION
This also fixes issue #886 "--coverage-all fails to find any files on Windows", which still has issues after #888.

I have also fixed a few tests that relied on path strings to work with Windows paths.