### PR TITLE
Add '--mutable-context' option to allow tests to mutate context.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Lead Maintainer: [Wyatt Preul](https://github.com/geek)
 - `--lint-options` - specify options to pass to linting program. It must be a string that is JSON.parse(able).
 - `-m`, `--timeout` - individual tests timeout in milliseconds (zero disables timeout). Defaults to 2 seconds.
 - `-M`, `--context-timeout` - default timeouts for before, after, beforeEach and afterEach in milliseconds. Disabled by default.
+- `--mutable-context` - allow tests to mutate flags.context. Disabled by default.
 - `-o`, `--output` - file to write the report to, otherwise sent to stdout.
 - `-p`, `--default-plan-threshold` - sets the minimum number of assertions a test must run. Overridable with [`plan`](#plan).
 - `-P`, `--pattern` - only load files with the given pattern in the name.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -313,6 +313,11 @@ internals.options = function () {
             description: 'linter warnings threshold in absolute value',
             default: null
         },
+        'mutable-context': {
+            type: 'boolean',
+            description: 'allow tests to mutate flags.context',
+            default: null
+        },
         output: {
             alias: 'o',
             type: 'string',
@@ -405,6 +410,7 @@ internals.options = function () {
         'lint-fix': false,
         'lint-errors-threshold': 0,
         'lint-warnings-threshold': 0,
+        'mutable-context': false,
         paths: ['test'],
         reporter: 'console',
         shuffle: false,
@@ -440,7 +446,7 @@ internals.options = function () {
     const keys = ['assert', 'bail', 'colors', 'context-timeout', 'coverage', 'coverage-exclude',
         'coverage-path', 'coverage-all', 'coverage-flat', 'coverage-pattern', 'default-plan-threshold', 'dry', 'environment', 'flat', 'globals', 'grep',
         'lint', 'lint-errors-threshold', 'lint-fix', 'lint-options', 'lint-warnings-threshold',
-        'linter', 'output', 'pattern', 'reporter', 'seed', 'shuffle', 'silence',
+        'linter', 'mutable-context', 'output', 'pattern', 'reporter', 'seed', 'shuffle', 'silence',
         'silent-skips', 'sourcemaps', 'threshold', 'timeout', 'transform', 'verbose'];
     for (let i = 0; i < keys.length; ++i) {
         if (argv.hasOwnProperty(keys[i]) && argv[keys[i]] !== undefined && argv[keys[i]] !== null) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -56,7 +56,9 @@ internals.defaults = {
     lint: false,
     'lint-fix': false,
     'lint-errors-threshold': 0,
-    'lint-warnings-threshold': 0
+    'lint-warnings-threshold': 0,
+
+    'mutable-context': false
 };
 
 
@@ -263,7 +265,15 @@ internals.executeExperiments = async function (experiments, state, skip, parentC
     for (const experiment of experiments) {
         const skipExperiment = skip || experiment.options.skip || !internals.experimentHasTests(experiment, state) || (state.options.bail && state.report.failures);
 
-        state.currentContext = parentContext ? Hoek.clone(parentContext) : {};
+        if (!parentContext) {
+            state.currentContext = {};
+        }
+        else if (state.options['mutable-context']) {
+            state.currentContext = parentContext;
+        }
+        else {
+            state.currentContext = Hoek.clone(parentContext);
+        }
 
         // Before
 
@@ -371,7 +381,13 @@ internals.executeTests = async function (experiment, state, skip) {
 
         const start = Date.now();
         try {
-            test.context = Hoek.clone(state.currentContext);
+            if (state.options['mutable-context']) {
+                test.context = state.currentContext;
+            }
+            else {
+                test.context = Hoek.clone(state.currentContext);
+            }
+
             await internals.protect(test, state);
         }
         catch (ex) {

--- a/test/cli.js
+++ b/test/cli.js
@@ -356,6 +356,24 @@ describe('CLI', () => {
         expect(result.output).to.not.contain('##before##');
     });
 
+    it('defaults to immutable context', async () => {
+
+        const result = await RunCli(['test/cli_context/before.js']);
+
+        expect(result.errorOutput).to.equal('');
+        expect(result.code).to.equal(0);
+        expect(result.output).to.contain('##original##');
+    });
+
+    it('can specify mutable-context for test functions', async () => {
+
+        const result = await RunCli(['test/cli_context/before.js', '--mutable-context']);
+
+        expect(result.errorOutput).to.equal('');
+        expect(result.code).to.equal(0);
+        expect(result.output).to.contain('##mutated##');
+    });
+
     it('can include files for coverage with the --coverage-path argument', async () => {
 
         const result = await RunCli(['test/cli_coverage', '-t', '100', '--coverage-path', 'test/cli_coverage/include', '-a', 'code']);

--- a/test/cli_context/before.js
+++ b/test/cli_context/before.js
@@ -1,0 +1,39 @@
+'use strict';
+
+// Load modules
+
+const Code = require('code');
+const _Lab = require('../../test_runner');
+
+
+// Declare internals
+
+const internals = {};
+
+
+// Test shortcuts
+
+const lab = exports.lab = _Lab.script();
+const before = lab.before;
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
+
+before(({ context }) => {
+
+  context._message = '##original##';
+});
+
+describe('test context', () => {
+
+  it('test tries to change context', ({ context }) => {
+
+    context._message = '##mutated##';
+  })
+
+  it('test outputs context._message', ({ context: { _message } }) => {
+
+    console.log(_message);
+    expect(1).to.equal(1);
+  });
+});

--- a/test/runner.js
+++ b/test/runner.js
@@ -1656,6 +1656,58 @@ describe('Runner', () => {
         expect(notebook.failures).to.equal(1);
     });
 
+    it('defaults to an immutable test context', async () => {
+
+        const script = Lab.script({ schedule: false });
+        script.experiment('context', () => {
+
+            script.before(({ context }) => {
+
+                context._message = '##original##';
+            });
+
+            script.test('test attempts to mutate context', ({ context }) => {
+
+                context._message = '##mutated##';
+            });
+
+            script.test('test successfully mutated context', ({ context: { _message } }) => {
+
+                expect(_message).to.equal('##mutated##');
+            });
+        });
+
+        const notebook = await Lab.execute(script, null);
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.failures).to.equal(1);
+    });
+
+    it('allows mutable test context', async () => {
+
+        const script = Lab.script({ schedule: false });
+        script.experiment('context', () => {
+
+            script.before(({ context }) => {
+
+                context._message = '##original##';
+            });
+
+            script.test('test attempts to mutate context', ({ context }) => {
+
+                context._message = '##mutated##';
+            });
+
+            script.test('test successfully mutated context', ({ context: { _message } }) => {
+
+                expect(_message).to.equal('##mutated##');
+            });
+        });
+
+        const notebook = await Lab.execute(script, { 'mutable-context': true });
+        expect(notebook.tests).to.have.length(2);
+        expect(notebook.failures).to.equal(0);
+    });
+
     it('nullifies test context on finish', async () => {
 
         const script = Lab.script({ schedule: false });


### PR DESCRIPTION
Currently I have been executing this hack in `before(({ context }) => ... )` to allow mutable context...
```
    /*
     * @HACK
     * Allow the lab context to be mutable across tests by fooling Hoek.clone(context) into thinking we are Immutable.js...
     * Hopefully upstream makes this a config option at some point...
     */
    const labContextPrototype = Object.getPrototypeOf(context)
    if (!labContextPrototype) {
        Object.setPrototypeOf(context, {
            isImmutable: () => false
        })
    } else if (!labContextPrototype.isImmutable) {
        Object.setPrototypeOf(context, {
            ...labContextPrototype,
            isImmutable: () => false
        })
    }
```

having an option to explicitly enable tests to mutate context would be more ideal! :D