### PR TITLE
Use util.inspect() for console reporter

### DIFF
--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -1,9 +1,8 @@
 'use strict';
 
+const Util = require('util');
 
 const Diff = require('diff');
-const StringifySafe = require('json-stringify-safe');
-const StableStringify = require('json-stable-stringify');
 
 
 const internals = {
@@ -11,10 +10,9 @@ const internals = {
 };
 
 
-internals.stringify = (obj, serializer, indent) => {
+internals.stringify = (obj, indent) => {
 
-    return StableStringify(obj,
-        { space: indent, replacer: StringifySafe.getSerialize(serializer) });
+    return Util.inspect(obj, { compact: !indent, depth: Infinity, maxArrayLength: Infinity, breakLength: 80, sorted: true });
 };
 
 
@@ -97,29 +95,6 @@ internals.spacer = function (length) {
 };
 
 
-internals.stringifyReplacer = function (key, value) {
-
-    // Show usually invisible values from JSON.stringify in a different way,
-    // follow the bracket format of json-stringify-safe.
-
-    if (value === undefined) {
-        return '[undefined]';
-    }
-
-    if (typeof value === 'function' || value === Infinity || value === -Infinity) {
-        return '[' + value.toString() + ']';
-    }
-
-    /* $lab:coverage:off$ */ // There is no way to cover that in node 0.10
-    if (typeof value === 'symbol') {
-        return '[' + value.toString() + ']';
-    }
-    /* $lab:coverage:on$ */
-
-    return value;
-};
-
-
 internals.Reporter.prototype.end = function (notebook) {
 
     if (this.settings.progress) {
@@ -183,8 +158,8 @@ internals.Reporter.prototype.end = function (notebook) {
             if (test.err.actual !== undefined &&
                 test.err.expected !== undefined) {
 
-                const actual = internals.stringify(test.err.actual, internals.stringifyReplacer, 2);
-                const expected = internals.stringify(test.err.expected, internals.stringifyReplacer, 2);
+                const actual = internals.stringify(test.err.actual, true);
+                const expected = internals.stringify(test.err.expected, true);
 
                 output += '      ' + whiteRedBg('actual') + ' ' + blackGreenBg('expected') + '\n\n      ';
 
@@ -229,12 +204,12 @@ internals.Reporter.prototype.end = function (notebook) {
 
             if (test.err.data) {
                 const isObject = typeof test.err.data === 'object' && !Array.isArray(test.err.data);
-                let errorData = internals.stringify(test.err.data, null, isObject ? 4 : null);
+                let errorData = internals.stringify(test.err.data, isObject);
                 if (isObject) {
-                    errorData = errorData.replace(/(\n\s*)"(.*)"\:/g, '$1$2:').split('\n').slice(1, -1).join('\n');
+                    errorData = errorData.split('\n').slice(1, -1).join('\n');
                 }
 
-                output += gray('\n      Additional error data:\n' + errorData.replace(/^/gm, '      ')) + '\n';
+                output += gray('\n      Additional error data:\n' + errorData.replace(/^/gm, '        ')) + '\n';
             }
 
             output += '\n';

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
     "espree": "5.x.x",
     "find-rc": "4.x.x",
     "handlebars": "4.x.x",
-    "json-stable-stringify": "1.x.x",
-    "json-stringify-safe": "5.x.x",
     "mkdirp": "0.5.x",
     "seedrandom": "2.x.x",
     "source-map": "0.7.x",

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -330,7 +330,7 @@ describe('Reporter', () => {
 
             const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, output: false });
             expect(code).to.equal(1);
-            expect(output).to.contain('"e": 665');
+            expect(output).to.contain('e: 665');
             expect(output).to.contain('1 of 1 tests failed');
             expect(output).to.contain('Test duration:');
             expect(output).to.contain('No global variable leaks detected');
@@ -520,7 +520,7 @@ describe('Reporter', () => {
             expect(output).to.contain('1 of 1 tests failed');
             expect(output).to.contain('Failed tests');
             expect(output).to.contain('Additional error data:');
-            expect(output).to.contain('[1,2,3]');
+            expect(output).to.contain('[ 1, 2, 3 ]');
         });
 
         it('generates a report with caught error (data object)', async () => {
@@ -1178,7 +1178,7 @@ describe('Reporter', () => {
 
             const { output } = await Lab.report(script, { reporter: 'console', colors: false, output: false, assert: false });
             expect(output).to.contain('Failed tests:');
-            expect(output).to.contain('[Circular ~]');
+            expect(output).to.contain('[Circular]');
             expect(output).to.contain('Fail');
         });
 


### PR DESCRIPTION
I don't know how much sense this patch makes, but I created it to solve #914.

Basically, I have replaced the serialization of the reported object / diff. Instead of using `JSON.stringify()`, I use the node built-in `util.inspect()`.

The existing JSON-based serialization is not ideal, and is not able to represent modern types in a reasonable manner. E.g. the current implementation doesn't support `Map` and `Set` (represented as `{}`), or `BigInt` (crashes).

Using `util.inspect()` have the great advantage, that it can serialize all native types into somewhat reasonable representations, and should be updated with any new types as they become available.

One issue with this, is that node@8 doesn't support the `compact` and `sorted` options, resulting in 2 test failures.