### PR TITLE
Support multiple "only" flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ lab.experiment('math', () => {
 
 Both `test()` and `experiment()` accept an optional `options` argument which must be an object with the following optional keys:
 - `timeout` -  set a test or experiment specific timeout in milliseconds. Defaults to the global timeout (`2000`ms or the value of `-m`).
-- `skip` - skip execution. Cannot be overridden in children once parent is set to skip.
+- `skip` - skip execution. When used on an experiment, all children will be skipped - even if they are marked with `only`.
 - `only` - marks all other tests or experiments with `skip`.
 
 You can also append `.only(…)` or `.skip(…)` to `test` and `experiment` instead of using `options`:

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -150,6 +150,11 @@ exports.execute = async function (scripts, options, reporter) {
     if (onlyNodes.length) {
         onlyNodes.forEach((onlyNode) => {
 
+            internals.markParentsAsOnly(onlyNode.experiment);
+        });
+
+        onlyNodes.forEach((onlyNode) => {
+
             internals.skipAllButOnly(scripts, onlyNode);
         });
     }
@@ -245,6 +250,19 @@ internals.notOnly = (element) => {
 internals.enableSkip = (element) => {
 
     element.options.skip = true;
+};
+
+internals.markParentsAsOnly = (element) => {
+
+    if (!element.options.skip) {
+
+        element.options.only = true;
+
+        if (element.parent) {
+
+            internals.markParentsAsOnly(element.parent);
+        }
+    }
 };
 
 internals.shuffle = function (scripts, seed) {

--- a/test/cli.js
+++ b/test/cli.js
@@ -578,7 +578,7 @@ describe('CLI', () => {
 
         const result = await RunCli(['test/cli_only-skip/onlyMultiple.js']);
 
-        expect(result.combinedOutput).to.contain('8 skipped');
+        expect(result.combinedOutput).to.contain('7 skipped');
         expect(result.code).to.equal(0);
     });
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -623,6 +623,7 @@ describe('Runner', () => {
                     script.experiment('level 4a', () => {
 
                         script.test('test a', () => {
+
                             throw new Error();
                         });
 
@@ -638,6 +639,7 @@ describe('Runner', () => {
                     script.experiment('level 4b', () => {
 
                         script.test('test a', () => {
+
                             throw new Error();
                         });
 
@@ -688,6 +690,26 @@ describe('Runner', () => {
         const notebook = await Lab.execute(script, {}, null);
         expect(notebook.tests).to.have.length(5);
         expect(notebook.tests.filter((test) => test.skipped)).to.have.length(3);
+        expect(notebook.failures).to.equal(0);
+    });
+
+    it('skips "only" tests when ancestor experiment is skipped', async () => {
+
+        const script = Lab.script();
+        script.experiment.skip('test', () => {
+
+            script.experiment('subexperiment1', () => {
+
+                script.test.only('s1', () => {
+
+                    throw new Error();
+                });
+            });
+        });
+
+        const notebook = await Lab.execute(script, {}, null);
+        expect(notebook.tests).to.have.length(1);
+        expect(notebook.tests.filter((test) => test.skipped)).to.have.length(1);
         expect(notebook.failures).to.equal(0);
     });
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -583,6 +583,7 @@ describe('Runner', () => {
     });
 
     it('skips everything except "only" tests when multiple "only" tests are in the same experiment', async () => {
+
         const script = Lab.script();
         script.experiment('test', () => {
 
@@ -611,6 +612,7 @@ describe('Runner', () => {
     });
 
     it('skips everything except "only" tests when multiple "only" tests are deeply nested in the same experiment', async () => {
+
         const script = Lab.script();
         script.experiment('test', () => {
 
@@ -652,6 +654,7 @@ describe('Runner', () => {
     });
 
     it('skips everything except "only" tests when "only" tests are in different experiments', async () => {
+
         const script = Lab.script();
         script.experiment('test', () => {
 
@@ -689,6 +692,7 @@ describe('Runner', () => {
     });
 
     it('skips everything except "only" tests when "only" tests are in different scripts', async () => {
+
         const script1 = Lab.script();
         script1.experiment('test', () => {
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -582,8 +582,113 @@ describe('Runner', () => {
         expect(notebook.failures).to.equal(0);
     });
 
-    it('reports an error if there is more than one "only", even accross multiple scripts', async () => {
+    it('skips everything except "only" tests when multiple "only" tests are in the same experiment', async () => {
+        const script = Lab.script();
+        script.experiment('test', () => {
 
+            script.experiment('subexperiment', () => {
+
+                script.test('s1', () => {
+
+                    throw new Error();
+                });
+
+                script.test.only('s2', () => {});
+
+                script.test.only('s3', () => {});
+            });
+
+            script.test('a', () => {
+
+                throw new Error();
+            });
+        });
+
+        const notebook = await Lab.execute(script, {}, null);
+        expect(notebook.tests).to.have.length(4);
+        expect(notebook.tests.filter((test) => test.skipped)).to.have.length(2);
+        expect(notebook.failures).to.equal(0);
+    });
+
+    it('skips everything except "only" tests when multiple "only" tests are deeply nested in the same experiment', async () => {
+        const script = Lab.script();
+        script.experiment('test', () => {
+
+            script.experiment('level 2a', () => {
+
+                script.experiment('level 3a', () => {
+
+                    script.experiment('level 4a', () => {
+
+                        script.test('test a', () => {
+                            throw new Error();
+                        });
+
+                        script.test.only('test b', () => {});
+                    });
+                });
+            });
+
+            script.experiment('level 2b', () => {
+
+                script.experiment('level 3b', () => {
+
+                    script.experiment('level 4b', () => {
+
+                        script.test('test a', () => {
+                            throw new Error();
+                        });
+
+                        script.test.only('test b', () => {});
+                    });
+                });
+            });
+        });
+
+        const notebook = await Lab.execute(script, {}, null);
+        expect(notebook.tests).to.have.length(4);
+        expect(notebook.tests.filter((test) => test.skipped)).to.have.length(2);
+        expect(notebook.failures).to.equal(0);
+    });
+
+    it('skips everything except "only" tests when "only" tests are in different experiments', async () => {
+        const script = Lab.script();
+        script.experiment('test', () => {
+
+            script.experiment('subexperiment1', () => {
+
+                script.test('s1', () => {
+
+                    throw new Error();
+                });
+
+                script.test.only('s2', () => {});
+            });
+
+            script.experiment('subexperiment2', () => {
+
+                script.test('s1', () => {
+
+                    throw new Error();
+                });
+
+                script.test.only('s2', () => {});
+
+            });
+
+            script.test('a', () => {
+
+                throw new Error();
+            });
+        });
+
+        const notebook = await Lab.execute(script, {}, null);
+        expect(notebook.tests).to.have.length(5);
+        expect(notebook.tests.filter((test) => test.skipped)).to.have.length(3);
+        expect(notebook.failures).to.equal(0);
+    });
+
+    it('skips everything except "only" tests when "only" tests are in different scripts', async () => {
         const script1 = Lab.script();
         script1.experiment('test', () => {
 
@@ -608,24 +713,15 @@ describe('Runner', () => {
             });
         });
         const script2 = Lab.script();
-        script2.experiment.only('test2', () => {
+        script2.experiment('test2', () => {
 
-            script2.test('x1', () => {
-
-                throw new Error();
-            });
+            script2.test.only('x1', () => {});
         });
 
-        try {
-            await Lab.execute([script1, script2], {}, null);
-        }
-        catch (ex) {
-            expect(ex.message).to.contain([
-                'Multiple tests are marked as "only":',
-                'Test: test a',
-                'Experiment: test2'
-            ]);
-        }
+        const notebook = await Lab.execute([script1, script2] , {}, null);
+        expect(notebook.tests).to.have.length(5);
+        expect(notebook.tests.filter((test) => test.skipped)).to.have.length(3);
+        expect(notebook.failures).to.equal(0);
     });
 
     it('skips before function in non-run experiment', async () => {


### PR DESCRIPTION
Multiple "only" flags currently work, but only in certain cases
depending on experimnet depth. This PR implements full support for
multiple "only" flags, regardless of same experiment, different
experimnt, different script, and depth.

As an approach, prior to marking non-only tests as skipped, we now mark
all parents of an "only" element as "only" (unless they are explicitly
skipped).

Also, fixed a few incorrect tests.