### PR TITLE
TS: Uses an inferred generic on flags.mustCall

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -380,7 +380,7 @@ declare namespace script {
          * 
          * @returns a wrapped function.
          */
-        mustCall(func: Function, count: number): Function;
+        mustCall<T extends (...args: any[]) => any>(func: T, count: number): T;
 
         /**
          * Adds notes to the test log.


### PR DESCRIPTION
Previously, the type of the function returned by `flags.mustCall` did not match the type of the function being passed in. As a result, attempts to use the function returned by `flags.mustCall` would lack type safety.