### PR TITLE
TS: String object type -> string literal type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -308,26 +308,26 @@ declare namespace script {
 
     interface Experiment {
 
-        (title: String, content: () => void): void;
-        (title: String, options: Omit<TestOptions, 'plan'>, content: () => void): void;
+        (title: string, content: () => void): void;
+        (title: string, options: Omit<TestOptions, 'plan'>, content: () => void): void;
 
-        only(title: String, content: () => void): void;
-        only(title: String, options: Omit<TestOptions, 'plan'>, content: () => void): void;
+        only(title: string, content: () => void): void;
+        only(title: string, options: Omit<TestOptions, 'plan'>, content: () => void): void;
 
-        skip(title: String, content: () => void): void;
-        skip(title: String, options: Omit<TestOptions, 'plan'>, content: () => void): void;
+        skip(title: string, content: () => void): void;
+        skip(title: string, options: Omit<TestOptions, 'plan'>, content: () => void): void;
     }
 
     interface Test {
 
-        (title: String, test: Action): void;
-        (title: String, options: TestOptions, test: Action): void;
+        (title: string, test: Action): void;
+        (title: string, options: TestOptions, test: Action): void;
 
-        only(title: String, test: Action): void;
-        only(title: String, options: TestOptions, test: Action): void;
+        only(title: string, test: Action): void;
+        only(title: string, options: TestOptions, test: Action): void;
 
-        skip(title: String, test: Action): void;
-        skip(title: String, options: TestOptions, test: Action): void;
+        skip(title: string, test: Action): void;
+        skip(title: string, options: TestOptions, test: Action): void;
     }
 
     interface Action {


### PR DESCRIPTION

I suspect the use of the `String` object type was an accident of history. This PR makes moves to a more consistent use of types for literal types.

> Note: there is some [weirdness about type compatibility between `String` and `string`](https://www.typescriptlang.org/play/#code/C4TwDgpgBAhlC8UDKwBOBLAdgcyhAHsBJgCYDOUZaWuA-FAOQgRkNQBcjmA9gwNwAoUJCgAjBJWo48hYuWRS6jZqw5deg4dADGElBmkEipCvppR6TFm04Me-IA).