### PR TITLE
update test assertion for node core changes

### DIFF
--- a/test/reporters.js
+++ b/test/reporters.js
@@ -1213,7 +1213,7 @@ describe('Reporter', () => {
 
             const { output } = await Lab.report(script, { reporter: 'console', colors: false, output: false, assert: false });
             expect(output).to.contain('Failed tests:');
-            expect(output).to.contain('[Circular]');
+            expect(output).to.match(/\[Circular( \*1)?\]/);
             expect(output).to.contain('Fail');
         });
 


### PR DESCRIPTION
The way circular references are inspected in Node core changed recently. This commit updates a test that was failing on the latest Node versions to handle the change.