### PR TITLE
Update to relocate Flags subsection on lab's hapi.dev page

### DIFF
--- a/API.md
+++ b/API.md
@@ -412,7 +412,7 @@ Same as calling [`script.test()`](#scripttesttitle-options-test) with `only` opt
 
 Same as calling [`script.test()`](#scripttesttitle-options-test) with `skip` option set to `true`.
 
-#### `Flags`
+### `Flags`
 
 The `test` function is passed a `flags` object that can be used to create notes or set a function to execute for cleanup operations after the test is complete.
 


### PR DESCRIPTION
Hi there!

On lab's API docs page, the "Flags" subsection appears nested under `script.test.skip`. I found this counterintuitive (more theoretically, than actually confusing :) ) because "Flags" are relevant to all `script.test` methods, whereas this nesting suggests (to me at least) they're specific to `script.test.skip`. 

<img width="334" alt="current Flags docs layout" src="https://user-images.githubusercontent.com/7771785/72207687-5d50ac80-3469-11ea-9a55-93e6371bffe9.png">

Do y'all think it would be beneficial to somehow relocate "Flags" to make that feature more apparent?

This change proposes moving the "Flags" header up a level, so it'll appear as its own section, on the same level as the other methods, with the individual flags nested within it. Seemed like the least intrusive way to get close enough.

e.g. 

```
- script.test
- script.test.only
- script.test.skip
+ Flags
    - context
    - mustCall
    - note
...etc
```