### PR TITLE
feat: refactor handlebars into template literals.

### DIFF
--- a/.labrc.js
+++ b/.labrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+    enableTemplateStringHTMLReporter: 'true'
+};

--- a/.labrc.js
+++ b/.labrc.js
@@ -1,3 +1,3 @@
 module.exports = {
     enableTemplateStringHTMLReporter: 'true'
-};
+}

--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@
 - [Changelog](https://hapi.dev/family/lab/changelog/)
 - [Project policies](https://hapi.dev/policies/)
 - [Free and commercial support options](https://hapi.dev/support/)
+
+
+# Notes
+- Replacing Handlebars with template strings.  Implement similar to https://medium.com/your-majesty-co/frameworkless-javascript-template-literals-the-best-thing-since-sliced-bread-d97f000ce955

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -7,9 +7,18 @@ const Handlebars = require('handlebars');
 const Hoek = require('@hapi/hoek');
 const SourceMap = require('source-map');
 const SourceMapSupport = require('source-map-support');
+const { reportTemplate } = require('./html/report.js');
 
+const FindRc = require('find-rc');
 
 const internals = {};
+
+internals.rcPath = FindRc('lab');
+/* $lab:coverage:off$ */
+internals.rc = internals.rcPath ? require(internals.rcPath) : {};
+/* $lab:coverage:on$ */
+
+const { enableTemplateStringHTMLReporter } = internals.rc;
 
 
 exports = module.exports = internals.Reporter = function (options) {
@@ -18,7 +27,7 @@ exports = module.exports = internals.Reporter = function (options) {
 
     const filename = Path.join(__dirname, 'html', 'report.html');
     const template = Fs.readFileSync(filename, 'utf8');
-
+    /* $lab:coverage:off$ */
     // Display all valid numbers except zeros
     Handlebars.registerHelper('number', (number) => {
 
@@ -60,6 +69,7 @@ exports = module.exports = internals.Reporter = function (options) {
         const stack = err.stack.slice(err.stack.indexOf('\n') + 1).replace(/^\s*/gm, '  ');
         return new Handlebars.SafeString(Hoek.escapeHtml(stack));
     });
+    /* $lab:coverage:on$ */
 
     const partialsPath = Path.join(__dirname, 'html', 'partials');
     const partials = Fs.readdirSync(partialsPath);
@@ -284,7 +294,14 @@ internals.Reporter.prototype.end = async function (notebook) {
         }, this);
     }
 
-    this.report(this.view(context));
+    /* $lab:coverage:off$ */
+    if (enableTemplateStringHTMLReporter === 'true') {
+        this.report(reportTemplate(context));
+    }
+    else {
+        this.report(this.view(context));
+    }
+/* $lab:coverage:on$ */
 };
 
 internals.findLint = function (lint, file) {

--- a/lib/reporters/html/helpers.js
+++ b/lib/reporters/html/helpers.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const Hoek = require('@hapi/hoek');
+
+exports.replace = (str, from, to, flags) => {
+
+    return str.replace(new RegExp(from, flags), to);
+};
+
+// Display all valid numbers except zeros
+exports.number = (number) => {
+
+    return +number || '';
+};
+
+exports.join = (array, separator) => {
+
+    return array.join(separator);
+};
+
+exports.lintJoin = (array) => {
+
+    let str = '';
+
+    for (let i = 0; i < array.length; ++i) {
+        if (str) {
+            str += '&#xa;'; // This is a line break
+        }
+
+        str += Hoek.escapeHtml(array[i]);
+    }
+
+    return `${str}`;
+};
+
+exports.errorMessage = (err) => {
+
+    return `${Hoek.escapeHtml('' + err.message)}`;
+};
+
+exports.errorStack = (err) => {
+
+    const stack = err.stack.slice(err.stack.indexOf('\n') + 1).replace(/^\s*/gm, '  ');
+    return `${Hoek.escapeHtml(stack)}`;
+};

--- a/lib/reporters/html/partials/cov.js
+++ b/lib/reporters/html/partials/cov.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { file } = require('./file');
+
+exports.cov = (coverage) => {
+
+    return `<div id="coverage">
+    <h1>Code Coverage Report</h1>
+    <div class="stats ${coverage.percentClass}">
+        <div class="percentage">${coverage.percent}%</div>
+        <div class="sloc">${coverage.cov.sloc}</div>
+        <div class="hits">${coverage.cov.hits}</div>
+        <div class="misses">${coverage.cov.misses}</div>
+    </div>
+    <div id="filters">
+      <input type="checkbox" checked="" onchange="filter(this)" value="generated" id="show-generated">
+      <label for="show-generated">Show generated files</label>
+    </div>
+    <div id="files">
+        ${coverage.cov.files.map((item, i) => {
+
+        return file(item);
+    })}
+    </div>
+</div>`;
+};

--- a/lib/reporters/html/partials/css.js
+++ b/lib/reporters/html/partials/css.js
@@ -1,0 +1,446 @@
+'use strict';
+
+exports.css = () => `<style>
+    body {
+        font: 14px/1.6 Helvetica, Arial, sans-serif;
+        margin: 0;
+        color: #2c2c2c;
+    }
+
+    #tests, #coverage, #linting {
+        padding: 60px;
+    }
+
+    h1 a:hover {
+        text-decoration: none;
+    }
+
+    a[href^="#"],
+    a[href^="#"]:visited {
+        color: inherit;
+        text-decoration: none;
+    }
+
+    h2 {
+        width: 80%;
+        margin-top: 80px;
+        margin-bottom: 0;
+        font-weight: 100;
+        letter-spacing: 1px;
+    }
+
+    ul {
+        margin-top: 20px;
+        padding: 0 15px;
+        width: 100%;
+    }
+
+    ul li {
+        float: left;
+        width: 40%;
+        margin-top: 5px;
+        margin-right: 60px;
+        list-style: none;
+        padding: 5px 0;
+        font-size: 12px;
+    }
+
+    #menu {
+        position: fixed;
+        font-size: 12px;
+        overflow-y: auto;
+        top: 0;
+        right: 0;
+        margin: 0;
+        height: 100%;
+        padding: 15px 15px;
+        border-left: 1px solid #eee;
+        background-color: #666;
+        z-index: 1;
+    }
+
+    #menu::after {
+        display: block;
+        content: '';
+        padding-top: 80px;
+    }
+
+    #menu li a {
+        display: block;
+        color: white;
+        padding: 0 5px 0 35px;
+        transition: background 300ms;
+        text-decoration: none;
+    }
+
+    #menu li {
+        position: relative;
+        list-style: none;
+    }
+
+    #menu a:hover,
+    #menu a.active {
+        text-decoration: none;
+        background: rgba(255, 255, 255, .4);
+    }
+
+    #menu li:hover .cov {
+        opacity: 1;
+    }
+
+    #menu li .dirname {
+        opacity: .60;
+        padding-right: 2px;
+    }
+
+    #menu li .basename {
+        opacity: 1;
+    }
+
+    #menu .cov, #menu .lint {
+        background: rgba(0, 0, 0, .3);
+        position: absolute;
+        top: 0;
+        font-size: 9px;
+        text-align: center;
+        opacity: .8;
+        width: 22px;
+        border-radius: 10px;
+        padding: 2px 3px;
+    }
+
+    #files .stats:nth-child(2n):not(.hide) {
+        display: inline-block;
+        margin-top: 15px;
+        border: 1px solid #eee;
+        padding: 10px;
+        border-radius: 5px;
+    }
+
+    .stats div {
+        float: left;
+        padding: 0 5px;
+    }
+
+    .stats::after {
+        display: block;
+        content: '';
+        clear: both;
+    }
+
+    .stats .sloc::after {
+        content: ' SLOC';
+        color: #b6b6b6;
+    }
+
+    .stats .percentage::after {
+        content: ' coverage';
+        color: #b6b6b6;
+    }
+
+    .stats .hits::before {
+        content: '(';
+        color: #b6b6b6;
+    }
+
+    .stats .hits::after {
+        content: ' Covered';
+        color: #b6b6b6;
+    }
+
+    .stats .misses::after {
+        content: ' Not Covered)';
+        color: #b6b6b6;
+    }
+
+    .stats .failures::after {
+        content: ' Failures';
+        color: #b6b6b6;
+    }
+
+    .stats .skipped::after {
+        content: ' Skipped';
+        color: #b6b6b6;
+    }
+
+    .stats .test-count::after {
+        content: ' Tests';
+        color: #b6b6b6;
+    }
+
+    .stats .duration::before {
+        content: '(';
+        color: #b6b6b6;
+    }
+
+    .stats .duration::after {
+        content: ' ms)';
+        color: #b6b6b6;
+    }
+
+    .high {
+        color: #00d4b4;
+    }
+
+    .medium {
+        color: #e87d0d;
+    }
+
+    .low {
+        color: #d4081a;
+    }
+
+    .terrible {
+        color: #d4081a;
+        font-weight: bold;
+    }
+
+    #files table {
+        width: 80%;
+        margin-top: 10px;
+        border-collapse: collapse;
+        border: 1px solid #cbcbcb;
+        color: #363636;
+        border-radius: 3px;
+    }
+
+    #files thead {
+        display: none;
+    }
+
+    table td.line,
+    table td.lint,
+    table td.hits,
+    table td.original-line {
+        width: 20px;
+        background: #eaeaea;
+        text-align: right;
+        font-size: 11px;
+        padding: 0 10px;
+        color: #949494;
+        white-space: nowrap;
+    }
+
+    table td.hits {
+        width: 10px;
+        padding: 2px 5px;
+        color: rgba(0, 0, 0, .2);
+        background: #f0f0f0;
+    }
+
+    table td.lint.empty {
+        width: 0;
+        padding: 0;
+    }
+
+    table td.lint > span {
+        border-radius: 50%;
+        width: 8px;
+        height: 8px;
+        display: inline-block;
+        vertical-align: baseline;
+    }
+
+    table td.lint .errors {
+        background-color: red;
+    }
+
+    table td.lint .warnings {
+        background-color: orange;
+    }
+
+    tr.miss td.line,
+    tr.miss td.hits {
+        background: #e6c3c7;
+    }
+
+    tr.miss td {
+        background: #f8d5d8;
+    }
+
+    td.source {
+        padding-left: 15px;
+        line-height: 15px;
+        white-space: pre;
+        font: 12px monaco, monospace;
+    }
+
+    td.source div {
+        display: inline-block;
+    }
+
+    td.source div.true {
+        background: #bae8bf;
+    }
+
+    td.source div.false {
+        background: #e8e5ba;
+    }
+
+    td.source div.never {
+        background: #f8d5d8;
+    }
+
+    #tests table {
+        width: 80%;
+        margin-top: 10px;
+        border-collapse: collapse;
+        border: 1px solid #cbcbcb;
+        color: #363636;
+        border-radius: 3px;
+    }
+
+    #tests thead {
+        background: #F5F5F5;
+    }
+
+    #tests tr {
+        border: 1px solid #ccc;
+    }
+
+    #tests td {
+        padding-left: 8px;
+        vertical-align: top;
+    }
+
+    #tests .success:nth-child(2n) {
+        background: #F5F5F5;
+    }
+
+    #tests .failure {
+        background: #FF9E9E;
+    }
+
+    #tests table .skipped {
+        background: #AA82FF;
+    }
+
+    #tests .success {
+        color: #949494;
+    }
+
+    #tests .failure .test-title {
+        font-weight: bold;
+        margin-top: 5px;
+    }
+
+    #tests .stack {
+        margin-top: 4px;
+        padding-left: 15px;
+        margin-bottom: 12px;
+        font: 12px monaco, monospace;
+        white-space: pre;
+        line-height: 15px;
+    }
+
+    .hide {
+        display: none;
+    }
+
+    .show {
+        display: inherit;
+    }
+
+    #tests table .show {
+        display: table-row;
+    }
+
+    [data-tooltip] {
+        position: relative;
+    }
+
+    [data-tooltip]:hover:before {
+        border: solid;
+        border-color: #333 transparent;
+        border-width: 6px 6px 0 6px;
+        bottom: 20px;
+        content: "";
+        left: 0;
+        position: absolute;
+        z-index: 99;
+    }
+
+    [data-tooltip]:hover:after {
+        background: #333;
+        background: rgba(0, 0, 0, .8);
+        border-radius: 5px;
+        bottom: 26px;
+        color: #fff;
+        left: -10px;
+        padding: 5px 15px;
+        position: absolute;
+        z-index: 98;
+        content: attr(data-tooltip);
+        white-space: pre;
+        text-align: left;
+    }
+
+    .line[data-tooltip]:hover:after {
+        content: "Line number";
+    }
+
+    .hits[data-tooltip]:hover:after {
+        content: "Number of hits";
+    }
+
+    .miss .source[data-tooltip]:hover:after {
+        content: "Missed line";
+    }
+
+    .miss.true[data-tooltip]:hover:after {
+        content: "Condition always true";
+    }
+
+    .miss.false[data-tooltip]:hover:after {
+        content: "Condition always false";
+    }
+
+    .miss.never[data-tooltip]:hover:after {
+        content: "Statement never reached";
+    }
+
+    .lint .errors[data-tooltip]:hover:after {
+        content: "Linting errors:\A" attr(data-tooltip);
+    }
+
+    .lint .warnings[data-tooltip]:hover:after {
+        content: "Linting warnings:\A" attr(data-tooltip);
+    }
+
+    .original-line[data-tooltip]:hover:after {
+        content: "Original line in file " attr(data-tooltip);
+    }
+
+    #filters {
+        width: 75%;
+        margin-top: 25px;
+    }
+
+    #filters label {
+        margin-right: 10px;
+    }
+
+    .lint-stats .lint-errors::after {
+        content: ' linting errors';
+        color: #b6b6b6;
+    }
+
+    .lint-stats .lint-warnings::after {
+        content: ' linting warnings';
+        color: #b6b6b6;
+    }
+
+    .lint-entry {
+        color: #b6b6b6;
+        float: none;
+        padding: 0;
+    }
+
+    .lint-entry .level-ERROR {
+        color: #d4081a;
+    }
+
+    .lint-entry .level-WARNING {
+        color: #e87d0d;
+    }
+</style>`;

--- a/lib/reporters/html/partials/file.js
+++ b/lib/reporters/html/partials/file.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const { line } = require('./line');
+
+exports.file = (item) => {
+
+    const { filename } = item;
+
+    return `<div class="file ${ item.sourcemaps ? `show generated` : `` }">
+    <h2 id="${item.filename}">${item.filename} ${item.generated ? `(transformed to <a href="#${item.generated}">${item.generated})</a>` : ``}</h2>
+    <div class="stats ${item.percentClass}">
+        <div class="percentage">${item.percent}%</div>
+        <div class="sloc">${item.sloc}</div>
+        <div class="hits">${item.hits}</div>
+        <div class="misses">${item.misses}</div>
+    </div>
+    <table>
+        <thead>
+            <tr>
+                <th>Line</th>
+                <th>Lint</th>
+                <th>Hits</th>
+                <th>Source</th>
+                ${item.sourcemaps ? `<th>Original line</th>` : ``}
+            </tr>
+        </thead>
+        <tbody>
+        ${item.source ?
+        `
+        ${Object.entries(item.source).map((subitem,i) =>
+
+        `
+            ${line(filename, subitem[1], i)}
+        `)}` : ``}
+        </tbody>
+    </table>
+</div>`;
+};

--- a/lib/reporters/html/partials/line.js
+++ b/lib/reporters/html/partials/line.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const { number } = require('../helpers');
+const { lint } = require('./lint');
+
+exports.line = (filename, item, key) => {
+
+    return `<tr id="${filename}__${key + 1}" class="${item.miss ? item.chunks ? `chunks` : `miss` : `hit`}">
+  <td class="line" data-tooltip>${key}</td>
+  ${lint(item.lintErrors)}
+  <td class="hits" data-tooltip>${item.miss ? `${number(item.percent)}` : `${number(item.hits)}`}</td>
+  ${item.chunks ?
+        `<td class="source">${item.chunks.map((subitem,i) =>
+
+            `${subitem.miss ? `<div class="miss ${subitem.miss}" data-tooltip>${subitem.source}</div>` : `<div>${subitem.source}</div>`}`
+        ).join('')}</td>`
+        :
+        `<td class="source"${item.miss ? ` data-tooltip` : ``}>${item.source}</td>`
+}
+  ${item.originalFilename ? `<td class="original-line" data-tooltip="${item.originalFilename}"><a href="#${item.originalFilename}__${item.originalLine}">${item.originalLine}</a></td>` : ``}
+</tr>`;
+};

--- a/lib/reporters/html/partials/lint-file.js
+++ b/lib/reporters/html/partials/lint-file.js
@@ -1,0 +1,15 @@
+'use strict';
+
+exports.lintFile = (item) => {
+
+    return `<div class="lint-file">
+    ${item.errors ?
+        `<h2 id="lint-${item.filename}">${item.filename}</h2>
+    <ul>
+    ${item.errors.map((subitem,i) =>
+
+        `<li class="lint-entry">L${subitem.line} - <span class="level-${subitem.severity}">${subitem.severity}</span> - ${subitem.message}</li>`
+    )}
+    </ul>` : ``}
+</div>`;
+};

--- a/lib/reporters/html/partials/lint.js
+++ b/lib/reporters/html/partials/lint.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const { lintJoin } = require('../helpers');
+
+exports.lint = (lintErrors) => {
+
+    if ( lintErrors ) {
+        return `<td class="lint">
+            ${lintErrors.errors ?
+        `<span class="errors" data-tooltip="${lintJoin(lintErrors.errors)}"></span>`
+        : `test`}
+            ${lintErrors.warnings ?
+        `<span class="warnings" data-tooltip="${lintJoin(lintErrors.warnings)}"></span>`
+        : ``}
+        </td>`;
+    }
+
+    return `<td class="lint empty"></td>`;
+
+};

--- a/lib/reporters/html/partials/linting.js
+++ b/lib/reporters/html/partials/linting.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { lintFile } = require('./lint-file');
+
+const lintingPartialMainChild = function (lint) {
+
+    if ( lint.total ) {
+        return `${lint.lint.map((item,i) =>
+
+            lintFile(item,i)
+        )}`;
+    }
+
+    return ``;
+
+};
+
+const lintingPartialMain = function (lint) {
+
+    if ( lint.disabled ) {
+        return `<span>Nothing to show here, linting is disabled.</span>`;
+    }
+
+    return `<div class="lint-stats">
+            <span class="lint-errors ${lint.errorClass}">${lint.totalErrors}</span>
+            <span class="lint-warnings ${lint.warningClass}">${lint.totalWarnings}</span>
+        </div>
+        <div class="lint-files">
+            ${lintingPartialMainChild(lint)}
+        </div>`;
+
+};
+
+exports.linting = (lint) => {
+
+    return `<div id="linting">
+        <h1>Linting Report</h1>
+        ${lintingPartialMain(lint)}
+    </div>`;
+};

--- a/lib/reporters/html/partials/menu.js
+++ b/lib/reporters/html/partials/menu.js
@@ -1,0 +1,25 @@
+'use strict';
+
+exports.menu = (coverage, lint) => {
+
+    return `<div id="menu">
+    <li><a href="#tests">Test Report</a></li>
+    <li><a href="#coverage">Coverage Report</a></li>
+    ${coverage.cov.files.map((item,i) => {
+
+        return `<li class="${item.sourcemaps ? `generated` : ``}">
+        <span class="cov ${item.percentClass}">${item.percent}</span>
+        <a href="#${item.filename}">${item.dirname ? `<span class="dirname">${item.dirname}</span>` : ``}<span class="basename">${item.basename}</span></a>
+    </li>`;
+    })}
+    <li><a href="#linting">Linting Report</a></li>
+    ${lint.lint.map((item,i) => {
+
+        return item.errors.length ?
+            `<li>
+        <span class="lint"><span class="${item.errorClass}">${item.totalErrors}</span> || <span class="${item.warningClass}">${item.totalWarnings}</span></span>
+        <a href="#lint-${item.filename}">${item.filename}</a>
+    </li>` : ``;
+    })}
+</div>`;
+};

--- a/lib/reporters/html/partials/scripts.js
+++ b/lib/reporters/html/partials/scripts.js
@@ -1,0 +1,89 @@
+'use strict';
+
+exports.scripts = () => {
+
+    return `<script>
+  headings = [];
+
+  onload = function () {
+      headings = document.querySelectorAll('h2');
+      reset();
+  };
+
+  onscroll = function (e) {
+      var heading = find(window.scrollY);
+      if (!heading) {
+        var current = document.querySelector('#menu a.active');
+        if (current) {
+          current.className = '';
+        }
+        return;
+      }
+      var links = document.querySelectorAll('#menu a')
+              , link;
+
+      for (var i = 0, len = links.length; i < len; ++i) {
+          link = links[i];
+          link.className = link.getAttribute('href') == '#' + heading.id ? 'active' : '';
+      }
+  };
+
+  function find (y) {
+      var i = headings.length
+              , heading;
+
+      while (i--) {
+          heading = headings[i];
+          if (y >= heading.offsetTop) {
+              return heading;
+          }
+      }
+  }
+
+  function toggle (className) {
+
+      var elements = document.getElementsByClassName(className);
+
+      for (var i = 0, il = elements.length; i < il; ++i) {
+          var element = elements[i];
+
+          if (element.classList.contains('hide')) {
+              element.classList.remove('hide');
+              element.classList.add('show');
+          }
+          else {
+              element.classList.remove('show');
+              element.classList.add('hide');
+          }
+      };
+  }
+
+  function reset () {
+
+      var shownElements = document.getElementsByClassName('show');
+      var filterElements = document.querySelectorAll('input[type=checkbox]');
+
+      for (var i = 0, il = filterElements.length; i < il; ++i) {
+          filterElements[i].checked = false;
+      }
+
+      // Check any filters with visible elements
+      for (i = 0, il = shownElements.length; i < il; ++i) {
+          var shownElement = shownElements[i];
+          var classNames = shownElement.className.split(' ');
+          for (var ci = 0, cl = classNames.length; ci < cl; ++ci){
+              var element = document.getElementById('show-' + classNames[ci]);
+              if (element) {
+                  element.checked = true;
+              }
+          }
+      }
+  };
+
+  function filter (element) {
+
+      toggle(element.value);
+      reset();
+  }
+</script>`;
+};

--- a/lib/reporters/html/partials/tests.js
+++ b/lib/reporters/html/partials/tests.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const { replace, join, errorMessage, errorStack } = require('../helpers');
+
+exports.tests = (failures, skipped, tests, duration, paths, errors) => {
+
+    return `<div id="tests">
+  <h1>Test Report</h1>
+  <div class="stats ${failures.length ? `terrible` : skipped.length ? `low` : `high`}">
+      <div class="failures">${failures.length}</div>
+      <div class="skipped">${skipped.length}</div>
+      <div class="test-count">${tests.length}</div>
+      <div class="duration">${duration}</div>
+  </div>
+  <div id="filters">
+      <input type="checkbox" checked="" onchange="filter(this)" value="success" id="show-success">
+      <label for="show-success">Show Success</label>
+      <input type="checkbox" checked="" onchange="filter(this)" value="failure" id="show-failure">
+      <label for="show-failure">Show Failure</label>
+      <br>
+      ${paths.map((item,i) =>
+
+        `
+      <input type="checkbox" checked="" onchange="filter(this)" value="${item}" id="show-${item}">
+      <label for="show-${item}">${replace(item, '\_', ' ', 'gi')}</label>
+      `)}
+  </div>
+  <table>
+      <thead>
+      <tr>
+          <th>ID</th>
+          <th>Title</th>
+          <th>Duration (ms)</th>
+      </tr>
+      </thead>
+      <tbody>
+      ${tests.map((item,i) =>
+
+        `
+      <tr class="show ${join(item.path, ' ')} ${item.err ? `failure` : `success` }">
+        <td class="test-id">${item.id}</td>
+        <td class="test-title">${item.title}
+            ${item.err ? `<div class="stack">${item.err.stack}</div>` : ``}
+        </td>
+        <td class="test-duration">${item.duration}</td>
+      </tr>
+      `)}
+      </tbody>
+  </table>
+
+  ${errors.length ?
+        `<h2>Script errors :</h2>
+  <ul>
+    ${errors.map((item, i) =>
+
+        `
+    <li>
+      <div>${errorMessage(item)}</div>
+      ${item.stack ?
+        `<pre>${errorStack(item)}</pre>` : ``}
+    </li>
+    `)}
+  </ul>` : ``}
+</div>`;
+};

--- a/lib/reporters/html/report.js
+++ b/lib/reporters/html/report.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { scripts } = require('./partials/scripts');
+const { css } = require('./partials/css');
+const { menu } = require('./partials/menu');
+const { tests } = require('./partials/tests');
+const { cov } = require('./partials/cov');
+const { linting } = require('./partials/linting');
+
+exports.reportTemplate = function (context) {
+
+    return `<!doctype html>
+<html>
+  <head>
+    <title>Tests &amp; Coverage</title>
+    ${scripts()}
+    ${css()}
+  </head>
+  <body>
+    ${menu(context.coverage, context.lint)}
+    ${tests(context.failures, context.skipped, context.tests, context.duration, context.paths, context.errors)}
+    ${cov(context.coverage)}
+    ${linting(context.lint)}
+  </body>
+</html>`;
+};

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "eslint": "6.x.x",
         "find-rc": "4.x.x",
         "globby": "10.x.x",
-        "handlebars": "4.x.x",
+        "handlebars": "^4.7.3",
         "seedrandom": "3.x.x",
         "source-map": "0.7.x",
         "source-map-support": "0.5.x",
@@ -44,7 +44,8 @@
     },
     "scripts": {
         "test": "node ./bin/_lab -f -L -t 100 -m 10000 --types-test test/index.ts",
-        "test-cov-html": "node ./bin/_lab -f -L -r html -m 10000 -o coverage.html"
+        "test-cov-html": "node ./bin/_lab -f -L -r html -m 10000 -o coverage.html",
+        "lint": "node ./bin/_lab -d -f -L"
     },
     "license": "BSD-3-Clause"
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "eslint": "6.x.x",
         "find-rc": "4.x.x",
         "globby": "10.x.x",
-        "handlebars": "^4.7.3",
+        "handlebars": "4.x.x",
         "seedrandom": "3.x.x",
         "source-map": "0.7.x",
         "source-map-support": "0.5.x",

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -1385,6 +1385,193 @@ describe('Reporter', () => {
     });
 
     describe('html', () => {
+        
+        it('generates corresponding lint-file parital when there are errors', () => {
+
+            const { lintFile } = require('../lib/reporters/html/partials/lint-file');
+
+            const options = {
+                errors: [
+                    {
+                        line: 19,
+                        severity: 'high',
+                        message: 'some message'
+                    }
+                ],
+                filename: 'some-file-name.js'
+
+            };
+            expect(lintFile(options)).to.include('<li class="lint-entry">L19 - <span class="level-high">high</span> - some message</li>');
+        });
+
+        it('generates corresponding lint-file partial when there are no errors', () => {
+
+            const { lintFile } = require('../lib/reporters/html/partials/lint-file');
+
+            const options = {
+                filename: 'some-file-name.js'
+
+            };
+            expect(lintFile(options)).to.include('<div class="lint-file">\n    \n</div>');
+        });
+
+        it('generates corresponding lint partial when there are lint errors', () => {
+
+            const { lint } = require('../lib/reporters/html/partials/lint');
+
+            const options = {
+                errors: ['error 1','error 2', 'error 3', 'error 4']
+            };
+            expect(lint(options)).to.include('<span class="errors" data-tooltip="error 1&#xa;error 2&#xa;error 3&#xa;error 4"></span>');
+        });
+
+        it('generates corresponding lint partial when there are lint warnings', () => {
+
+            const { lint } = require('../lib/reporters/html/partials/lint');
+
+            const options = {
+                warnings: ['warning 1', 'warning 2']
+            };
+            expect(lint(options)).to.include('<span class="warnings" data-tooltip="warning 1&#xa;warning 2"></span>');
+        });
+
+        it('generates corresponding linting partial when lint is disabled', () => {
+
+            const { linting } = require('../lib/reporters/html/partials/linting');
+
+            const options = {
+                disabled: true
+            };
+            expect(linting(options)).to.include('<span>Nothing to show here, linting is disabled.</span>');
+        });
+
+        it('generates corresponding linting partial when lint is enabled ', () => {
+
+            const { linting } = require('../lib/reporters/html/partials/linting');
+
+            const options = {
+                errorClass: 'error',
+                totalErrors: 10,
+                warningClass: 'warning',
+                totalWarnings: 13,
+                lint: [
+                    {
+                        errors: ['error1'],
+                        warnings: ['warning 1', 'warning 2']
+                    }
+                ],
+                total: 23
+            };
+
+            expect(linting(options)).to.include('<span class="lint-errors error">10</span>');
+        });
+
+        it('generates corresponding linting partial when total is undefined', () => {
+
+            const { linting } = require('../lib/reporters/html/partials/linting');
+
+            const options = {
+                errorClass: 'error',
+                totalErrors: 10,
+                warningClass: 'warning',
+                totalWarnings: 13,
+                lint: [
+                    {
+                        warnings: ['warning 1', 'warning 2']
+                    }
+                ]
+            };
+
+            expect(linting(options)).to.not.include('<div class="lint-file">');
+        });
+
+        it('generates corresponding tests partial when there are failures', () => {
+
+            const { tests } = require('../lib/reporters/html/partials/tests');
+
+            const options = {
+                failures: ['failure 1, failure 2'],
+                skipped: ['s1', 's2', 's3'],
+                tests: [{
+                    path: ['p1', 'p2']
+                }],
+                duration: 10,
+                paths: [],
+                errors: []
+            };
+
+            expect(tests(options.failures, options.skipped, options.tests, options.duration, options.paths, options.errors)).to.include('<div class="stats terrible">');
+        });
+
+        it('generates corresponding tests partial for errors with stack', () => {
+
+            const { tests } = require('../lib/reporters/html/partials/tests');
+
+            const options = {
+                failures: ['failure 1, failure 2'],
+                skipped: ['s1', 's2', 's3'],
+                tests: [{
+                    path: ['p1', 'p2']
+                }],
+                duration: 10,
+                paths: [],
+                errors: [
+                    {
+                        message: 'some error message',
+                        stack: `Unexpected identifier
+                        at wrapSafe (internal/modules/cjs/loader.js:1072:16)
+                        at Module._compile (internal/modules/cjs/loader.js:1122:27)
+                        at Object.require.extensions.<computed> [as .js] (/Users/aorinevo/Repositories/hapi/lab/lib/coverage.js:127:113)
+                        at Module.load (internal/modules/cjs/loader.js:1002:32)`
+                    }
+                ]
+
+            };
+            const compiledTests = tests(options.failures, options.skipped, options.tests, options.duration, options.paths, options.errors);
+            expect(compiledTests).to.include('<div>some error message</div>');
+            expect(compiledTests).to.include('<pre>  at wrapSafe &#x28;internal&#x2f;modules&#x2f;cjs&#x2f;loader.js:1072:16&#x29;&#x0a;');
+        });
+
+        it('generates corresponding tests partial for errors without stack', () => {
+
+            const { tests } = require('../lib/reporters/html/partials/tests');
+
+            const options = {
+                failures: [],
+                skipped: ['s1', 's2', 's3'],
+                tests: [{
+                    path: ['p1', 'p2']
+                }],
+                duration: 10,
+                paths: [],
+                errors: [
+                    {
+                        message: 'some error message'
+                    }
+                ]
+            };
+            const compiledTests = tests(options.failures, options.skipped, options.tests, options.duration, options.paths, options.errors);
+            expect(compiledTests).to.include('<div>some error message</div>');
+            expect(compiledTests).to.not.include('<pre');
+        });
+
+        it('generates corresponding tests partial when there are no failures', () => {
+
+            const { tests } = require('../lib/reporters/html/partials/tests');
+
+            const options = {
+                failures: [],
+                skipped: ['s1', 's2', 's3'],
+                tests: [{
+                    path: ['p1', 'p2']
+                }],
+                duration: 10,
+                paths: [],
+                errors: []
+            };
+
+            expect(tests(options.failures, options.skipped, options.tests, options.duration, options.paths, options.errors)).to.include('<div class="stats low">');
+        });
 
         it('generates a coverage report', async () => {
 
@@ -1427,7 +1614,7 @@ describe('Reporter', () => {
                 '<td class="source"><div>    while ( </div><div class="miss false" data-tooltip>value ) </div><div>{</div></td>']);
             expect(output, 'missed original line not included').to.contains([
                 '<tr id="while.js__14" class="miss">',
-                '<td class="source" data-tooltip>        value &#x3D; false;</td>']);
+                '<td class="source" data-tooltip>        value = false;</td>']);
             delete global.__$$testCovHtml;
         });
 

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -1385,7 +1385,7 @@ describe('Reporter', () => {
     });
 
     describe('html', () => {
-        
+
         it('generates corresponding lint-file parital when there are errors', () => {
 
             const { lintFile } = require('../lib/reporters/html/partials/lint-file');


### PR DESCRIPTION
# Changes
- replace `handlebards` with natively supported template strings in a backwards compatible fashion.
- feature is hidden behind a feature flag.  To enable simply set `enableTemplateStringHTMLReporter` to `'true'` in `.labrc.js`.
- add lint to scripts.

## Notes
- dependent on approval of open issue https://github.com/hapijs/lab/issues/977
- while this PR adds 1069 lines of code, ~185 correspond to unit tests.  In addition, 714 lines of code can be removed once we/if backwards compatibility is dropped.  More related stats:  
  - `hapijs:master` branch consists of 95.5% javascript, 3.8% html, and 0.7% other.
  - `aorinevo:replace_handlebars` branch consists of 95.5% javascript, 3.9% html, and 0.7% other.
  - Percentage of html can go down to 0% once/if backwards compatibility is dropped.
- handlebars package can be removed from `package.json` once/if backwards compatibility is dropped.