### PR TITLE
Add globals introduce in Node.js v14.6.0

### DIFF
--- a/lib/leaks.js
+++ b/lib/leaks.js
@@ -42,6 +42,7 @@ const internals = {
         'Number',
         'RangeError',
         'EvalError',
+        'FinalizationRegistry',
         'Function',
         'isFinite',
         'Object',
@@ -73,6 +74,7 @@ const internals = {
         'Set',
         'Symbol',
         'WeakMap',
+        'WeakRef',
         'WeakSet',
 
         // Sometime


### PR DESCRIPTION
Lab is currently reporting leaked globals on v14.6.0 for
`FinalizationRegistry` and `WeakRef`. The test suite is also failing
on v14.5.0. With this change lab will no longer fail any test suite run
on v14.6.0, it also fixes broken tests with lab on v14.5.0.