### PR TITLE
update some dependencies and use travis templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,7 @@
-language: node_js
+version: ~> 1.0
 
-node_js:
-  - "12"
-  - "node"
 
-os:
-  - linux
-  - osx
-  - windows
-
-sudo: false
-
-cache:
-    npm: false
-    directories:
-        - $HOME/.npm
-
+import:
+  - hapijs/ci-config-travis:node_js.yml@main
+  - hapijs/ci-config-travis:install.yml@main
+  - hapijs/ci-config-travis:os.yml@main

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
         "@hapi/code": "8.x.x",
         "cpr": "3.x.x",
         "lab-event-reporter": "1.x.x",
-        "rimraf": "2.x.x",
-        "semver": "6.x.x"
+        "rimraf": "3.x.x",
+        "semver": "7.x.x"
     },
     "bin": {
         "lab": "./bin/lab"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "@hapi/hoek": "9.x.x",
         "babel-eslint": "10.x.x",
         "diff": "4.x.x",
-        "eslint": "6.x.x",
+        "eslint": "7.x.x",
         "find-rc": "4.x.x",
         "globby": "10.x.x",
         "handlebars": "4.x.x",

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -505,11 +505,11 @@ describe('Coverage', () => {
 
             const cacheBackup = require.cache; // backup require cache
             const filename = Path.resolve(__dirname, './coverage/basic.js');
-            let file = require('./coverage/basic'); //eslint-disable-line no-unused-vars
+            let file = require('./coverage/basic');
 
             const fileCovBefore = global.__$$labCov.files[filename];
             require.cache = Module._cache = {}; // clear require cache before additional require
-            file = require('./coverage/basic');
+            file = require('./coverage/basic'); //eslint-disable-line no-unused-vars
             require.cache = Module._cache = cacheBackup; // restore require cache
 
             const fileCovAfter = global.__$$labCov.files[filename];

--- a/test/linters.js
+++ b/test/linters.js
@@ -63,9 +63,9 @@ describe('Linters - eslint', () => {
         expect(result).to.include('lint');
 
         const eslintResults = result.lint;
-        expect(eslintResults).to.have.length(1);
+        expect(eslintResults).to.have.length(2);
 
-        const checkedFile = eslintResults[0];
+        const checkedFile = eslintResults[1];
         expect(checkedFile).to.include({ filename: Path.join(path, 'fail.js') });
         expect(checkedFile.errors).to.include([
             { line: 14, severity: 'ERROR', message: 'eol-last - Newline required at end of file but not found.' }]);


### PR DESCRIPTION
See the commit summary for more details. A few things to note:

- There are still two dependencies that are out of date - `globby` and `typescript`. Updating them causes a number of test failures related to typescript, so I'll just leave that to someone else to fix.
- The ESLint update is a major version bump, and there is potential for user facing changes (see the changes in `test/`). Does `lab` classify those linter changes as breaking changes? If so, we'll need to publish a new major version.

Commit summary:

##### update devDependency versions
This updates the devDependencies that were out of date.

##### update to eslint 7.x.x

This commit includes a bump in the eslint dependency, and the
following fixes related to it:

- The line reported for no-unused-vars has changed. In this
  commit, a comment has been moved.
- Starting with eslint 7, .eslintrc.js is no longer ignored by
  default. This required updating a test whose directory
  contains a .eslintrc.js file.

##### update to travis templates and test on node 14