### PR TITLE
throw error if an async experiment function is provided

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -125,7 +125,11 @@ internals.experiment = function (title, options, fn) {
         this._setOnly(child, null, this._path);
     }
 
-    fn.call(null);  // eslint-disable-line no-useless-call
+    const returnValue = fn.call(null); // eslint-disable-line no-useless-call
+    // ensure that calls to experiment/describe are synchronous
+    if (typeof Hoek.reach(returnValue, 'then') === 'function') {
+        throw new Error(`Function for experiment '${title}' must be a synchronous function.`);
+    }
 
     this._titles.pop();
     this._path = this._titles.concat();                      // Clone

--- a/test/index.js
+++ b/test/index.js
@@ -108,6 +108,45 @@ describe('Lab', () => {
         expect(notebook.failures).to.equal(0);
     });
 
+    it('should throw on experiments with asynchronous functions', () => {
+
+        const script = Lab.script({ schedule: false });
+
+        expect(() => {
+
+            script.experiment('async function', async () => {
+
+                await Promise.resolve();
+            });
+        }).to.throw(/must be a synchronous function/);
+    });
+
+    it('should throw on experiments with asynchronous functions (BDD)', () => {
+
+        const script = Lab.script({ schedule: false });
+
+        expect(() => {
+
+            script.describe('async function', async () => {
+
+                await Promise.resolve();
+            });
+        }).to.throw(/must be a synchronous function/);
+    });
+
+    it('should throw on experiments with asynchronous functions (TDD)', () => {
+
+        const script = Lab.script({ schedule: false });
+
+        expect(() => {
+
+            script.suite('async function', async () => {
+
+                await Promise.resolve();
+            });
+        }).to.throw(/must be a synchronous function/);
+    });
+
     it('executes beforeEach and afterEach', async () => {
 
         let a = 0;


### PR DESCRIPTION
Currently with code as follows:
```javascript
const Code = require('@hapi/code');
const Hoek = require('@hapi/hoek');
const Lab = require('@hapi/lab');

const lab = exports.lab = Lab.script();

const { expect } = Code;
const { describe, it } = lab;

describe('Suite', async () => {
	
	await Hoek.wait(1000);

	it('should work', async () => {
		
		expect(1).to.exist();
	});
});
```
This test suite will be dropped and not reported silently due to the asynchronous `describe` function. If people are trying to do an async action within a describe block, they should use a `before` block with an async function.

This PR causes async experiment/describe/suite functions to throw an error instead of silently swallowing and hiding this type of issue.