### PR TITLE
Use eslint-plugin-hapi embedded config

### DIFF
--- a/API.md
+++ b/API.md
@@ -583,9 +583,9 @@ As stated at the beginning of the document, `--ignore` parameter is an alias for
 
 **lab** uses a shareable [eslint](http://eslint.org/) config, and a plugin containing several **hapi** specific linting rules. If you want to extend the default linter you must:
 
-1. Add `@hapi/eslint-plugin-hapi` and `@hapi/eslint-config-hapi` as dependencies in your `package.json`. You must add both the plugin and the config because eslint treats them as peer dependencies. For more background, see [eslint/eslint#3458](https://github.com/eslint/eslint/issues/3458) and [eslint/eslint#2518](https://github.com/eslint/eslint/issues/2518).
+1. Add `@hapi/eslint-plugin-hapi` as a dependency in your `package.json`.
 
-2. In your project's eslint configuration, add `"extends": "@hapi/eslint-config-hapi"`.
+2. In your project's eslint configuration, add `"extends": "plugin:@hapi/hapi/recommended"`.
 
 Your project's eslint configuration will now extend the default **lab** configuration.
 

--- a/API.md
+++ b/API.md
@@ -583,9 +583,9 @@ As stated at the beginning of the document, `--ignore` parameter is an alias for
 
 **lab** uses a shareable [eslint](http://eslint.org/) config, and a plugin containing several **hapi** specific linting rules. If you want to extend the default linter you must:
 
-1. Add `@hapi/eslint-plugin-hapi` as a dependency in your `package.json`.
+1. Add `@hapi/eslint-plugin` as a dependency in your `package.json`.
 
-2. In your project's eslint configuration, add `"extends": "plugin:@hapi/hapi/recommended"`.
+2. In your project's eslint configuration, add `"extends": "plugin:@hapi/recommended"`.
 
 Your project's eslint configuration will now extend the default **lab** configuration.
 

--- a/API.md
+++ b/API.md
@@ -581,7 +581,7 @@ As stated at the beginning of the document, `--ignore` parameter is an alias for
 
 ## Linting
 
-**lab** uses a shareable [eslint](http://eslint.org/) config, and a plugin containing several **hapi** specific linting rules. If you want to extend the default linter you must:
+**lab** uses a shareable [eslint](http://eslint.org/) plugin containing a recommended config and several **hapi** specific linting rules. If you want to extend the default linter you must:
 
 1. Add `@hapi/eslint-plugin` as a dependency in your `package.json`.
 

--- a/lib/linter/.eslintrc.js
+++ b/lib/linter/.eslintrc.js
@@ -2,7 +2,7 @@
 
 module.exports = {
     parser: 'babel-eslint',
-    extends: 'plugin:@hapi/hapi/recommended',
+    extends: 'plugin:@hapi/recommended',
     parserOptions: {
         loc: true,
         comment: true,

--- a/lib/linter/.eslintrc.js
+++ b/lib/linter/.eslintrc.js
@@ -2,7 +2,7 @@
 
 module.exports = {
     parser: 'babel-eslint',
-    extends: require.resolve('@hapi/eslint-config-hapi'),
+    extends: 'plugin:@hapi/hapi/recommended',
     parserOptions: {
         loc: true,
         comment: true,

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     ],
     "dependencies": {
         "@hapi/bossy": "5.x.x",
-        "@hapi/eslint-plugin": "github:kanongil/eslint-plugin-hapi#rename",
-        "@hapi/eslint-plugin-hapi": "4.x.x",
+        "@hapi/eslint-plugin": "5.x.x",
         "@hapi/hoek": "9.x.x",
         "babel-eslint": "10.x.x",
         "diff": "4.x.x",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     ],
     "dependencies": {
         "@hapi/bossy": "5.x.x",
+        "@hapi/eslint-plugin": "github:kanongil/eslint-plugin-hapi#rename",
         "@hapi/eslint-plugin-hapi": "4.x.x",
         "@hapi/hoek": "9.x.x",
         "babel-eslint": "10.x.x",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     ],
     "dependencies": {
         "@hapi/bossy": "5.x.x",
-        "@hapi/eslint-config-hapi": "13.x.x",
         "@hapi/eslint-plugin-hapi": "4.x.x",
         "@hapi/hoek": "9.x.x",
         "babel-eslint": "10.x.x",


### PR DESCRIPTION
Draft changes needed to use the new plugin-based config from https://github.com/hapijs/eslint-plugin-hapi/pull/20. Final PR is dependent on it being published, and its name and version.