### PR TITLE
lib: add new globals from Node.js 15.x

### DIFF
--- a/lib/modules/leaks.js
+++ b/lib/modules/leaks.js
@@ -15,6 +15,7 @@ const internals = {
         'console',
         'AbortController',
         'AbortSignal',
+        'AggregateError',
         'Buffer',
         'process',
         'global',

--- a/lib/modules/leaks.js
+++ b/lib/modules/leaks.js
@@ -13,6 +13,8 @@ const internals = {
         'clearInterval',
         'clearImmediate',
         'console',
+        'AbortController',
+        'AbortSignal',
         'Buffer',
         'process',
         'global',
@@ -33,6 +35,10 @@ const internals = {
         'DataView',
         '__$$labCov',
         'gc',
+        'MessageChannel',
+        'MessageEvent',
+        'MessagePort',
+
 
         // Non-Enumerable globals
 
@@ -42,6 +48,8 @@ const internals = {
         'Number',
         'RangeError',
         'EvalError',
+        'Event',
+        'EventTarget',
         'FinalizationRegistry',
         'Function',
         'isFinite',

--- a/lib/modules/leaks.js
+++ b/lib/modules/leaks.js
@@ -40,7 +40,6 @@ const internals = {
         'MessageEvent',
         'MessagePort',
 
-
         // Non-Enumerable globals
 
         'Array',


### PR DESCRIPTION
This avoids lab failing with Leak errors.

There might be a few other globals that get introduced, not 100%. Might make sense to wait until EOW to confirm the globals.