### PR TITLE
Fix retrying of passing tests

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -654,6 +654,7 @@ internals.protect = function (item, state) {
 
             item.tries = 0;
             let retries = !item.options.retry ? 1 : (item.options.retry === true ? state.options.retries : item.options.retry);
+            let lastError;
             while (retries--) {
                 ++item.tries;
 
@@ -664,14 +665,14 @@ internals.protect = function (item, state) {
 
                         setImmediate(next);
                     });
-                    finish();
+                    return finish();
                 }
                 catch (ex) {
-                    if (!retries) {
-                        return finish(ex, 'unit test');
-                    }
+                    lastError = ex;
                 }
             }
+
+            return finish(lastError, 'unit test');
         });
     });
 };

--- a/test/runner.js
+++ b/test/runner.js
@@ -2,8 +2,11 @@
 
 // Load modules
 
-const Code = require('@hapi/code');
 const Path = require('path');
+
+const Code = require('@hapi/code');
+const Hoek = require('@hapi/hoek');
+
 const _Lab = require('../test_runner');
 const Lab = require('../');
 
@@ -1673,6 +1676,26 @@ describe('Runner', () => {
 
         const { code } = await Lab.report(script, { output: false, assert: assertions });
         expect(code).to.equal(1);
+    });
+
+    it('does not retry non-failing test', async () => {
+
+        const script = Lab.script();
+        const assertions = Code;
+        let count = 0;
+        script.experiment('test', () => {
+
+            script.test('1', { retry: true }, () => {
+
+                ++count;
+            });
+        });
+
+        const { code } = await Lab.report(script, { output: false, assert: assertions });
+        expect(code).to.equal(0);
+
+        await Hoek.wait(1);
+        expect(count).to.equal(1);
     });
 
     describe('global timeout functions', () => {


### PR DESCRIPTION
Any test configured with a `retry` more than 1 will erroneously re-run the test logic until all tries are used.

The issue is fixed with this PR.