### PR TITLE
Introduce an upper limit to how much actual vs. expected is diffed

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -317,6 +317,11 @@ internals.options = function () {
             description: 'linter warnings threshold in absolute value',
             default: null
         },
+        'max-diff-length': {
+            type: 'number',
+            description: 'maximum length of "actual" and "expected" strings that are logged and diffed in case of test failures. Longer strings are truncated to this length. Set to 0 remove the limit.',
+            default: null,
+        },
         output: {
             alias: 'o',
             type: 'string',
@@ -426,6 +431,7 @@ internals.options = function () {
         'lint-fix': false,
         'lint-errors-threshold': 0,
         'lint-warnings-threshold': 0,
+        'max-diff-length': 20 * 1024, // 20K should be more than most people want logged to their console and the diff algorithm becomes very slow for larger strings.
         paths: ['test'],
         reporter: 'console',
         retries: 5,
@@ -463,7 +469,7 @@ internals.options = function () {
         'coverage-path', 'coverage-all', 'coverage-flat', 'coverage-module', 'coverage-pattern',
         'default-plan-threshold', 'dry', 'environment', 'flat', 'globals', 'grep',
         'lint', 'lint-errors-threshold', 'lint-fix', 'lint-options', 'lint-warnings-threshold',
-        'linter', 'output', 'pattern', 'reporter', 'retries', 'seed', 'shuffle', 'silence',
+        'linter', 'max-diff-length', 'output', 'pattern', 'reporter', 'retries', 'seed', 'shuffle', 'silence',
         'silent-skips', 'sourcemaps', 'threshold', 'timeout', 'transform', 'types', 'types-test', 'verbose'];
 
     for (let i = 0; i < keys.length; ++i) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -320,7 +320,7 @@ internals.options = function () {
         'max-diff-length': {
             type: 'number',
             description: 'maximum length of "actual" and "expected" strings that are logged and diffed in case of test failures. Longer strings are truncated to this length. Set to 0 remove the limit.',
-            default: null,
+            default: null
         },
         output: {
             alias: 'o',

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -317,11 +317,6 @@ internals.options = function () {
             description: 'linter warnings threshold in absolute value',
             default: null
         },
-        'max-diff-length': {
-            type: 'number',
-            description: 'maximum length of "actual" and "expected" strings that are logged and diffed in case of test failures. Longer strings are truncated to this length. Set to 0 remove the limit.',
-            default: null
-        },
         output: {
             alias: 'o',
             type: 'string',
@@ -431,7 +426,7 @@ internals.options = function () {
         'lint-fix': false,
         'lint-errors-threshold': 0,
         'lint-warnings-threshold': 0,
-        'max-diff-length': 20 * 1024, // 20K should be more than most people want logged to their console and the diff algorithm becomes very slow for larger strings.
+        'max-diff-length': 20 * 1024, // 20K should be more than most people want logged to their console. The diff algorithm becomes very slow for larger strings.
         paths: ['test'],
         reporter: 'console',
         retries: 5,

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -209,8 +209,18 @@ internals.Reporter.prototype.end = function (notebook) {
             if (test.err.actual !== undefined &&
                 test.err.expected !== undefined) {
 
-                const actual = internals.stringify(test.err.actual);
-                const expected = internals.stringify(test.err.expected);
+                let actual = internals.stringify(test.err.actual);
+                let expected = internals.stringify(test.err.expected);
+
+                if (this.settings['max-diff-length'] > 0) {
+                    const maxLen = this.settings['max-diff-length'];
+                    if (actual.length > maxLen) {
+                        actual = actual.substr(0, maxLen) + '[truncated]';
+                    }
+                    if (expected.length > maxLen) {
+                        expected = expected.substr(0, maxLen) + '[truncated]';
+                    }
+                }
 
                 output += '      ' + whiteRedBg('actual') + ' ' + blackGreenBg('expected') + '\n\n      ';
 

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -217,6 +217,7 @@ internals.Reporter.prototype.end = function (notebook) {
                     if (actual.length > maxLen) {
                         actual = actual.substr(0, maxLen) + '[truncated]';
                     }
+
                     if (expected.length > maxLen) {
                         expected = expected.substr(0, maxLen) + '[truncated]';
                     }

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -393,6 +393,25 @@ describe('Reporter', () => {
             expect(output).to.contain('Leaks: No issues');
         });
 
+        it('does not truncate if diff length less than the maximum', async () => {
+
+            const script = Lab.script();
+            script.experiment('test', () => {
+
+                script.test('works', () => {
+
+                    expect({ a: 1 }).to.equal({ b: 1 });
+                });
+            });
+
+            const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, output: false, 'max-diff-length': 10 * 1024 });
+            expect(code).to.equal(1);
+            expect(output).to.not.contain('[truncated]');
+            expect(output).to.contain('1 of 1 tests failed');
+            expect(output).to.contain('Test duration:');
+            expect(output).to.contain('Leaks: No issues');
+        });
+
         it('counts "todo" tests as skipped', async () => {
 
             const script = Lab.script();

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -336,7 +336,7 @@ describe('Reporter', () => {
             expect(output).to.contain(internals.colors('Leaks: \u001b[32mNo issues'));
         });
 
-        it('generate a report with stable diff of actual/expected objects of a failed test', async () => {
+        it('generates a report with stable diff of actual/expected objects of a failed test', async () => {
 
             const script = Lab.script();
             script.experiment('test', () => {
@@ -350,6 +350,44 @@ describe('Reporter', () => {
             const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, output: false });
             expect(code).to.equal(1);
             expect(output).to.contain('e: 665');
+            expect(output).to.contain('1 of 1 tests failed');
+            expect(output).to.contain('Test duration:');
+            expect(output).to.contain('Leaks: No issues');
+        });
+
+        it('truncates actual/expected if necessary', async () => {
+
+            const script = Lab.script();
+            script.experiment('test', () => {
+
+                script.test('works', () => {
+
+                    expect({ a: 1 }).to.equal({ b: 1 });
+                });
+            });
+
+            const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, output: false, 'max-diff-length': 8 });
+            expect(code).to.equal(1);
+            expect(output).to.contain('ab: 1[truncated]');
+            expect(output).to.contain('1 of 1 tests failed');
+            expect(output).to.contain('Test duration:');
+            expect(output).to.contain('Leaks: No issues');
+        });
+
+        it('does not truncate if max diff length is set to 0', async () => {
+
+            const script = Lab.script();
+            script.experiment('test', () => {
+
+                script.test('works', () => {
+
+                    expect({ a: 1 }).to.equal({ b: 1 });
+                });
+            });
+
+            const { code, output } = await Lab.report(script, { reporter: 'console', colors: false, output: false, 'max-diff-length': 0 });
+            expect(code).to.equal(1);
+            expect(output).to.contain('ab: 1\n');
             expect(output).to.contain('1 of 1 tests failed');
             expect(output).to.contain('Test duration:');
             expect(output).to.contain('Leaks: No issues');


### PR DESCRIPTION
When (accidentally) asserting on very big object graphs (like Node.js’ response objects), the actual / expected strings generated by the `console` logger can become hundreds of MB long.

In this case the reporter stalls for a very, very long time while trying to create diffs for these huge strings. Adding an upper limit reduces those stalls to a bearable amount while still remaining useful for most conceivable applications.