### PR TITLE
Add new globals for node v16

### DIFF
--- a/lib/modules/leaks.js
+++ b/lib/modules/leaks.js
@@ -17,6 +17,7 @@ const internals = {
         'AbortSignal',
         'AggregateError',
         'Buffer',
+        'performance',
         'process',
         'global',
         'GLOBAL',
@@ -43,6 +44,8 @@ const internals = {
         // Non-Enumerable globals
 
         'Array',
+        'atob',
+        'btoa',
         'isNaN',
         'ReferenceError',
         'Number',


### PR DESCRIPTION
Adds `atob`, `btoa`, and `performance` to the list of allowed globals.  Resolves #1003.