### PR TITLE
removing error truncation from types module

### DIFF
--- a/lib/modules/types.js
+++ b/lib/modules/types.js
@@ -14,6 +14,7 @@ const Utils = require('../utils');
 
 const internals = {
     compiler: {
+        noErrorTruncation: true,
         strict: true,
         jsx: Ts.JsxEmit.React,
         lib: ['lib.es2020.d.ts'],


### PR DESCRIPTION
This helps when debugging error messages if they´re too long.