### PR TITLE
Report on private/protected class type errors

### DIFF
--- a/lib/modules/types.js
+++ b/lib/modules/types.js
@@ -37,7 +37,9 @@ const internals = {
         2322,                                       // Type is not assignable to other type
         2314,                                       // Generic type requires type arguments
         2554,                                       // Expected arguments but got other
-        2769                                        // No overload matches this call
+        2769,                                       // No overload matches this call
+        2673,                                       // Constructor of class is private
+        2674                                        // Constructor of class is protected
     ]
 };
 


### PR DESCRIPTION
Adding some typescript diagnostic error codes to check for use of private/protected class constructors in `expect.error()`.  This resolves #1006, and affects https://github.com/hapijs/mimos/pull/37.