### PR TITLE
Add eslint-plugin module config to lint/coverage feature

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -27,7 +27,7 @@ exports.run = function () {
     const settings = internals.options();
 
     settings.coveragePath = Path.join(process.cwd(), settings['coverage-path'] || '');
-    settings.coverageExclude = ['node_modules', 'test', 'test_runner'];
+    settings.coverageExclude = ['node_modules', 'test', 'test_runner', Path.join('lib', 'linter', '.eslintrc.js')];
     if (settings['coverage-exclude']) {
         settings.coverageExclude = settings.coverageExclude.concat(settings['coverage-exclude']);
     }

--- a/lib/linter/.eslintrc.js
+++ b/lib/linter/.eslintrc.js
@@ -1,13 +1,5 @@
 'use strict';
 
 module.exports = {
-    parser: 'babel-eslint',
-    extends: 'plugin:@hapi/recommended',
-    parserOptions: {
-        loc: true,
-        comment: true,
-        range: true,
-        ecmaVersion: 2020,
-        sourceType: 'script'
-    }
+    extends: 'plugin:@hapi/module'
 };

--- a/lib/modules/coverage.js
+++ b/lib/modules/coverage.js
@@ -18,7 +18,7 @@ const Transform = require('./transform');
 const internals = {
     ext: Symbol.for('@hapi/lab/coverage/initialize'),
     _state: Symbol.for('@hapi/lab/coverage/_state'),
-    EslintEngine: new ESLint.CLIEngine({ baseConfig: Eslintrc }),
+    EslintEngine: new ESLint.CLIEngine({ baseConfig: Eslintrc })
 };
 
 
@@ -336,7 +336,7 @@ internals.instrument = function (filename) {
         ...eslintConfig.parserOptions,
         loc: true,
         range: true,
-        comment: true 
+        comment: true
     });
 
     // Process comments

--- a/lib/modules/coverage.js
+++ b/lib/modules/coverage.js
@@ -7,17 +7,18 @@
 const Fs = require('fs');
 const Path = require('path');
 
-const BabelESLint = require('babel-eslint');
+const ESLint = require('eslint');
+const ESLintParser = require('@babel/eslint-parser');
 const SourceMap = require('source-map');
 const SourceMapSupport = require('source-map-support');
 
 const Eslintrc = require('../linter/.eslintrc');
 const Transform = require('./transform');
 
-
 const internals = {
     ext: Symbol.for('@hapi/lab/coverage/initialize'),
-    _state: Symbol.for('@hapi/lab/coverage/_state')
+    _state: Symbol.for('@hapi/lab/coverage/_state'),
+    EslintEngine: new ESLint.CLIEngine({ baseConfig: Eslintrc }),
 };
 
 
@@ -330,7 +331,13 @@ internals.instrument = function (filename) {
 
     // Parse tree
 
-    const tree = BabelESLint.parse(content, Eslintrc.parserOptions);
+    const eslintConfig = internals.EslintEngine.getConfigForFile(filename);
+    const tree = ESLintParser.parse(content, {
+        ...eslintConfig.parserOptions,
+        loc: true,
+        range: true,
+        comment: true 
+    });
 
     // Process comments
 

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
         "lib"
     ],
     "dependencies": {
+        "@babel/core": "^7.14.3",
+        "@babel/eslint-parser": "^7.14.3",
         "@hapi/bossy": "5.x.x",
         "@hapi/eslint-plugin": "5.x.x",
         "@hapi/hoek": "9.x.x",
-        "babel-eslint": "10.x.x",
         "diff": "4.x.x",
         "eslint": "7.x.x",
         "find-rc": "4.x.x",


### PR DESCRIPTION
Since we published a new version of the `@hapi/eslint-plugin` with a new configuration `@hapi/module` we want to migrate the inner configuration declared in `lib/linter/.eslintrc.js` to use the new configuration.
