### PR TITLE
Add eslint configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
         "bin/lab",
         "lib"
     ],
+    "eslintConfig": {
+        "extends": [
+            "plugin:@hapi/module"
+        ]
+    },
     "dependencies": {
         "@babel/core": "^7.14.3",
         "@babel/eslint-parser": "^7.14.3",


### PR DESCRIPTION
If you want to test that the configuration is correctly picked up by your IDE make sure to update your local dependencies to pick up the latest version of `@hapi/eslint-plugin` otherwise you might not have the new configuration in it.
