### PR TITLE
fix: correct semver range for @hapi/eslint-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "@babel/core": "^7.14.3",
         "@babel/eslint-parser": "^7.14.3",
         "@hapi/bossy": "5.x.x",
-        "@hapi/eslint-plugin": "5.x.x",
+        "@hapi/eslint-plugin": "^5.1.0",
         "@hapi/hoek": "9.x.x",
         "diff": "4.x.x",
         "eslint": "7.x.x",


### PR DESCRIPTION
lab tries to extend a config that doesn't exist in 5.0.0 of eslint-plugin, so the `5.x.x` semver here is wrong. switched it to the standard caret syntax so we can express what we actually need, which is _at least_ 5.1.0