### PR TITLE
fix: never instrument eslint configs for coverage

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -27,7 +27,7 @@ exports.run = function () {
     const settings = internals.options();
 
     settings.coveragePath = Path.join(process.cwd(), settings['coverage-path'] || '');
-    settings.coverageExclude = ['node_modules', 'test', 'test_runner', Path.join('lib', 'linter', '.eslintrc.js')];
+    settings.coverageExclude = ['node_modules', 'test', 'test_runner'];
     if (settings['coverage-exclude']) {
         settings.coverageExclude = settings.coverageExclude.concat(settings['coverage-exclude']);
     }

--- a/lib/modules/coverage.js
+++ b/lib/modules/coverage.js
@@ -118,9 +118,12 @@ internals.prime = function (extension) {
 
     require.extensions[extension] = function (localModule, filename) {
 
-        for (let i = 0; i < internals.state.patterns.length; ++i) {
-            if (internals.state.patterns[i].test(filename.replace(/\\/g, '/'))) {
-                return localModule._compile(internals.instrument(filename), filename);
+        // We never want to instrument eslint configs in order to avoid infinite recursion
+        if (Path.basename(filename, extension) !== '.eslintrc') {
+            for (let i = 0; i < internals.state.patterns.length; ++i) {
+                if (internals.state.patterns[i].test(filename.replace(/\\/g, '/'))) {
+                    return localModule._compile(internals.instrument(filename), filename);
+                }
             }
         }
 

--- a/test/coverage/test-folder/.eslintrc.js
+++ b/test/coverage/test-folder/.eslintrc.js
@@ -1,0 +1,9 @@
+// this is a deliberately unused function that will reduce coverage percentage
+// if it ends up getting instrumented, giving us something to assert against
+const unusedMethod = () => {
+	console.log('hello world')
+}
+
+module.exports = {
+	extends: 'plugin:@hapi/module'
+}


### PR DESCRIPTION
this is an alternative fix to the issue we saw where we'd blow up the call stack when the test runner tried to instrument the eslint config. adding our own internal eslint config to the coverage exclusions did so in too specific of a way, so instead i tweaked the require extension such that it will never instrument an eslint config of any type.

this is necessary to make it so users don't have to explicitly ignore their own `.eslintrc.js` if they have one