### PR TITLE
Add DOMException and structuredClone globals to leaks module

### DIFF
--- a/lib/modules/leaks.js
+++ b/lib/modules/leaks.js
@@ -40,6 +40,7 @@ const internals = {
         'MessageChannel',
         'MessageEvent',
         'MessagePort',
+        'structuredClone',
 
         // Non-Enumerable globals
 
@@ -87,6 +88,7 @@ const internals = {
         'WeakMap',
         'WeakRef',
         'WeakSet',
+        'DOMException',
 
         // Sometime
 


### PR DESCRIPTION
`DOMException` is not `enumerable`: https://github.com/nodejs/node/blob/cdde45c9e88de0299fbb3c2cdf8d9bf70d502835/lib/internal/bootstrap/node.js#L497 and https://github.com/nodejs/node/blob/cdde45c9e88de0299fbb3c2cdf8d9bf70d502835/lib/internal/bootstrap/node.js#L204.

`structuredClone` is `enumerable`: https://github.com/nodejs/node/blob/cdde45c9e88de0299fbb3c2cdf8d9bf70d502835/lib/internal/bootstrap/node.js#L507 and https://github.com/nodejs/node/blob/cdde45c9e88de0299fbb3c2cdf8d9bf70d502835/lib/internal/bootstrap/node.js#L261.

Fixes #1019 