### PR TITLE
Cleanup flaky tests, lint CLI scripts

### DIFF
--- a/bin/_lab
+++ b/bin/_lab
@@ -9,6 +9,7 @@ const Rimraf = require('rimraf');
 
 if (process.env.ROOT_SPAWN) {
     (async () => {
+
         try {
             const { code } = await require('../test_runner/cli').run();
             process.exit(code);
@@ -18,6 +19,7 @@ if (process.env.ROOT_SPAWN) {
             process.exit(1);
         }
     })();
+
     return;
 }
 

--- a/bin/lab
+++ b/bin/lab
@@ -16,7 +16,7 @@ if (process.env.NODE_DEBUG_OPTION || inspectArg) {
     const args = [];
 
     if (process.env.NODE_DEBUG_OPTION) { // WebStorm debugger
-        args.push.apply(args, process.env.NODE_DEBUG_OPTION.split(' '));
+        args.push(...process.env.NODE_DEBUG_OPTION.split(' '));
         delete process.env.NODE_DEBUG_OPTION;
     }
     else { // V8 inspector
@@ -26,7 +26,7 @@ if (process.env.NODE_DEBUG_OPTION || inspectArg) {
     args.push(lab);
 
     // Remove node, lab, and the --inspect that might have been provided in the options
-    args.push.apply(args, process.argv.slice(2).filter((argument) => !inspectPattern.test(argument)));
+    args.push(...process.argv.slice(2).filter((argument) => !inspectPattern.test(argument)));
 
     const options = {
         stdio: 'inherit'
@@ -53,10 +53,8 @@ if (process.env.NODE_DEBUG_OPTION || inspectArg) {
 
 const main = async () => {
 
-    let { code } = await require('../lib/cli').run();
+    const { code } = await require('../lib/cli').run();
     process.exit(code);
 };
 
 main();
-
-

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -239,7 +239,9 @@ internals.Reporter.prototype.end = function (notebook) {
                 output += '      ' + red(message) + '\n\n';
             }
 
-            if (test.err.at) {
+            if (test.err instanceof Error && test.err.at) {
+                // Ensure test.err is indeed an Error since internal failures may surface as a
+                // string, and strings have an at() method as of node v16.8.
                 output += gray('      at ' + test.err.at.filename + ':' + test.err.at.line + ':' + test.err.at.column) + '\n';
             }
             else if (!test.timeout &&

--- a/test/cli_throws/debug.js
+++ b/test/cli_throws/debug.js
@@ -26,12 +26,16 @@ describe('Test CLI domain error debug', () => {
 
     it('throws badly', () => {
 
-        setTimeout(() => {
+        setImmediate(() => {
+            // See timing in runner's internals.protect():
+            // we want to land error after this test completes but before the
+            // whole test suite completes, in particular before after() completes.
+            setImmediate(() => {
 
-            throw new Error('throwing later');
-        }, 0);
+                throw new Error('throwing later');
+            });
+        });
 
         return Promise.resolve();
     });
 });
-


### PR DESCRIPTION
Two issues recently appeared in the test suite that are resolved here:
 - There was a test that was flaky due to inconsistent timing of `setTimeout()`.  This PR makes it more precise by moving it to two `setImmediate()`s which matches the timing we're looking for based on lab's internals.
 - In node v16.8 strings gained a new method, `str.at()`. There's a place in lab where we anticipate an error may have an object `err.at` containing the file location where the error occurred, and in certain cases `err` can actually be a string— so this new method violated one of lab's assumptions about an errors with an `err.at` property.  This PR makes it more precise by ensuring we have an `Error` object before checking for `err.at`.

I also noticed that the CLI scripts didn't pass our linter, so I tidied that up too.