### PR TITLE
Skip coverage on non-mapped transpiled code

### DIFF
--- a/lib/modules/coverage.js
+++ b/lib/modules/coverage.js
@@ -593,37 +593,6 @@ exports.analyze = async function (options) {
 };
 
 
-internals.addSourceMapsInformation = function (smc, ret, num) {
-
-    const source = ret.source[num];
-    const position = {
-        source: ret.filename,
-        line: num,
-        // when using 0 column, it sometimes miss the original line
-        column: source.source.length
-    };
-    let originalPosition = smc.originalPositionFor(position);
-
-    // Ensure folder separator to be url-friendly
-    source.originalFilename = originalPosition.source && originalPosition.source.replace(/\\/g, '/');
-    source.originalLine = originalPosition.line;
-
-    if (!ret.sourcemaps) {
-        ret.sourcemaps = true;
-    }
-
-    if (source.chunks) {
-        source.chunks.forEach((chunk) => {
-            // Also add source map information on chunks
-            originalPosition = smc.originalPositionFor({ line: num, column: chunk.column });
-            chunk.originalFilename = originalPosition.source;
-            chunk.originalLine = originalPosition.line;
-            chunk.originalColumn = originalPosition.column;
-        });
-    }
-};
-
-
 internals.file = async function (filename, data, options) {
 
     const ret = {
@@ -673,92 +642,125 @@ internals.file = async function (filename, data, options) {
 
         num++;
 
-        let isMiss = false;
-        ret.source[num] = {
-            source: line
+        const source = {
+            source: line,
+            hits: data.lines[num],
+            miss: false
         };
 
-        if (data.lines[num] === 0) {
-            isMiss = true;
-            ret.misses++;
-        }
-        else if (line) {
-            if (data.statements[num]) {
-                const mask = new Array(line.length);
-                Object.keys(data.statements[num]).forEach((id) => {
+        ret.source[num] = source;
 
-                    const statement = data.statements[num][id];
-                    if (statement.hit.true &&
-                        statement.hit.false) {
-
-                        return;
-                    }
-
-                    if (statement.loc.start.line !== num) {
-                        data.statements[statement.loc.start.line] = data.statements[statement.loc.start.line] || {};
-                        data.statements[statement.loc.start.line][id] = statement;
-                        return;
-                    }
-
-                    if (statement.loc.end.line !== num) {
-                        data.statements[statement.loc.end.line] = data.statements[statement.loc.end.line] || {};
-                        data.statements[statement.loc.end.line][id] = {
-                            hit: statement.hit,
-                            loc: {
-                                start: {
-                                    line: statement.loc.end.line,
-                                    column: 0
-                                },
-                                end: {
-                                    line: statement.loc.end.line,
-                                    column: statement.loc.end.column
-                                }
-                            }
-                        };
-
-                        statement.loc.end.column = line.length;
-                    }
-
-                    isMiss = true;
-                    const issue = statement.hit.true ? 'true' : (statement.hit.false ? 'false' : 'never');
-                    for (let i = statement.loc.start.column; i < statement.loc.end.column; ++i) {
-                        mask[i] = issue;
-                    }
-                });
-
-                const chunks = [];
-
-                let from = 0;
-                for (let i = 1; i < mask.length; ++i) {
-                    if (mask[i] !== mask[i - 1]) {
-                        chunks.push({ source: line.slice(from, i), miss: mask[i - 1], column: from });
-                        from = i;
-                    }
-                }
-
-                chunks.push({ source: line.slice(from), miss: mask[from], column: from });
-
-                if (isMiss) {
-                    ret.source[num].chunks = chunks;
-                    ret.misses++;
-                }
-                else {
-                    ret.hits++;
-                }
-            }
-            else if (!data.commentedLines[num] &&
-                line.trim()) {
-
-                ret.hits++;                 // Only increment hits if the current line isn't blank and commented
-            }
-        }
+        const isValidLine = !data.commentedLines[num] && line.trim();
 
         if (smc) {
-            internals.addSourceMapsInformation(smc, ret, num);
+            ret.sourcemaps = true;
+            const position = {
+                source: ret.filename,
+                line: num,
+                column: source.source.length    // when using 0 column, it sometimes miss the original line
+            };
+
+            const originalPosition = smc.originalPositionFor(position);
+            source.originalFilename = originalPosition.source && originalPosition.source.replace(/\\/g, '/');  // Ensure folder separator to be url-friendly
+            source.originalLine = originalPosition.line;
+            if (!originalPosition.source) {
+                if (line &&
+                    isValidLine) {
+
+                    ret.hits++;
+                }
+
+                return;
+            }
         }
 
-        ret.source[num].hits = data.lines[num];
-        ret.source[num].miss = isMiss;
+        if (data.lines[num] === 0) {
+            source.miss = true;
+            ret.misses++;
+            return;
+        }
+
+        if (!line) {
+            return;
+        }
+
+        if (data.statements[num]) {
+            const mask = new Array(line.length);
+            Object.keys(data.statements[num]).forEach((id) => {
+
+                const statement = data.statements[num][id];
+                if (statement.hit.true &&
+                    statement.hit.false) {
+
+                    return;
+                }
+
+                if (statement.loc.start.line !== num) {
+                    data.statements[statement.loc.start.line] = data.statements[statement.loc.start.line] || {};
+                    data.statements[statement.loc.start.line][id] = statement;
+                    return;
+                }
+
+                if (statement.loc.end.line !== num) {
+                    data.statements[statement.loc.end.line] = data.statements[statement.loc.end.line] || {};
+                    data.statements[statement.loc.end.line][id] = {
+                        hit: statement.hit,
+                        loc: {
+                            start: {
+                                line: statement.loc.end.line,
+                                column: 0
+                            },
+                            end: {
+                                line: statement.loc.end.line,
+                                column: statement.loc.end.column
+                            }
+                        }
+                    };
+
+                    statement.loc.end.column = line.length;
+                }
+
+                source.miss = true;
+                const issue = statement.hit.true ? 'true' : (statement.hit.false ? 'false' : 'never');
+                for (let i = statement.loc.start.column; i < statement.loc.end.column; ++i) {
+                    mask[i] = issue;
+                }
+            });
+
+            const chunks = [];
+
+            let from = 0;
+            for (let i = 1; i < mask.length; ++i) {
+                if (mask[i] !== mask[i - 1]) {
+                    chunks.push({ source: line.slice(from, i), miss: mask[i - 1], column: from });
+                    from = i;
+                }
+            }
+
+            chunks.push({ source: line.slice(from), miss: mask[from], column: from });
+
+            if (!source.miss) {
+                ret.hits++;
+                return;
+            }
+
+            if (smc) {
+                for (const chunk of chunks) {
+                    const chunkPosition = smc.originalPositionFor({ line: num, column: chunk.column });
+                    chunk.originalFilename = chunkPosition.source;
+                    chunk.originalLine = chunkPosition.line;
+                    chunk.originalColumn = chunkPosition.column;
+                }
+            }
+
+            ret.source[num].chunks = chunks;
+            ret.misses++;
+            return;
+        }
+
+        if (isValidLine) {
+            ret.hits++;                 // Only increment hits if the current line isn't blank and commented
+        }
     });
 
     ret.percent = ret.hits / ret.sloc * 100;

--- a/lib/modules/coverage.js
+++ b/lib/modules/coverage.js
@@ -635,6 +635,9 @@ internals.file = async function (filename, data, options) {
     }
 
     const smc = sourcemap ? await new SourceMap.SourceMapConsumer(sourcemap.map) : null;
+    if (smc) {
+        ret.sourcemaps = true;
+    }
 
     // Process each line of code
 
@@ -653,7 +656,6 @@ internals.file = async function (filename, data, options) {
         const isValidLine = !data.commentedLines[num] && line.trim();
 
         if (smc) {
-            ret.sourcemaps = true;
             const position = {
                 source: ret.filename,
                 line: num,
@@ -664,23 +666,17 @@ internals.file = async function (filename, data, options) {
             source.originalFilename = originalPosition.source && originalPosition.source.replace(/\\/g, '/');  // Ensure folder separator to be url-friendly
             source.originalLine = originalPosition.line;
             if (!originalPosition.source) {
-                if (line &&
-                    isValidLine) {
-
-                    ret.hits++;
+                if (isValidLine) {
+                    ret.sloc--;
                 }
 
                 return;
             }
         }
 
-        if (data.lines[num] === 0) {
+        if (source.hits === 0) {
             source.miss = true;
             ret.misses++;
-            return;
-        }
-
-        if (!line) {
             return;
         }
 
@@ -727,6 +723,11 @@ internals.file = async function (filename, data, options) {
                 }
             });
 
+            if (!source.miss) {
+                ret.hits++;
+                return;
+            }
+
             const chunks = [];
 
             let from = 0;
@@ -738,11 +739,6 @@ internals.file = async function (filename, data, options) {
             }
 
             chunks.push({ source: line.slice(from), miss: mask[from], column: from });
-
-            if (!source.miss) {
-                ret.hits++;
-                return;
-            }
 
             if (smc) {
                 for (const chunk of chunks) {

--- a/test/cli_typescript/api.ts
+++ b/test/cli_typescript/api.ts
@@ -1,0 +1,6 @@
+export * from './types';
+
+export function add(a: number, b: number) {
+
+    return a + b;
+}

--- a/test/cli_typescript/simple.ts
+++ b/test/cli_typescript/simple.ts
@@ -1,17 +1,20 @@
 import { expect } from '@hapi/code';
 import * as _Lab from '../../test_runner';
 
+import { add } from './api';
+
+
 const { describe, it } = exports.lab = _Lab.script();
 
 describe('Test CLI', () => {
 
     it('adds two numbers together', () => {
 
-        expect(1 + 1).to.equal(2);
+        expect(add(1, 1)).to.equal(2);
     });
 
     it('subtracts two numbers', () => {
 
-        expect(2 - 2).to.equal(0);
+        expect(add(2, - 2)).to.equal(0);
     });
 });

--- a/test/cli_typescript/types.ts
+++ b/test/cli_typescript/types.ts
@@ -1,0 +1,1 @@
+export type Test = string;

--- a/test/typescript.js
+++ b/test/typescript.js
@@ -37,4 +37,15 @@ describe('TypeScript', () => {
         expect(result.code).to.equal(1);
         expect(result.output).to.contain('error.ts:10:26');
     });
+
+    it('supports coverage', async () => {
+
+        process.chdir(Path.join(__dirname, 'cli_typescript'));
+        const result = await RunCli(['simple.ts', '-m', '2000', '-t', '100', '--typescript']);
+
+        expect(result.errorOutput).to.equal('');
+        expect(result.code).to.equal(0);
+        expect(result.output).to.contain('2 tests complete');
+        expect(result.output).to.contain('Coverage: 100.00%');
+    });
 });


### PR DESCRIPTION
When measuring coverage on transpiled files, sometimes the compiler adds code that is not mapped to code in the source file. Usually this means adding stuff like `'use strict';` which doesn't get a coverage statement wrapper. However, when using something like `export * from 'x'`, TS will add some crap code that cannot be covered. Luckily, the source maps reveal this code and can be counted for.

This change is actually pretty simple but because I took the opportunity to also make it read better, it looks like a lot more code changes than it really is. I recommend comparing without whitespaces. What it does is split the `addSourceMapsInformation()` method into two parts so that we can test if the entire line has coverage first, and only then annotate the chunks.