### PR TITLE
Add inline typescript sources to transformed output

### DIFF
--- a/lib/modules/typescript.js
+++ b/lib/modules/typescript.js
@@ -24,7 +24,8 @@ internals.transform = function (content, fileName) {
         const { options } = Typescript.parseJsonConfigFileContent(config, Typescript.sys, Typescript.getDirectoryPath(configFile), {}, configFile);
         options.sourceMap = false;
         options.inlineSourceMap = true;
-        options.module = 1; // CommonJS
+        options.inlineSources = true;
+        options.module = Typescript.ModuleKind.CommonJS;
         internals.configs.set(configFile, options);
     }
 

--- a/test/typescript.js
+++ b/test/typescript.js
@@ -1,10 +1,12 @@
 'use strict';
 
+const Fs = require('fs');
 const Path = require('path');
 
 const Code = require('@hapi/code');
 const _Lab = require('../test_runner');
 const RunCli = require('./run_cli');
+const Typescript = require('../lib/modules/typescript');
 
 
 const internals = {
@@ -36,5 +38,21 @@ describe('TypeScript', () => {
         expect(result.errorOutput).to.equal('');
         expect(result.code).to.equal(1);
         expect(result.output).to.contain('error.ts:10:26');
+    });
+
+    describe('transform', () => {
+
+        it('generates embedded sourcemap with sourcesContent', () => {
+
+            const smre = /\/\/\#\s*sourceMappingURL=data:application\/json[^,]+base64,(.*)\r?\n?$/;
+            const path = Path.join(__dirname, 'cli_typescript', 'simple.ts');
+            const transformed = Typescript.extensions[0].transform(Fs.readFileSync(path, { encoding: 'utf8' }), path);
+            const matches = smre.exec(transformed);
+            expect(matches).to.exist();
+            const sourcemap = JSON.parse(Buffer.from(matches[1], 'base64').toString());
+            expect(sourcemap.sources).to.equal(['simple.ts']);
+            expect(sourcemap.sourcesContent).to.exist();
+            expect(sourcemap.sourcesContent).to.have.length(1);
+        });
     });
 });


### PR DESCRIPTION
The html reporter cannot resolve the path to the original typescript source files which means that it only displays the transformed code. This PR fixes the issue by including the source in the inline source-map.