### PR TITLE
Support for ES modules

### DIFF
--- a/API.md
+++ b/API.md
@@ -740,7 +740,7 @@ See the [json reporter](lib/reporters/json.js) for a good starting point.
 
 Lab does not support code coverage for ES modules.  There are two reasons for this: in order to implement this we would either use [V8's builtin coverage](https://v8.dev/blog/javascript-code-coverage) or an [ESM Loader](https://nodejs.org/api/esm.html#loaders).  Unfortunately the former [doesn't support](https://bugs.chromium.org/p/v8/issues/detail?id=10627) granular branch coverage as we do in lab, and the latter is an experimental API that is still settling.  We hope to provide ESM coverage support in the future once one or both of these issues are resolved.
 
-In the meantime, we recomming using lab with [c8](https://github.com/bcoe/c8) in order to provide code coverage in ESM projects.  Note that c8 does not support granular branch coverage the way we do in lab, for the same reasons listed above.  It's pretty simple to use c8 with lab, though.
+In the meantime, we recommend using lab with [c8](https://github.com/bcoe/c8) in order to provide code coverage in ESM projects.  Note that c8 does not support granular branch coverage the way we do in lab, for the same reasons listed above.  It's pretty simple to use c8 with lab, though.
 
 First install c8:
 ```

--- a/API.md
+++ b/API.md
@@ -740,7 +740,7 @@ See the [json reporter](lib/reporters/json.js) for a good starting point.
 
 Lab does not support code coverage for ES modules.  There are two reasons for this: in order to implement this we would either use [V8's builtin coverage](https://v8.dev/blog/javascript-code-coverage) or an [ESM Loader](https://nodejs.org/api/esm.html#loaders).  Unfortunately the former [doesn't support](https://bugs.chromium.org/p/v8/issues/detail?id=10627) granular branch coverage as we do in lab, and the latter is an experimental API that is still settling.  We hope to provide ESM coverage support in the future once one or both of these issues are resolved.
 
-In the meantime, we recommend using lab with [c8](https://github.com/bcoe/c8) in order to provide code coverage in ESM projects.  Note that c8 does not support granular branch coverage the way we do in lab, for the same reasons listed above.  It's pretty simple to use c8 with lab, though.
+In the meantime, we recommend using lab with [c8](https://github.com/bcoe/c8) in order to provide code coverage in ESM projects.  Note that c8 does not support granular branch coverage the way we do in lab, for the same reasons listed above. Additionally, lab's coverage [inline enabling/disabling](#inline-enablingdisabling) and [bypass stack](#coverage-bypass-stack) are not compatible with c8, which has its own comparable functionality. It's pretty simple to use c8 with lab, though.
 
 First install c8:
 ```

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -5,6 +5,7 @@ const Path = require('path');
 
 const Bossy = require('@hapi/bossy');
 const FindRc = require('find-rc');
+const Mo = require('mo-walk');
 const Hoek = require('@hapi/hoek');
 
 const Modules = require('./modules');
@@ -22,7 +23,7 @@ internals.rcPath = FindRc('lab');
 internals.rc = internals.rcPath ? require(internals.rcPath) : {};
 
 
-exports.run = function () {
+exports.run = async function () {
 
     const settings = internals.options();
 
@@ -57,22 +58,22 @@ exports.run = function () {
         require('source-map-support').install(sourceMapOptions);
     }
 
-    const scripts = internals.traverse(settings.paths, settings);
+    const scripts = await internals.traverse(settings.paths, settings);
     return Runner.report(scripts, settings);
 };
 
 
-internals.traverse = function (paths, options) {
+internals.traverse = async function (paths, options) {
 
     let nextPath = null;
-    const traverse = function (path) {
+    const traverse = function (path, defaultToESM) {
 
         let files = [];
         nextPath = path;
 
         const pathStat = Fs.statSync(path);
         if (pathStat.isFile()) {
-            return path;
+            return [[path, defaultToESM]];
         }
 
         Fs.readdirSync(path).forEach((filename) => {
@@ -82,7 +83,7 @@ internals.traverse = function (paths, options) {
             if (stat.isDirectory() &&
                 !options.flat) {
 
-                files = files.concat(traverse(nextPath, options));
+                files = files.concat(traverse(nextPath, defaultToESM));
                 return;
             }
 
@@ -90,7 +91,7 @@ internals.traverse = function (paths, options) {
                 options.pattern.test(filename) &&
                 Path.basename(nextPath)[0] !== '.') {
 
-                files.push(nextPath);
+                files.push([nextPath, defaultToESM]);
             }
         });
 
@@ -99,10 +100,10 @@ internals.traverse = function (paths, options) {
 
     let testFiles = [];
     try {
-        paths.forEach((path) => {
-
-            testFiles = testFiles.concat(traverse(path));
-        });
+        for (const path of paths) {
+            const defaultToESM = await Mo.getDefaultToESM(path);
+            testFiles = testFiles.concat(traverse(path, defaultToESM));
+        }
     }
     catch (err) {
         if (err.code !== 'ENOENT') {
@@ -120,19 +121,18 @@ internals.traverse = function (paths, options) {
         process.exit(0);
     }
 
-    testFiles = testFiles.map((path) => {
-
-        return Path.resolve(path);
-    });
-
     const scripts = [];
-    testFiles.forEach((file) => {
+
+    for (const [unresolvedFile, defaultToESM] of testFiles) {
 
         global._labScriptRun = false;
-        file = Path.resolve(file);
+        const file = Path.resolve(unresolvedFile);
 
+        let pkg;
         try {
-            require(file);
+            const resolved = await Mo.tryToResolve(file, { defaultToESM });
+            Hoek.assert(resolved, 'File missing');
+            [pkg] = resolved;
         }
         catch (ex) {
             console.error(`Error requiring file: ${file}`);
@@ -140,8 +140,6 @@ internals.traverse = function (paths, options) {
             console.error(`${ex.stack}`);
             return process.exit(1);
         }
-
-        const pkg = require(file);
 
         if (pkg.lab &&
             pkg.lab._root) {
@@ -156,7 +154,7 @@ internals.traverse = function (paths, options) {
             console.error(`The file: ${file} includes a lab script that is not exported via exports.lab`);
             return process.exit(1);
         }
-    });
+    }
 
     return scripts;
 };
@@ -537,14 +535,14 @@ internals.options = function () {
         options.sourcemaps = true;
     }
 
-    let exts = '\\.(js)$';
+    let exts = '\\.(js|mjs|cjs)$';
     if (options.transform) {
         const transform = typeof options.transform === 'string' ? require(Path.resolve(options.transform)) : options.transform;
 
         Hoek.assert(Array.isArray(transform) && transform.length > 0, 'transform module must export an array of objects {ext: ".js", transform: null or function (content, filename)}');
         options.transform = transform;
 
-        const includes = 'js|' + transform.map(internals.mapTransform).join('|');
+        const includes = 'js|mjs|cjs|' + transform.map(internals.mapTransform).join('|');
         exts = '\\.(' + includes + ')$';
     }
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -61,8 +61,19 @@ exports.run = async function () {
     const scripts = await internals.traverse(settings.paths, settings);
 
     const isNotCjs = (script) => script._type !== 'cjs';
+
     if (settings.coverage && scripts.some(isNotCjs)) {
         console.error('Cannot use code coverage with ES modules. Consider using c8: instructions can be found in lab\'s docs.');
+        process.exit(1);
+    }
+
+    if (settings.typescript && scripts.some(isNotCjs)) {
+        console.error('Cannot use typescript with ES modules.');
+        process.exit(1);
+    }
+
+    if (settings.transform && scripts.some(isNotCjs)) {
+        console.error('Cannot use transform with ES modules.');
         process.exit(1);
     }
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -144,6 +144,7 @@ internals.traverse = async function (paths, options) {
         if (pkg.lab &&
             pkg.lab._root) {
 
+            pkg.lab._executionScheduled = true;
             scripts.push(pkg.lab);
 
             if (pkg.lab._cli) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -59,6 +59,13 @@ exports.run = async function () {
     }
 
     const scripts = await internals.traverse(settings.paths, settings);
+
+    const isNotCjs = (script) => script._type !== 'cjs';
+    if (settings.coverage && scripts.some(isNotCjs)) {
+        console.error('Cannot use code coverage with ES modules. Consider using c8: instructions can be found in lab\'s docs.');
+        process.exit(1);
+    }
+
     return Runner.report(scripts, settings);
 };
 
@@ -129,10 +136,11 @@ internals.traverse = async function (paths, options) {
         const file = Path.resolve(unresolvedFile);
 
         let pkg;
+        let type;
         try {
             const resolved = await Mo.tryToResolve(file, { defaultToESM });
             Hoek.assert(resolved, 'File missing');
-            [pkg] = resolved;
+            [pkg, , type] = resolved;
         }
         catch (ex) {
             console.error(`Error requiring file: ${file}`);
@@ -144,8 +152,10 @@ internals.traverse = async function (paths, options) {
         if (pkg.lab &&
             pkg.lab._root) {
 
-            pkg.lab._executionScheduled = true;
-            scripts.push(pkg.lab);
+            scripts.push(Object.assign(pkg.lab, {
+                _type: type,
+                _executionScheduled: true
+            }));
 
             if (pkg.lab._cli) {
                 Object.assign(options, pkg.lab._cli);

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,7 @@ exports.script = function (options) {
         _titles: [],
         _path: [],
         _count: 0,
-        _executed: false,
+        _executionScheduled: false,
         _onlyNodes: [],
         _cli: options.cli,
         _setOnly: function (experiment, test, path) {
@@ -86,7 +86,7 @@ exports.script = function (options) {
     if (options.schedule !== false) {                   // Defaults to true
         setImmediate(() => {
 
-            if (!script._executed) {
+            if (!script._executionScheduled) {
                 Runner.report(script, options);         // Schedule automatic execution when used without the CLI
             }
         });

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,6 +48,7 @@ exports.script = function (options) {
             options: {},
             title: 'script'
         },
+        _type: null,                                                    // 'cjs' or 'esm' if known
         _titles: [],
         _path: [],
         _count: 0,

--- a/lib/linter/index.js
+++ b/lib/linter/index.js
@@ -19,6 +19,7 @@ exports.lint = function () {
     const options = process.argv[2] ? JSON.parse(process.argv[2]) : undefined;
 
     if (!Fs.existsSync('.eslintrc.js') &&
+        !Fs.existsSync('.eslintrc.cjs') && // Needed for projects with "type": "module"
         !Fs.existsSync('.eslintrc.yaml') &&
         !Fs.existsSync('.eslintrc.yml') &&
         !Fs.existsSync('.eslintrc.json') &&

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -139,7 +139,7 @@ exports.execute = async function (scripts, options, reporter) {
 
     const experiments = scripts.map((script) => {
 
-        script._executed = true;
+        script._executionScheduled = true;
         return script._root;
     });
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "find-rc": "4.x.x",
         "globby": "10.x.x",
         "handlebars": "4.x.x",
+        "mo-walk": "^1.2.0",
         "seedrandom": "3.x.x",
         "source-map": "0.7.x",
         "source-map-support": "0.5.x",
@@ -36,8 +37,8 @@
         "will-call": "1.x.x"
     },
     "peerDependencies": {
-        "typescript": ">=3.6.5",
-        "@hapi/eslint-plugin": "^5.1.0"
+        "@hapi/eslint-plugin": "^5.1.0",
+        "typescript": ">=3.6.5"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/test/cli.js
+++ b/test/cli.js
@@ -898,4 +898,16 @@ describe('CLI', () => {
         expect(output).to.contain('does not crash lab');
         expect(output).to.not.contain('has another test');
     });
+
+    it('supports test suites that use ESM.', async () => {
+
+        const result = await RunCli(['test/cli_esm', '-m', '2000', '-a', '@hapi/code']);
+
+        expect(result.errorOutput).to.equal('');
+        expect(result.code).to.equal(1);
+        expect(result.output).to.contain('1 of 5 tests failed');
+
+        // Ensure scripts are run together, not independently
+        expect(result.output.split('Test duration').length - 1).to.equal(1);
+    });
 });

--- a/test/cli.js
+++ b/test/cli.js
@@ -901,7 +901,7 @@ describe('CLI', () => {
 
     it('supports test suites that use ESM.', async () => {
 
-        const result = await RunCli(['test/cli_esm', '-m', '2000', '-a', '@hapi/code']);
+        const result = await RunCli(['test/cli_esm']);
 
         expect(result.errorOutput).to.equal('');
         expect(result.code).to.equal(1);
@@ -909,5 +909,14 @@ describe('CLI', () => {
 
         // Ensure scripts are run together, not independently
         expect(result.output.split('Test duration').length - 1).to.equal(1);
+    });
+
+    it('does not allow using coverage with ESM test scripts.', async () => {
+
+        const result = await RunCli(['test/cli_esm', '-c', '--coverage-path', 'test/cli_esm']);
+
+        expect(result.output).to.equal('');
+        expect(result.code).to.equal(1);
+        expect(result.errorOutput).to.contain('Cannot use code coverage with ES modules. Consider using c8: instructions can be found in lab\'s docs.');
     });
 });

--- a/test/cli.js
+++ b/test/cli.js
@@ -919,4 +919,22 @@ describe('CLI', () => {
         expect(result.code).to.equal(1);
         expect(result.errorOutput).to.contain('Cannot use code coverage with ES modules. Consider using c8: instructions can be found in lab\'s docs.');
     });
+
+    it('does not allow using transform with ESM test scripts.', async () => {
+
+        const result = await RunCli(['test/cli_esm', '-T', 'test/transform/exclude/lab-transform']);
+
+        expect(result.output).to.equal('');
+        expect(result.code).to.equal(1);
+        expect(result.errorOutput).to.contain('Cannot use transform with ES modules.');
+    });
+
+    it('does not allow using typescript with ESM test scripts.', async () => {
+
+        const result = await RunCli(['test/cli_esm', '--typescript']);
+
+        expect(result.output).to.equal('');
+        expect(result.code).to.equal(1);
+        expect(result.errorOutput).to.contain('Cannot use typescript with ES modules.');
+    });
 });

--- a/test/cli_esm/api.js
+++ b/test/cli_esm/api.js
@@ -2,3 +2,8 @@ export function add(a, b) {
 
     return a + b;
 }
+
+export function unused(a, b) {
+
+    return a - b;
+}

--- a/test/cli_esm/api.js
+++ b/test/cli_esm/api.js
@@ -1,0 +1,4 @@
+export function add(a, b) {
+
+    return a + b;
+}

--- a/test/cli_esm/commonjs-api.cjs
+++ b/test/cli_esm/commonjs-api.cjs
@@ -1,0 +1,6 @@
+'use strict';
+
+exports.add = (a, b) => {
+
+    return a + b;
+};

--- a/test/cli_esm/commonjs-simple.cjs
+++ b/test/cli_esm/commonjs-simple.cjs
@@ -1,0 +1,30 @@
+'use strict';
+
+// Load modules
+
+const Code = require('@hapi/code');
+const _Lab = require('../../test_runner');
+
+const Api = require('./commonjs-api.cjs');
+
+// Declare internals
+
+const internals = {};
+
+// Test shortcuts
+
+const { describe, it } = exports.lab = _Lab.script();
+const expect = Code.expect;
+
+describe('Test CLI', () => {
+
+    it('adds two numbers together', () => {
+
+        expect(Api.add(1, 1)).to.equal(2);
+    });
+
+    it('subtracts two numbers', () => {
+
+        expect(Api.add(2, -2)).to.equal(0);
+    });
+});

--- a/test/cli_esm/error.js
+++ b/test/cli_esm/error.js
@@ -1,0 +1,13 @@
+import { expect } from '@hapi/code';
+import * as _Lab from '../../test_runner/index.js';
+
+export const lab = _Lab.script();
+const { describe, it } = lab;
+
+describe('Test CLI', () => {
+
+    it('adds two numbers together', () => {
+
+        expect(1 + 1).to.equal(4);
+    });
+});

--- a/test/cli_esm/package.json
+++ b/test/cli_esm/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }

--- a/test/cli_esm/simple.js
+++ b/test/cli_esm/simple.js
@@ -1,0 +1,20 @@
+import { expect } from '@hapi/code';
+import * as _Lab from '../../test_runner/index.js';
+
+import { add } from './api.js';
+
+export const lab = _Lab.script();
+const { describe, it } = lab
+
+describe('Test CLI', () => {
+
+    it('adds two numbers together', () => {
+
+        expect(add(1, 1)).to.equal(2);
+    });
+
+    it('subtracts two numbers', () => {
+
+        expect(add(2, - 2)).to.equal(0);
+    });
+});

--- a/test/lint/eslint/esm/.eslintrc.cjs
+++ b/test/lint/eslint/esm/.eslintrc.cjs
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+    parserOptions: {
+        sourceType: 'module'
+    }
+};

--- a/test/lint/eslint/esm/fail.js
+++ b/test/lint/eslint/esm/fail.js
@@ -1,0 +1,12 @@
+// Load modules
+
+
+// Declare internals
+
+const internals = {};
+
+
+export const method = function (value) {
+
+    return value
+};

--- a/test/lint/eslint/esm/package.json
+++ b/test/lint/eslint/esm/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }

--- a/test/linters.js
+++ b/test/linters.js
@@ -72,6 +72,24 @@ describe('Linters - eslint', () => {
         expect(checkedFile.errors).to.not.include({ line: 8, severity: 'ERROR', message: 'no-unused-vars - internals is defined but never used' });
     });
 
+    it('should list ESM files', async () => {
+
+        const path = Path.join(__dirname, 'lint', 'eslint', 'esm');
+        const result = await Linters.lint({ lintingPath: path });
+
+        expect(result).to.include('lint');
+
+        const eslintResults = result.lint;
+        expect(eslintResults).to.have.length(1);
+
+        const checkedFile = eslintResults[0];
+        expect(checkedFile).to.include({ filename: Path.join(path, 'fail.js') });
+        expect(checkedFile.errors).to.include([
+            { line: 11, severity: 'ERROR', message: 'semi - Missing semicolon.' },
+            { line: 12, severity: 'WARNING', message: 'eol-last - Newline required at end of file but not found.' }
+        ]);
+    });
+
     it('displays success message if no issues found', async () => {
 
         const path = Path.join(__dirname, 'lint', 'eslint', 'clean');

--- a/test/linters.js
+++ b/test/linters.js
@@ -72,7 +72,7 @@ describe('Linters - eslint', () => {
         expect(checkedFile.errors).to.not.include({ line: 8, severity: 'ERROR', message: 'no-unused-vars - internals is defined but never used' });
     });
 
-    it('should list ESM files', async () => {
+    it('should lint ESM files', async () => {
 
         const path = Path.join(__dirname, 'lint', 'eslint', 'esm');
         const result = await Linters.lint({ lintingPath: path });


### PR DESCRIPTION
This implements basic ES module support in lab.  There are some technical blockers to implementing granular, branch-level code coverage for ESM, so I punted on that for now by a. not allowing users to use coverage options with ESM test files, and b. directing users to documentation on how to use [c8](https://github.com/bcoe/c8) with lab, which at least gives users a decent coverage option for now.

I expect there will be some finer points to tighten-up through code review and perhaps some real-life testing, but I wanted to make this available for feedback since I think it is largely complete.

From the docs, here are the current blockers with coverage:
> Lab does not support code coverage for ES modules.  There are two reasons for this: in order to implement this we would either use [V8's builtin coverage](https://v8.dev/blog/javascript-code-coverage) or an [ESM Loader](https://nodejs.org/api/esm.html#loaders).  Unfortunately the former [doesn't support](https://bugs.chromium.org/p/v8/issues/detail?id=10627) granular branch coverage as we do in lab, and the latter is an experimental API that is still settling.  We hope to provide ESM coverage support in the future once one or both of these issues are resolved.

Resolves #1027  