### PR TITLE
add Node.js 18 globals

### DIFF
--- a/lib/modules/leaks.js
+++ b/lib/modules/leaks.js
@@ -41,6 +41,7 @@ const internals = {
         'MessageEvent',
         'MessagePort',
         'structuredClone',
+        'fetch',
 
         // Non-Enumerable globals
 
@@ -89,6 +90,12 @@ const internals = {
         'WeakRef',
         'WeakSet',
         'DOMException',
+        'Blob',
+        'BroadcastChannel',
+        'FormData',
+        'Headers',
+        'Request',
+        'Response',
 
         // Sometime
 


### PR DESCRIPTION
The following globals are added in Node.js 18: Blob, BroadcastChannel,
fetch, FormData, Headers, Request, Response.

----
Surfaced via Node.js CITGM runs on the Node.js 18.0.0 proposal - https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/2880/nodes=aix72-ppc64/testReport/junit/(root)/citgm/_hapi_shot_v5_0_5/