### PR TITLE
Coverage for nullish coalescing operator

### DIFF
--- a/lib/modules/coverage.js
+++ b/lib/modules/coverage.js
@@ -41,11 +41,18 @@ global[internals._state] = global[internals._state] || {
     _statement: function (name, id, line, source) {
 
         const statement = global[internals._state].files[name].statements[line][id];
+
         if (!statement.bool) {
             statement.hit[!source] = true;
         }
 
-        statement.hit[!!source] = true;
+        if (statement.bool === 'nullish') {
+            statement.hit[source !== null && source !== undefined] = true;
+        }
+        else {
+            statement.hit[!!source] = true;
+        }
+
         return source;
     },
 
@@ -151,12 +158,19 @@ internals.instrument = function (filename) {
     const addStatement = function (line, node, bool) {
 
         const id = ++ids;
-        statements.push({
+        const statement = {
             id,
             loc: node.loc,
             line,
             bool: bool && node.type !== 'ConditionalExpression' && node.type !== 'LogicalExpression'
-        });
+        };
+
+        if (statement.bool && node.parent?.operator === '??') {
+            statement.bool = 'nullish';
+        }
+
+        statements.push(statement);
+
         return id;
     };
 

--- a/lib/modules/coverage.js
+++ b/lib/modules/coverage.js
@@ -165,9 +165,12 @@ internals.instrument = function (filename) {
             bool: bool && node.type !== 'ConditionalExpression' && node.type !== 'LogicalExpression'
         };
 
-        if (statement.bool && node.parent?.operator === '??') {
+        // Node v14+ only
+        /*$lab:coverage:off$*/
+        if (statement.bool && node.parent.operator === '??') {
             statement.bool = 'nullish';
         }
+        /*$lab:coverage:on$*/
 
         statements.push(statement);
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "devDependencies": {
         "@hapi/code": "8.x.x",
         "@hapi/lab-external-module-test": "1.x.x",
+        "@hapi/somever": "^3.0.1",
         "cpr": "3.x.x",
         "lab-event-reporter": "1.x.x",
         "rimraf": "3.x.x",

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -8,6 +8,7 @@ const Path = require('path');
 const Code = require('@hapi/code');
 const _Lab = require('../test_runner');
 const Lab = require('../');
+const Somever = require('@hapi/somever');
 const SupportsColor = require('supports-color');
 
 
@@ -36,6 +37,7 @@ const expect = Code.expect;
 
 describe('Coverage', () => {
 
+    const supportsNullishCoalescing = Somever.match(process.version, '>=14');
     Lab.coverage.instrument({ coveragePath: Path.join(__dirname, 'coverage'), coverageExclude: 'exclude' });
 
     it('computes sloc without comments', async () => {
@@ -464,7 +466,7 @@ describe('Coverage', () => {
         expect(missedLines).to.be.empty();
     });
 
-    it('should measure coverage on nullish coalescing operator', async () => {
+    it('should measure coverage on nullish coalescing operator', { skip: !supportsNullishCoalescing }, async () => {
 
         const Test = require('./coverage/conditional-coalesce');
 
@@ -492,7 +494,7 @@ describe('Coverage', () => {
         expect(missedLines).to.equal(['7']);
     });
 
-    it('should measure missing coverage on nullish coalescing operator', async () => {
+    it('should measure missing coverage on nullish coalescing operator', { skip: !supportsNullishCoalescing }, async () => {
 
         const Test = require('./coverage/conditional-coalesce2');
 

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -464,6 +464,20 @@ describe('Coverage', () => {
         expect(missedLines).to.be.empty();
     });
 
+    it('should measure coverage on nullish coalescing operator', async () => {
+
+        const Test = require('./coverage/conditional-coalesce');
+
+        expect(Test.method(false)).to.equal(false);
+        expect(Test.method()).to.equal('nullish');
+        expect(Test.method(null)).to.equal('nullish');
+
+        const cov = await Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/conditional-coalesce') });
+        const source = cov.files[0].source;
+        const missedLines = Object.keys(source).filter((lineNumber) => source[lineNumber].miss);
+        expect(missedLines).to.be.empty();
+    });
+
     it('should measure missing coverage on conditional value', async () => {
 
         const Test = require('./coverage/conditional-value2');

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -492,6 +492,18 @@ describe('Coverage', () => {
         expect(missedLines).to.equal(['7']);
     });
 
+    it('should measure missing coverage on nullish coalescing operator', async () => {
+
+        const Test = require('./coverage/conditional-coalesce2');
+
+        expect(Test.method(1, null)).to.equal('1secondMissing');
+
+        const cov = await Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/conditional-coalesce2') });
+        const source = cov.files[0].source;
+        const missedLines = Object.keys(source).filter((lineNumber) => source[lineNumber].miss);
+        expect(missedLines).to.equal(['13', '14']);
+    });
+
     describe('analyze()', () => {
 
         it('sorts file paths in report', async () => {

--- a/test/coverage/conditional-coalesce.js
+++ b/test/coverage/conditional-coalesce.js
@@ -1,0 +1,14 @@
+'use strict';
+
+// Load modules
+
+
+// Declare internals
+
+const internals = {};
+
+
+exports.method = function (value) {
+
+    return value ?? 'nullish';
+};

--- a/test/coverage/conditional-coalesce2.js
+++ b/test/coverage/conditional-coalesce2.js
@@ -1,0 +1,17 @@
+'use strict';
+
+// Load modules
+
+
+// Declare internals
+
+const internals = {};
+
+
+exports.method = function (first, second) {
+
+    const a = first ?? 'firstMissing';
+    const b = second ?? 'secondMissing';
+
+    return a + b;
+};


### PR DESCRIPTION
Supporting coverage for nullish coalescing operator `??`.  Previously it would flag false positives for coverage issues.