### PR TITLE
Remove undocumented --coverage-module option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -229,12 +229,6 @@ internals.options = function () {
             description: 'prevent recursive inclusion of all files in coveragePath in report',
             default: null
         },
-        'coverage-module': {
-            type: 'string',
-            description: 'enable coverage on external module',
-            multiple: true,
-            default: null
-        },
         'coverage-path': {
             type: 'string',
             description: 'set code coverage path',
@@ -484,7 +478,7 @@ internals.options = function () {
     options.paths = argv._ ? [].concat(argv._) : options.paths;
 
     const keys = ['assert', 'bail', 'colors', 'context-timeout', 'coverage', 'coverage-exclude',
-        'coverage-path', 'coverage-all', 'coverage-flat', 'coverage-module', 'coverage-pattern',
+        'coverage-path', 'coverage-all', 'coverage-flat', 'coverage-pattern',
         'default-plan-threshold', 'dry', 'environment', 'flat', 'globals', 'grep',
         'lint', 'lint-errors-threshold', 'lint-fix', 'lint-options', 'lint-warnings-threshold',
         'linter', 'output', 'pattern', 'reporter', 'retries', 'seed', 'shuffle', 'silence', 'silent-skips',

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -81,11 +81,6 @@ declare namespace script {
         readonly 'coverage-flat'?: boolean;
 
         /**
-         * Enables coverage on external modules.
-         */
-        readonly 'coverage-module'?: string[];
-
-        /**
          * Sets code coverage path.
          */
         readonly 'coverage-path'?: string;

--- a/lib/modules/coverage.js
+++ b/lib/modules/coverage.js
@@ -16,7 +16,6 @@ const Eslintrc = require('../linter/.eslintrc');
 const Transform = require('./transform');
 
 const internals = {
-    ext: Symbol.for('@hapi/lab/coverage/initialize'),
     _state: Symbol.for('@hapi/lab/coverage/_state'),
     EslintEngine: new ESLint.CLIEngine({ baseConfig: Eslintrc })
 };
@@ -28,8 +27,6 @@ const internals = {
 global[internals._state] = global[internals._state] || {
 
     modules: new Set(),
-
-    externals: new Set(),
 
     files: {},
 
@@ -47,17 +44,6 @@ global[internals._state] = global[internals._state] || {
 
         statement.hit[!!source] = true;
         return source;
-    },
-
-    _external: function (name, line, source) {
-
-        const initialize = source[Symbol.for('@hapi/lab/coverage/initialize')];
-        if (typeof initialize !== 'function') {
-            throw new Error('Failed to find a compatible external coverage method in ' + name + ':' + line);
-        }
-
-        internals.state.externals.add(initialize());
-        return source;
     }
 };
 
@@ -70,12 +56,6 @@ if (typeof global.__$$labCov === 'undefined') {
 
 
 exports.instrument = function (options) {
-
-    if (options['coverage-module']) {
-        for (const name of options['coverage-module']) {
-            internals.state.modules.add(name);
-        }
-    }
 
     internals.state.patterns.unshift(internals.pattern(options));
     Transform.install(options, internals.prime);
@@ -319,14 +299,6 @@ internals.instrument = function (filename) {
 
             node.set(`global.__$$labCov._statement(\'${filename}\',${test},${line},${node.source()})`);
         }
-        else if (node.type === 'CallExpression' &&
-            node.callee.name === 'require') {
-
-            const name = node.arguments[0].value;
-            if (internals.state.modules.has(name)) {
-                node.set(`global.__$$labCov._external(\'${filename}\',${line},${node.source()})`);
-            }
-        }
     };
 
     // Parse tree
@@ -526,7 +498,6 @@ exports.analyze = async function (options) {
         hits: 0,
         misses: 0,
         percent: 0,
-        externals: 0,
         files: []
     };
 
@@ -547,7 +518,6 @@ exports.analyze = async function (options) {
             cov.hits += data.hits;
             cov.misses += data.misses;
             cov.sloc += data.sloc;
-            cov.externals += data.externals ? data.externals.length : 0;
         }
     }
 
@@ -599,8 +569,7 @@ internals.file = async function (filename, data, options) {
         hits: 0,
         misses: 0,
         sloc: data.sloc,
-        source: {},
-        externals: internals.external(filename)
+        source: {}
     };
 
     // Use sourcemap consumer rather than SourceMapSupport.mapSourcePosition itself which perform path transformations
@@ -758,23 +727,4 @@ internals.file = async function (filename, data, options) {
 
     ret.percent = ret.hits / ret.sloc * 100;
     return ret;
-};
-
-
-internals.external = function (filename) {
-
-    filename = Path.normalize(filename);
-
-    const reports = [];
-    for (const external of internals.state.externals) {
-        const report = external.report(filename);
-        if (report) {
-            const items = [].concat(report);
-            for (const item of items) {
-                reports.push(Object.assign({}, item, { source: external.name }));
-            }
-        }
-    }
-
-    return reports.length ? reports : null;
 };

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -400,37 +400,6 @@ internals.Reporter.prototype.end = function (notebook) {
         }
 
         output += '\n';
-
-        // External coverage
-
-        if (this.settings['coverage-module']) {
-            output += 'External coverage:';
-
-            let hasErrors = false;
-            for (const file of coverage.files) {
-                if (!file.externals) {
-                    continue;
-                }
-
-                hasErrors = true;
-                output += gray('\n' + file.filename + ':');
-                let source;
-                for (const report of file.externals) {
-                    if (source !== report.source) {
-                        source = report.source;
-                        output += gray('\n\t' + source + ':');
-                    }
-
-                    output += (report.severity !== 'warning' ? red : yellow)('\n\t\tLine ' + report.line + ': ' + report.message);
-                }
-            }
-
-            if (!hasErrors) {
-                output += green(' No issues');
-            }
-
-            output += '\n';
-        }
     }
 
     // Lint

--- a/lib/reporters/index.js
+++ b/lib/reporters/index.js
@@ -98,7 +98,6 @@ exports.generate = function (options) {
 
                     if (((notebook.errors?.length) ||                                                         // Before/after/exceptions
                         options.coverage && options.threshold && notebook.coverage.percent < options.threshold) ||              // Missing coverage
-                        options.coverage && options['coverage-module'] && notebook.coverage.externals ||                        // Missing external coverage
                         notebook.failures ||                                                                                    // Tests failed
                         (notebook.leaks?.length) ||                                                            // Global leaked
                         (notebook.types?.length) ||                                                            // Types definition

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     },
     "devDependencies": {
         "@hapi/code": "8.x.x",
-        "@hapi/lab-external-module-test": "1.x.x",
         "cpr": "3.x.x",
         "lab-event-reporter": "1.x.x",
         "rimraf": "3.x.x",

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -8,7 +8,6 @@ const Path = require('path');
 const Code = require('@hapi/code');
 const _Lab = require('../test_runner');
 const Lab = require('../');
-const SupportsColor = require('supports-color');
 
 
 const internals = {
@@ -633,13 +632,3 @@ describe('Coverage via Transform API', () => {
         ]);
     });
 });
-
-
-internals.colors = function (string) {
-
-    if (SupportsColor.stdout) {
-        return string;
-    }
-
-    return string.replace(/\u001b\[\d+m/g, '');
-};

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -571,46 +571,6 @@ describe('Coverage', () => {
             expect(cov.percent).to.equal(100);
         });
     });
-
-    describe('coverage-module option', () => {
-
-        it('reports external coverage', async () => {
-
-            const coveragePath = Path.join(__dirname, 'coverage/module');
-            Lab.coverage.instrument({ coveragePath, 'coverage-module': ['@hapi/lab-external-module-test'] });
-
-            require(coveragePath);
-
-            const cov = await Lab.coverage.analyze({ coveragePath });
-
-            expect(cov.percent).to.equal(100);
-            expect(cov.externals).to.equal(2);
-            expect(cov.files[0].externals).to.equal([
-                {
-                    line: 9,
-                    message: 'Checker missing tests for 2, 3',
-                    source: 'Ext',
-                    severity: 'error'
-                },
-                {
-                    line: 12,
-                    message: 'Checker missing tests for 3',
-                    source: 'Ext',
-                    severity: 'warning'
-                }
-            ]);
-
-            const script = Lab.script();
-            const { output, code } = await Lab.report(script, { reporter: 'console', coverage: true, coveragePath: Path.join(__dirname, 'coverage'), 'coverage-module': ['@hapi/lab-external-module-test'], output: false });
-            expect(code).to.equal(1);
-            expect(output).to.contain(internals.colors('External coverage:\u001b[90m\n' +
-                'test/coverage/module.js:\u001b[0m\u001b[90m\n' +
-                '\tExt:\u001b[0m\u001b[31m\n' +
-                '\t\tLine 9: Checker missing tests for 2, 3\u001b[0m\u001b[33m\n' +
-                '\t\tLine 12: Checker missing tests for 3\u001b[0m\n' +
-                '\n'));
-        });
-    });
 });
 
 describe('Coverage via Transform API', () => {

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -955,7 +955,7 @@ describe('Reporter', () => {
                 });
             });
 
-            const { output } = await Lab.report(script, { reporter: 'console', coverage: true, coveragePath: Path.join(__dirname, './coverage/console'), output: false, 'coverage-module': ['@hapi/lab-external-module-test'], colors: true });
+            const { output } = await Lab.report(script, { reporter: 'console', coverage: true, coveragePath: Path.join(__dirname, './coverage/console'), output: false, colors: true });
             expect(output).to.contain('Coverage: \u001b[31m64.86% (26/74)');
             expect(output).to.contain('test/coverage/console.js missing coverage on line(s): 14, 17-19, 22, 23');
             expect(output).to.contain('test/coverage/console-large-file.js missing coverage on line(s): 13, 17, 20, 25, 26, 29, 35-37, 40, 47-50, 53, 61-65');


### PR DESCRIPTION
I'm not aware of any existing usage of this half-baked feature, and it seems like a good candidate for inclusion in the v25 release.

This also fixes `npm install` on the lab repo, so it doesn't complain about the moved `@hapi/pinpoint` dependency, and `@hapi/lab-external-module-test` can now be deprecated.