### PR TITLE
Update sindresorhus deps to pre ESM versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
         "diff": "4.x.x",
         "eslint": "7.x.x",
         "find-rc": "4.x.x",
-        "globby": "10.x.x",
+        "globby": "^11.1.0",
         "handlebars": "4.x.x",
         "mo-walk": "^1.2.0",
         "seedrandom": "3.x.x",
         "source-map": "0.7.x",
         "source-map-support": "0.5.x",
-        "supports-color": "7.x.x",
+        "supports-color": "^8.1.1",
         "will-call": "1.x.x"
     },
     "peerDependencies": {
@@ -48,6 +48,7 @@
     "devDependencies": {
         "@hapi/code": "8.x.x",
         "@hapi/lab-external-module-test": "1.x.x",
+        "@types/node": "^17.0.23",
         "cpr": "3.x.x",
         "lab-event-reporter": "1.x.x",
         "rimraf": "3.x.x",


### PR DESCRIPTION
I expect that these are the end of the road for the current v24 release.

AFAIK, these versions are still supported for critical issues. FAQ for ESM move: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c

FYI `globby@11` will fail the test suite if `@types/node` is not available.