### PR TITLE
feat: 🎸 depedencies cli option

### DIFF
--- a/API.md
+++ b/API.md
@@ -256,6 +256,12 @@ Then the test can be executed using the following command line:
 $ lab --typescript
 ```
 
+If your typescript project has custom paths, Lab can be passed `tsconfig-paths/register` as a requirement before running and it will resolve based on your path config.
+
+```sh
+$ lab --typescript --require 'tsconfig-paths/register'
+```
+
 ## Command Line
 
 **lab** supports the following command line options:
@@ -298,6 +304,7 @@ $ lab --typescript
     - `clover` - output results in [Clover XML](https://confluence.atlassian.com/display/CLOVER) format.
     - [Multiple Reporters](#multiple-reporters) - See Below
     - [Custom Reporters](#custom-reporters) - See Below
+- `--req`, `--require` - dependencies to require and run before tests run (useful for things like `babel`, `tsconfig-paths`, test setup, etc).
 - `-R`, `--retries` - the number of times to retry a failing test that is explicitly marked with `retry`. Defaults to `5`.
 - `--shuffle` - randomize the order that test scripts are executed.  Will not work with `--id`.
 - `--seed` - use this seed to randomize the order with `--shuffle`. This is useful to debug order dependent test failures.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -252,13 +252,6 @@ internals.options = function () {
             description: 'minimum plan threshold to apply to all tests that don\'t define any plan',
             default: null
         },
-        require: {
-            alias: 'req',
-            multiple: true,
-            type: 'string',
-            description: 'dependency module to require and run before tests run (useful for things like babel, tsconfig-paths, etc)',
-            default: null
-        },
         dry: {
             alias: 'd',
             type: 'boolean',
@@ -364,6 +357,13 @@ internals.options = function () {
             multiple: true,
             default: null
         },
+        require: {
+            alias: 'req',
+            multiple: true,
+            type: 'string',
+            description: 'dependency module to require and run before tests run (useful for things like babel, tsconfig-paths, etc)',
+            default: null
+        },
         retries: {
             alias: 'R',
             type: 'number',
@@ -450,7 +450,6 @@ internals.options = function () {
         bail: false,
         coverage: false,
         dry: false,
-        require: [],
         environment: 'test',
         flat: false,
         leaks: true,
@@ -461,6 +460,7 @@ internals.options = function () {
         'lint-warnings-threshold': 0,
         paths: ['test'],
         reporter: 'console',
+        require: [],
         retries: 5,
         shuffle: false,
         silence: false,
@@ -494,9 +494,9 @@ internals.options = function () {
 
     const keys = ['assert', 'bail', 'colors', 'context-timeout', 'coverage', 'coverage-exclude',
         'coverage-path', 'coverage-all', 'coverage-flat', 'coverage-module', 'coverage-pattern',
-        'default-plan-threshold', 'require', 'dry', 'environment', 'flat', 'globals', 'grep',
-        'lint', 'lint-errors-threshold', 'lint-fix', 'lint-options', 'lint-warnings-threshold',
-        'linter', 'output', 'pattern', 'reporter', 'retries', 'seed', 'shuffle', 'silence', 'silent-skips',
+        'default-plan-threshold', 'dry', 'environment', 'flat', 'globals', 'grep', 'lint',
+        'lint-errors-threshold', 'lint-fix', 'lint-options', 'lint-warnings-threshold', 'linter',
+        'output', 'pattern', 'reporter', 'require', 'retries', 'seed', 'shuffle', 'silence', 'silent-skips',
         'sourcemaps', 'threshold', 'timeout', 'transform', 'types', 'types-test', 'typescript', 'verbose'];
 
     for (let i = 0; i < keys.length; ++i) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -252,7 +252,8 @@ internals.options = function () {
             description: 'minimum plan threshold to apply to all tests that don\'t define any plan',
             default: null
         },
-        dep: {
+        require: {
+            alias: 'req',
             multiple: true,
             type: 'string',
             description: 'dependency module to require and run before tests run (useful for things like babel, tsconfig-paths, etc)',
@@ -449,7 +450,7 @@ internals.options = function () {
         bail: false,
         coverage: false,
         dry: false,
-        dep: [],
+        require: [],
         environment: 'test',
         flat: false,
         leaks: true,
@@ -493,7 +494,7 @@ internals.options = function () {
 
     const keys = ['assert', 'bail', 'colors', 'context-timeout', 'coverage', 'coverage-exclude',
         'coverage-path', 'coverage-all', 'coverage-flat', 'coverage-module', 'coverage-pattern',
-        'default-plan-threshold', 'dep', 'dry', 'environment', 'flat', 'globals', 'grep',
+        'default-plan-threshold', 'require', 'dry', 'environment', 'flat', 'globals', 'grep',
         'lint', 'lint-errors-threshold', 'lint-fix', 'lint-options', 'lint-warnings-threshold',
         'linter', 'output', 'pattern', 'reporter', 'retries', 'seed', 'shuffle', 'silence', 'silent-skips',
         'sourcemaps', 'threshold', 'timeout', 'transform', 'types', 'types-test', 'typescript', 'verbose'];
@@ -565,11 +566,23 @@ internals.options = function () {
         options.sourcemaps = true;
     }
 
-    if (options.deps) {
+    if (options.require) {
 
-        for (let i = 0; i < options.deps.length; ++i) {
+        for (let i = 0; i < options.require.length; ++i) {
 
-            require(options.deps[i]);
+            const moduleName = options.require[i];
+
+            const resolved = require.resolve(
+
+                moduleName,
+                { paths: [process.cwd()] }
+            );
+
+            if (!resolved) {
+                console.error(`Could not resolve module used with --require option: ${options.deps[i]}`);
+            }
+
+            require(resolved);
         }
     }
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -252,6 +252,12 @@ internals.options = function () {
             description: 'minimum plan threshold to apply to all tests that don\'t define any plan',
             default: null
         },
+        dep: {
+            multiple: true,
+            type: 'string',
+            description: 'dependency module to require and run before tests run (useful for things like babel, tsconfig-paths, etc)',
+            default: null
+        },
         dry: {
             alias: 'd',
             type: 'boolean',
@@ -443,6 +449,7 @@ internals.options = function () {
         bail: false,
         coverage: false,
         dry: false,
+        dep: [],
         environment: 'test',
         flat: false,
         leaks: true,
@@ -486,12 +493,13 @@ internals.options = function () {
 
     const keys = ['assert', 'bail', 'colors', 'context-timeout', 'coverage', 'coverage-exclude',
         'coverage-path', 'coverage-all', 'coverage-flat', 'coverage-module', 'coverage-pattern',
-        'default-plan-threshold', 'dry', 'environment', 'flat', 'globals', 'grep',
+        'default-plan-threshold', 'dep', 'dry', 'environment', 'flat', 'globals', 'grep',
         'lint', 'lint-errors-threshold', 'lint-fix', 'lint-options', 'lint-warnings-threshold',
         'linter', 'output', 'pattern', 'reporter', 'retries', 'seed', 'shuffle', 'silence', 'silent-skips',
         'sourcemaps', 'threshold', 'timeout', 'transform', 'types', 'types-test', 'typescript', 'verbose'];
 
     for (let i = 0; i < keys.length; ++i) {
+
         if (argv.hasOwnProperty(keys[i]) && argv[keys[i]] !== undefined && argv[keys[i]] !== null) {
             options[keys[i]] = argv[keys[i]];
         }
@@ -555,6 +563,14 @@ internals.options = function () {
 
         options.transform = Modules.typescript.extensions;
         options.sourcemaps = true;
+    }
+
+    if (options.deps) {
+
+        for (let i = 0; i < options.deps.length; ++i) {
+
+            require(options.deps[i]);
+        }
     }
 
     let exts = '\\.(js|mjs|cjs)$';

--- a/package.json
+++ b/package.json
@@ -38,10 +38,14 @@
     },
     "peerDependencies": {
         "@hapi/eslint-plugin": "^5.1.0",
-        "typescript": ">=3.6.5"
+        "typescript": ">=3.6.5",
+        "tsconfig-paths": "^3.14.1"
     },
     "peerDependenciesMeta": {
         "typescript": {
+            "optional": true
+        },
+        "tsconfig-paths": {
             "optional": true
         }
     },
@@ -52,7 +56,8 @@
         "lab-event-reporter": "1.x.x",
         "rimraf": "3.x.x",
         "semver": "7.x.x",
-        "typescript": "^4.5.4"
+        "typescript": "^4.5.4",
+        "tsconfig-paths": "^3.14.1"
     },
     "bin": {
         "lab": "./bin/lab"

--- a/package.json
+++ b/package.json
@@ -38,14 +38,10 @@
     },
     "peerDependencies": {
         "@hapi/eslint-plugin": "^5.1.0",
-        "typescript": ">=3.6.5",
-        "tsconfig-paths": "^3.14.1"
+        "typescript": ">=3.6.5"
     },
     "peerDependenciesMeta": {
         "typescript": {
-            "optional": true
-        },
-        "tsconfig-paths": {
             "optional": true
         }
     },

--- a/test/cli_tsconfig_paths/error.ts
+++ b/test/cli_tsconfig_paths/error.ts
@@ -1,0 +1,12 @@
+import { expect } from '@hapi/code';
+import * as _Lab from '../../test_runner';
+
+const { describe, it } = exports.lab = _Lab.script();
+
+describe('Test CLI', () => {
+
+    it('adds two numbers together', () => {
+
+        expect(1 + 1).to.equal(4);
+    });
+});

--- a/test/cli_tsconfig_paths/includeMe.js
+++ b/test/cli_tsconfig_paths/includeMe.js
@@ -1,0 +1,1 @@
+global.shouldExist = true

--- a/test/cli_tsconfig_paths/really/super/nested/api.ts
+++ b/test/cli_tsconfig_paths/really/super/nested/api.ts
@@ -1,0 +1,6 @@
+export * from '~/types';
+
+export function add(a: number, b: number) {
+
+    return a + b;
+}

--- a/test/cli_tsconfig_paths/simple.ts
+++ b/test/cli_tsconfig_paths/simple.ts
@@ -1,5 +1,3 @@
-import 'tsconfig-paths/register';
-
 import { expect } from '@hapi/code';
 import * as _Lab from '../../test_runner';
 
@@ -18,5 +16,10 @@ describe('Test CLI', () => {
     it('subtracts two numbers', () => {
 
         expect(add(2, - 2)).to.equal(0);
+    });
+
+    it('should have included a global via require option', () => {
+
+        expect(global.shouldExist).to.be.true();
     });
 });

--- a/test/cli_tsconfig_paths/simple.ts
+++ b/test/cli_tsconfig_paths/simple.ts
@@ -1,0 +1,22 @@
+import 'tsconfig-paths/register';
+
+import { expect } from '@hapi/code';
+import * as _Lab from '../../test_runner';
+
+import { add } from 'nested/api';
+
+
+const { describe, it } = exports.lab = _Lab.script();
+
+describe('Test CLI', () => {
+
+    it('adds two numbers together', () => {
+
+        expect(add(1, 1)).to.equal(2);
+    });
+
+    it('subtracts two numbers', () => {
+
+        expect(add(2, - 2)).to.equal(0);
+    });
+});

--- a/test/cli_tsconfig_paths/tsconfig.json
+++ b/test/cli_tsconfig_paths/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "target": "es2021",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "baseUrl": ".",
+        "paths": {
+            "nested/*": ["./really/super/nested/*"],
+            "~/*": ["./*"]
+        }
+    },
+}

--- a/test/cli_tsconfig_paths/types.ts
+++ b/test/cli_tsconfig_paths/types.ts
@@ -1,0 +1,1 @@
+export type Test = string;

--- a/test/tsconfig-paths.js
+++ b/test/tsconfig-paths.js
@@ -19,7 +19,16 @@ const expect = Code.expect;
 
 const cwd = Path.join(__dirname, 'cli_tsconfig_paths');
 
-const commands = (file, ...extra) => [file, '-m', '2000', '--typescript', '--dep', 'tsconfig-paths/register', ...extra];
+const commands = (file, ...extra) => [
+    file,
+    '-m',
+    '2000',
+    '--typescript',
+    '--require', 'tsconfig-paths/register',
+    '--require', './includeMe.js',
+    '-I', 'shouldExist',
+    ...extra
+];
 
 describe('TypeScript Paths', () => {
 
@@ -32,7 +41,7 @@ describe('TypeScript Paths', () => {
         const result = await RunCli(commands('simple.ts'), cwd);
         expect(result.errorOutput).to.equal('');
         expect(result.code).to.equal(0);
-        expect(result.output).to.contain('2 tests complete');
+        expect(result.output).to.contain('3 tests complete');
     });
 
     it('handles errors', async () => {
@@ -51,7 +60,7 @@ describe('TypeScript Paths', () => {
 
         expect(result.errorOutput).to.equal('');
         expect(result.code).to.equal(0);
-        expect(result.output).to.contain('2 tests complete');
+        expect(result.output).to.contain('3 tests complete');
         expect(result.output).to.contain('Coverage: 100.00%');
     });
 

--- a/test/tsconfig-paths.js
+++ b/test/tsconfig-paths.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const Fs = require('fs');
+const Path = require('path');
+
+const Code = require('@hapi/code');
+const _Lab = require('../test_runner');
+const RunCli = require('./run_cli');
+const Typescript = require('../lib/modules/typescript');
+
+
+const internals = {
+    cwd: process.cwd()
+};
+
+
+const { describe, it, afterEach } = exports.lab = _Lab.script();
+const expect = Code.expect;
+
+const cwd = Path.join(__dirname, 'cli_tsconfig_paths');
+
+const commands = (file, ...extra) => [file, '-m', '2000', '--typescript', '--dep', 'tsconfig-paths/register', ...extra];
+
+describe('TypeScript Paths', () => {
+
+    afterEach(() => process.chdir(internals.cwd));
+
+    it('supports TypeScript', async () => {
+
+        process.chdir(cwd);
+
+        const result = await RunCli(commands('simple.ts'), cwd);
+        expect(result.errorOutput).to.equal('');
+        expect(result.code).to.equal(0);
+        expect(result.output).to.contain('2 tests complete');
+    });
+
+    it('handles errors', async () => {
+
+        process.chdir(cwd);
+        const result = await RunCli(commands('error.ts'), cwd);
+        expect(result.errorOutput).to.equal('');
+        expect(result.code).to.equal(1);
+        expect(result.output).to.contain('error.ts:10:26');
+    });
+
+    it('supports coverage', async () => {
+
+        process.chdir(cwd);
+        const result = await RunCli(commands('simple.ts', '-t', '100'), cwd);
+
+        expect(result.errorOutput).to.equal('');
+        expect(result.code).to.equal(0);
+        expect(result.output).to.contain('2 tests complete');
+        expect(result.output).to.contain('Coverage: 100.00%');
+    });
+
+    describe('transform', () => {
+
+        it('generates embedded sourcemap with sourcesContent', () => {
+
+            const smre = /\/\/\#\s*sourceMappingURL=data:application\/json[^,]+base64,(.*)\r?\n?$/;
+            const path = Path.join(__dirname, 'cli_tsconfig_paths', 'simple.ts');
+            const transformed = Typescript.extensions[0].transform(Fs.readFileSync(path, { encoding: 'utf8' }), path);
+            const matches = smre.exec(transformed);
+            expect(matches).to.exist();
+            const sourcemap = JSON.parse(Buffer.from(matches[1], 'base64').toString());
+            expect(sourcemap.sources).to.equal(['simple.ts']);
+            expect(sourcemap.sourcesContent).to.exist();
+            expect(sourcemap.sourcesContent).to.have.length(1);
+        });
+    });
+});


### PR DESCRIPTION
Addresses https://github.com/hapijs/lab/issues/1033

Uses `tsconfig-paths/register` as test.

> Needs documentation


Usage: 
```
lab --typescript --require 'tsconfig-paths/register' test
```