### PR TITLE
Remove node 8 compat fix

### DIFF
--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -14,45 +14,8 @@ const internals = {
 
 internals.stringify = function (obj) {
 
-    // $lab:coverage:off$
-
-    if (process.version[1] !== '1') {
-        obj = internals.sortObject(obj);
-    }
-    // $lab:coverage:on$
-
     return Util.inspect(obj, { compact: false, depth: Infinity, maxArrayLength: Infinity, breakLength: Infinity, sorted: true });
 };
-
-
-// $lab:coverage:off$
-
-internals.sortObject = (obj, _seen) => {
-
-    if (!obj ||
-        typeof obj !== 'object') {
-
-        return obj;
-    }
-
-    const seen = _seen || new Map();
-
-    if (seen.has(obj)) {
-        return seen.get(obj);
-    }
-
-    const output = Array.isArray(obj) ? [] : {};
-    seen.set(obj, output);
-
-    const keys = Object.keys(obj).sort();
-    for (const key of keys) {
-        const value = obj[key];
-        output[key] = internals.sortObject(value, seen);
-    }
-
-    return output;
-};
-// $lab:coverage:on$
 
 
 exports = module.exports = internals.Reporter = function (options) {


### PR DESCRIPTION
Introduced in https://github.com/hapijs/lab/commit/d39ee5584ea913407abbea140ed141bc3d4cf682.

Seems about time… Especially since it will inadvertently be enabled for node 20+.