### PR TITLE
New --coverage-predicates option

### DIFF
--- a/.labrc.js
+++ b/.labrc.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const Somever = require('@hapi/somever');
+
+module.exports = {
+    'coverage-predicate': [
+        process.platform,
+        Somever.match(process.version, '>=14') && 'has-nullish'
+    ]
+};

--- a/.labrc.js
+++ b/.labrc.js
@@ -3,8 +3,8 @@
 const Somever = require('@hapi/somever');
 
 module.exports = {
-    'coverage-predicate': [
-        process.platform,
-        Somever.match(process.version, '>=14') && 'has-nullish'
-    ]
+    'coverage-predicates': {
+        win32: process.platform === 'win32',
+        'has-nullish': Somever.match(process.version, '>=14')
+    }
 };

--- a/API.md
+++ b/API.md
@@ -267,7 +267,7 @@ $ lab --typescript
 - `--coverage-all` - report coverage for all matched files, not just those tested.
 - `--coverage-flat` - do not perform a recursive find of files for coverage report. Requires `--coverage-all`
 - `--coverage-pattern` - only report coverage for files with the given pattern in the name. Defaults to `pattern`. Requires `--coverage-all`
-- `--coverage-predicate` - sets custom code coverage predicates.
+- `--coverage-predicates` - sets custom code coverage predicates.
 - `-C`, `--colors` - enables or disables color output. Defaults to console capabilities.
 - `-d`, `--dry` - dry run. Skips all tests. Use with `-v` to generate a test catalog. Defaults to `false`.
 - `-e`, `--environment` - value to set the `NODE_ENV` environment variable to, defaults to 'test'.

--- a/API.md
+++ b/API.md
@@ -267,6 +267,7 @@ $ lab --typescript
 - `--coverage-all` - report coverage for all matched files, not just those tested.
 - `--coverage-flat` - do not perform a recursive find of files for coverage report. Requires `--coverage-all`
 - `--coverage-pattern` - only report coverage for files with the given pattern in the name. Defaults to `pattern`. Requires `--coverage-all`
+- `--coverage-predicate` - sets custom code coverage predicates.
 - `-C`, `--colors` - enables or disables color output. Defaults to console capabilities.
 - `-d`, `--dry` - dry run. Skips all tests. Use with `-v` to generate a test catalog. Defaults to `false`.
 - `-e`, `--environment` - value to set the `NODE_ENV` environment variable to, defaults to 'test'.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -246,11 +246,10 @@ internals.options = function () {
             description: 'file pattern to use for locating files for coverage',
             default: null
         },
-        'coverage-predicate': {
-            type: 'string',
-            description: 'set code coverage predicates',
-            multiple: true,
-            default: null
+        'coverage-predicates': {
+            type: 'json',
+            parsePrimitives: 'strict',
+            description: 'set code coverage predicates'
         },
         'default-plan-threshold': {
             alias: 'p',
@@ -491,7 +490,7 @@ internals.options = function () {
     options.paths = argv._ ? [].concat(argv._) : options.paths;
 
     const keys = ['assert', 'bail', 'colors', 'context-timeout', 'coverage', 'coverage-exclude',
-        'coverage-path', 'coverage-all', 'coverage-flat', 'coverage-module', 'coverage-pattern', 'coverage-predicate',
+        'coverage-path', 'coverage-all', 'coverage-flat', 'coverage-module', 'coverage-pattern', 'coverage-predicates',
         'default-plan-threshold', 'dry', 'environment', 'flat', 'globals', 'grep',
         'lint', 'lint-errors-threshold', 'lint-fix', 'lint-options', 'lint-warnings-threshold',
         'linter', 'output', 'pattern', 'reporter', 'retries', 'seed', 'shuffle', 'silence', 'silent-skips',

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -246,6 +246,12 @@ internals.options = function () {
             description: 'file pattern to use for locating files for coverage',
             default: null
         },
+        'coverage-predicate': {
+            type: 'string',
+            description: 'set code coverage predicates',
+            multiple: true,
+            default: null
+        },
         'default-plan-threshold': {
             alias: 'p',
             type: 'number',
@@ -485,7 +491,7 @@ internals.options = function () {
     options.paths = argv._ ? [].concat(argv._) : options.paths;
 
     const keys = ['assert', 'bail', 'colors', 'context-timeout', 'coverage', 'coverage-exclude',
-        'coverage-path', 'coverage-all', 'coverage-flat', 'coverage-module', 'coverage-pattern',
+        'coverage-path', 'coverage-all', 'coverage-flat', 'coverage-module', 'coverage-pattern', 'coverage-predicate',
         'default-plan-threshold', 'dry', 'environment', 'flat', 'globals', 'grep',
         'lint', 'lint-errors-threshold', 'lint-fix', 'lint-options', 'lint-warnings-threshold',
         'linter', 'output', 'pattern', 'reporter', 'retries', 'seed', 'shuffle', 'silence', 'silent-skips',

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -93,7 +93,7 @@ declare namespace script {
         /**
          * Set code coverage predicates.
          */
-        readonly 'coverage-predicate'?: string[];
+        readonly 'coverage-predicates'?: { [key: string]: boolean };
 
         /**
          * File pattern to use for locating files for coverage.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -91,6 +91,11 @@ declare namespace script {
         readonly 'coverage-path'?: string;
 
         /**
+         * Set code coverage predicates.
+         */
+        readonly 'coverage-predicate'?: string[];
+
+        /**
          * File pattern to use for locating files for coverage.
          */
         readonly coveragePattern?: RegExp;

--- a/lib/modules/coverage.js
+++ b/lib/modules/coverage.js
@@ -29,6 +29,8 @@ global[internals._state] = global[internals._state] || {
 
     modules: new Set(),
 
+    predicates: new Set(),
+
     externals: new Set(),
 
     files: {},
@@ -85,6 +87,7 @@ exports.instrument = function (options) {
     }
 
     internals.state.patterns.unshift(internals.pattern(options));
+    internals.state.predicates = new Set(options['coverage-predicate'] || []);
     Transform.install(options, internals.prime);
 };
 
@@ -370,12 +373,21 @@ internals.instrument = function (filename) {
     const skipStack = [];
 
     for (const comment of tree.comments) {
-        const directive = comment.value.match(/^\s*\$lab\:coverage\:(off|on|push|pop|ignore)\$\s*$/);
+        const directive = comment.value.match(/^\s*\$lab\:coverage\:(off|on|push|pop|ignore)\$\s*(?:\$(if|not)\:(\S+)\$\s*)?$/);
         if (!directive) {
             continue;
         }
 
-        const command = directive[1];
+        const [, command, op, predicate] = directive;
+
+        if (predicate) {
+            const hasPredicate = internals.state.predicates.has(predicate);
+            const expected = op === 'if' ? true : /* 'not' */ false;
+            if (hasPredicate !== expected) {
+                continue;
+            }
+        }
+
         if (command === 'push') {
             skipStack.push(segmentSkip);
             continue;

--- a/lib/modules/coverage.js
+++ b/lib/modules/coverage.js
@@ -168,12 +168,11 @@ internals.instrument = function (filename) {
             bool: bool && node.type !== 'ConditionalExpression' && node.type !== 'LogicalExpression'
         };
 
-        // Node v14+ only
-        /*$lab:coverage:off$*/
+        // $lab:coverage:off$ $not:has-nullish$
         if (statement.bool && node.parent.operator === '??') {
             statement.bool = 'nullish';
         }
-        /*$lab:coverage:on$*/
+        // $lab:coverage:on$
 
         statements.push(statement);
 

--- a/lib/modules/coverage.js
+++ b/lib/modules/coverage.js
@@ -29,7 +29,7 @@ global[internals._state] = global[internals._state] || {
 
     modules: new Set(),
 
-    predicates: new Set(),
+    predicates: {},
 
     externals: new Set(),
 
@@ -87,7 +87,7 @@ exports.instrument = function (options) {
     }
 
     internals.state.patterns.unshift(internals.pattern(options));
-    internals.state.predicates = new Set(options['coverage-predicate'] || []);
+    internals.state.predicates = options['coverage-predicates'] || {};
     Transform.install(options, internals.prime);
 };
 
@@ -380,7 +380,7 @@ internals.instrument = function (filename) {
         const [, command, op, predicate] = directive;
 
         if (predicate) {
-            const hasPredicate = internals.state.predicates.has(predicate);
+            const hasPredicate = !!internals.state.predicates[predicate];
             const expected = op === 'if' ? true : /* 'not' */ false;
             if (hasPredicate !== expected) {
                 continue;

--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -74,7 +74,7 @@ internals.Reporter.prototype.test = function (test) {
         }
     }
     else {
-        // $lab:coverage:off$
+        // $lab:coverage:off$ $if:win32$
         const check = process.platform === 'win32' ? '\u221A' : '\u2714';
         const asterisk = process.platform === 'win32' ? '\u00D7' : '\u2716';
         // $lab:coverage:on$

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -41,7 +41,7 @@ describe('Coverage', () => {
 
     lab.before(() => {
 
-        Lab.coverage.instrument({ coveragePath: Path.join(__dirname, 'coverage'), coverageExclude: 'exclude' });
+        Lab.coverage.instrument({ coveragePath: Path.join(__dirname, 'coverage'), coverageExclude: 'exclude', 'coverage-predicate': ['testing'] });
     });
 
     it('computes sloc without comments', async () => {

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -38,7 +38,11 @@ const expect = Code.expect;
 describe('Coverage', () => {
 
     const supportsNullishCoalescing = Somever.match(process.version, '>=14');
-    Lab.coverage.instrument({ coveragePath: Path.join(__dirname, 'coverage'), coverageExclude: 'exclude' });
+
+    lab.before(() => {
+
+        Lab.coverage.instrument({ coveragePath: Path.join(__dirname, 'coverage'), coverageExclude: 'exclude' });
+    });
 
     it('computes sloc without comments', async () => {
 
@@ -257,6 +261,45 @@ describe('Coverage', () => {
         expect(cov.sloc).to.equal(5);
         expect(cov.misses).to.equal(0);
         expect(cov.hits).to.equal(5);
+    });
+
+    it('ignores marked code when predicated', async () => {
+
+        const Test = require('./coverage/ignore-predicated');
+
+        Test.method();
+
+        const cov = await Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/ignore-predicated') });
+        expect(Math.floor(cov.percent)).to.equal(100);
+        expect(cov.sloc).to.equal(4);
+        expect(cov.misses).to.equal(0);
+        expect(cov.hits).to.equal(4);
+    });
+
+    it('does not ignore marked code when predicate fails', async () => {
+
+        const Test = require('./coverage/ignore-predicated-fail');
+
+        Test.method();
+
+        const cov = await Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/ignore-predicated-fail') });
+        expect(Math.floor(cov.percent)).to.equal(75);
+        expect(cov.sloc).to.equal(4);
+        expect(cov.misses).to.equal(1);
+        expect(cov.hits).to.equal(3);
+    });
+
+    it('bypasses marked code when predicated', async () => {
+
+        const Test = require('./coverage/bypass-predicated');
+
+        Test.method();
+
+        const cov = await Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/bypass-predicated') });
+        expect(Math.floor(cov.percent)).to.equal(100);
+        expect(cov.sloc).to.equal(7);
+        expect(cov.misses).to.equal(0);
+        expect(cov.hits).to.equal(7);
     });
 
     it('bypasses marked code and reports misses correctly', async () => {

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -41,7 +41,7 @@ describe('Coverage', () => {
 
     lab.before(() => {
 
-        Lab.coverage.instrument({ coveragePath: Path.join(__dirname, 'coverage'), coverageExclude: 'exclude', 'coverage-predicate': ['testing'] });
+        Lab.coverage.instrument({ coveragePath: Path.join(__dirname, 'coverage'), coverageExclude: 'exclude', 'coverage-predicates': { testing: true } });
     });
 
     it('computes sloc without comments', async () => {

--- a/test/coverage/bypass-predicated.js
+++ b/test/coverage/bypass-predicated.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.method = function () {
+
+	// $lab:coverage:off$ $if:testing$
+	if (false ? 1 : 0) {
+		// $lab:coverage:on$ $not:testing$
+		return -1;
+	}
+
+	// $lab:coverage:on$
+	return 1;
+};

--- a/test/coverage/ignore-predicated-fail.js
+++ b/test/coverage/ignore-predicated-fail.js
@@ -1,0 +1,6 @@
+'use strict';
+
+exports.method = function () {
+
+    return true ? 1 : 0;     // $lab:coverage:ignore$ $if:unknown$
+};

--- a/test/coverage/ignore-predicated.js
+++ b/test/coverage/ignore-predicated.js
@@ -1,0 +1,6 @@
+'use strict';
+
+exports.method = function () {
+
+    return true ? 1 : 0;     // $lab:coverage:ignore$ $if:testing$
+};

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -27,7 +27,10 @@ const expect = Code.expect;
 
 describe('Reporter', () => {
 
-    Lab.coverage.instrument({ coveragePath: Path.join(__dirname, './coverage/'), coverageExclude: 'exclude' });
+    lab.before(() => {
+
+        Lab.coverage.instrument({ coveragePath: Path.join(__dirname, './coverage/'), coverageExclude: 'exclude' });
+    });
 
     it('outputs to a stream', async () => {
 


### PR DESCRIPTION
This new option is designed to help improve code coverage for platform specific features, by providing a way to optionally signal when coverage has to be disabled. It was inspired by the unconditional coverage exclusion in https://github.com/hapijs/lab/pull/1036/commits/cfbf0601749f963245f6cc00e61a89eb8e0d06a0 from #1036, added only because it is not covered when running on node v12.

I designed it as a powerful primitive, with a simple implementation footprint of about 10 lines of code. For #1036, it can enable coverage on node 14+, by adding a new `has-nullish` predicate in `.labrc.js` when running on node 14+, and revising the "off" line to: `/*$lab:coverage:off$ $not:has-nullish$*/`.

I considered allowing multiple extra predicates with an implicit `AND` condition, but it would add extra complexity to the implementation. Also, it is still possible for a user to combine multiple predicates, by creating new composite predicates, eg. `node14+win32`.

FYI, I have previously discarded a hapi feature I worked on, only because it could not work on Windows, and adding coverage bypasses would mean that I could not reliably reach 100% coverage on the other platforms. With this feature, it could have been completed.

Note, I haven't yet documented how this is used inside coverage bypass comments since the syntax might still change depending on feedback.