### PR TITLE
Revise leak detection to use fresh node globals

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -8,21 +8,4 @@ on:
 
 jobs:
   test:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu, windows, macos]
-        node: ['*', '14', '12']
-
-    runs-on: ${{ matrix.os }}-latest
-    name: ${{ matrix.os }} node@${{ matrix.node }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node }}
-          check-latest: ${{ matrix.node == '*' }}
-      - name: install
-        run: npm install
-      - name: test
-        run: npm test
+    uses: hapijs/.github/.github/workflows/ci-module.yml@master

--- a/lib/modules/leaks.js
+++ b/lib/modules/leaks.js
@@ -1,116 +1,22 @@
 'use strict';
 
+const Events = require('events');
+const WorkerThreads = require('worker_threads');
+
 const internals = {
     allowed: [
         '_labScriptRun',                // Lab global to detect script executions
 
         // Enumerable globals
 
-        'setTimeout',
-        'setInterval',
-        'setImmediate',
-        'clearTimeout',
-        'clearInterval',
-        'clearImmediate',
-        'console',
-        'AbortController',
-        'AbortSignal',
-        'AggregateError',
-        'Buffer',
-        'performance',
-        'process',
-        'global',
         'GLOBAL',
-        'globalThis',
         'root',
         'constructor',
-        'ArrayBuffer',
-        'Int8Array',
-        'Uint8Array',
-        'Uint8ClampedArray',
-        'Int16Array',
-        'Uint16Array',
-        'Int32Array',
-        'Uint32Array',
-        'Float32Array',
-        'Float64Array',
-        'DataView',
         '__$$labCov',
         'gc',
-        'MessageChannel',
-        'MessageEvent',
-        'MessagePort',
-        'structuredClone',
-        'fetch',
-
-        // Non-Enumerable globals
-
-        'Array',
-        'atob',
-        'btoa',
-        'isNaN',
-        'ReferenceError',
-        'Number',
-        'RangeError',
-        'EvalError',
-        'Event',
-        'EventTarget',
-        'FinalizationRegistry',
-        'Function',
-        'isFinite',
-        'Object',
-        'undefined',
-        'Date',
-        'SyntaxError',
-        'String',
-        'eval',
-        'parseFloat',
-        'unescape',
-        'Error',
-        'encodeURI',
-        'NaN',
-        'RegExp',
-        'encodeURIComponent',
-        'Math',
-        'decodeURI',
-        'parseInt',
-        'Infinity',
-        'escape',
-        'decodeURIComponent',
-        'JSON',
-        'TypeError',
-        'URIError',
-        'Boolean',
-        'Intl',
-        'Map',
-        'Promise',
-        'Set',
-        'Symbol',
-        'WeakMap',
-        'WeakRef',
-        'WeakSet',
-        'DOMException',
-        'Blob',
-        'BroadcastChannel',
-        'FormData',
-        'Headers',
-        'Request',
-        'Response',
 
         // Sometime
 
-        'Atomics',
-        'Proxy',
-        'Reflect',
-        'SharedArrayBuffer',
-        'WebAssembly',
-        'URL',
-        'URLSearchParams',
-        'TextEncoder',
-        'TextDecoder',
-        'BigInt',
-        'BigUint64Array',
-        'BigInt64Array',
         'DTRACE_HTTP_SERVER_RESPONSE',
         'DTRACE_HTTP_SERVER_REQUEST',
         'DTRACE_HTTP_CLIENT_RESPONSE',
@@ -125,7 +31,6 @@ const internals = {
         'COUNTER_HTTP_SERVER_RESPONSE',
         'COUNTER_HTTP_CLIENT_REQUEST',
         'COUNTER_HTTP_CLIENT_RESPONSE',
-        'queueMicrotask',
 
         // External symbols
 
@@ -133,7 +38,6 @@ const internals = {
     ],
 
     symbols: [
-        Symbol.toStringTag,
         Symbol.for('@hapi/lab/coverage/_state')
     ],
 
@@ -166,9 +70,12 @@ const internals = {
 };
 
 
-exports.detect = function (customGlobals, options = {}) {
+exports.detect = async function (customGlobals, options = {}) {
 
-    let allowed = internals.allowed;
+    const nodeGlobals = await internals.getNodeGlobals();
+
+    let allowed = [...internals.allowed, ...nodeGlobals.allowed];
+
     if (customGlobals) {
         allowed = [...allowed, ...customGlobals];
     }
@@ -192,7 +99,8 @@ exports.detect = function (customGlobals, options = {}) {
 
     for (const sym of Object.getOwnPropertySymbols(global)) {
         if (!internals.symbols.includes(sym) &&
-            !symbols.includes(sym.toString())) {
+            !symbols.includes(sym.toString()) &&
+            !nodeGlobals.symbols.includes(sym.toString())) {
 
             leaks.push(sym.toString());
         }
@@ -200,3 +108,19 @@ exports.detect = function (customGlobals, options = {}) {
 
     return leaks;
 };
+
+internals.getNodeGlobals = async () => {
+
+    const nodeGlobalsWorker = new WorkerThreads.Worker(__filename);
+    const [nodeGlobals] = await Events.once(nodeGlobalsWorker, 'message');
+
+    return nodeGlobals;
+};
+
+if (!WorkerThreads.isMainThread) {
+    // When this module is used as a worker, it posts back global property names and symbols
+    WorkerThreads.parentPort.postMessage({
+        allowed: Object.getOwnPropertyNames(globalThis),
+        symbols: Object.getOwnPropertySymbols(globalThis).map(String)
+    });
+}

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -68,7 +68,7 @@ exports.report = async function (scripts, options) {
             const result = await exports.execute(scripts, settings, reporter);
 
             if (settings.leaks) {
-                result.leaks = Modules.leaks.detect(settings.globals, settings);
+                result.leaks = await Modules.leaks.detect(settings.globals, settings);
             }
 
             if (settings.coverage) {

--- a/test/leaks.js
+++ b/test/leaks.js
@@ -52,50 +52,50 @@ describe('Leaks', () => {
         });
     });
 
-    it('identifies global leaks', () => {
+    it('identifies global leaks', async () => {
 
         testedKeys.push('abc');
         global.abc = 1;
 
-        const leaks = Lab.leaks.detect();
+        const leaks = await Lab.leaks.detect();
         expect(leaks.length).to.equal(1);
     });
 
-    it('identifies global leaks (symbol)', () => {
+    it('identifies global leaks (symbol)', async () => {
 
         const symbol = Symbol('test');
         global[symbol] = 1;
 
-        const leaks = Lab.leaks.detect();
+        const leaks = await Lab.leaks.detect();
         expect(leaks.length).to.equal(1);
         delete global[symbol];
     });
 
-    it('identifies global leaks for non-enumerable properties', () => {
+    it('identifies global leaks for non-enumerable properties', async () => {
 
         testedKeys.push('abc');
         Object.defineProperty(global, 'abc', { enumerable: false, configurable: true, value: 1 });
 
-        const leaks = Lab.leaks.detect();
+        const leaks = await Lab.leaks.detect();
         expect(leaks.length).to.equal(1);
     });
 
-    it('verifies no leaks', () => {
+    it('verifies no leaks', async () => {
 
-        const leaks = Lab.leaks.detect();
+        const leaks = await Lab.leaks.detect();
         expect(leaks.length).to.equal(0);
     });
 
-    it('ignores DTrace globals', () => {
+    it('ignores DTrace globals', async () => {
 
         testedKeys.push('DTRACE_HTTP_SERVER_RESPONSE');
         global.DTRACE_HTTP_SERVER_RESPONSE = global.DTRACE_HTTP_SERVER_RESPONSE || 1;
 
-        const leaks = Lab.leaks.detect();
+        const leaks = await Lab.leaks.detect();
         expect(leaks.length).to.equal(0);
     });
 
-    it('works with missing DTrace globals', () => {
+    it('works with missing DTrace globals', async () => {
 
         delete global.DTRACE_HTTP_SERVER_RESPONSE;
         delete global.DTRACE_HTTP_CLIENT_REQUEST;
@@ -106,12 +106,12 @@ describe('Leaks', () => {
         delete global.DTRACE_NET_SOCKET_WRITE;
         delete global.DTRACE_NET_SERVER_CONNECTION;
 
-        const leaks = Lab.leaks.detect();
+        const leaks = await Lab.leaks.detect();
 
         expect(leaks.length).to.equal(0);
     });
 
-    it('ignores Counter globals', { skip: process.platform === 'win32' && Semver.gte(process.version, '11.0.0') }, () => {
+    it('ignores Counter globals', { skip: process.platform === 'win32' && Semver.gte(process.version, '11.0.0') }, async () => {
 
         const counterGlobals = internals.counterGlobals;
         testedKeys = internals.counterGlobals;
@@ -121,11 +121,11 @@ describe('Leaks', () => {
             global[counterGlobal] = global[counterGlobal] || 1;
         });
 
-        const leaks = Lab.leaks.detect();
+        const leaks = await Lab.leaks.detect();
         expect(leaks.length).to.equal(0);
     });
 
-    it('handles case where Counter globals do not exist', () => {
+    it('handles case where Counter globals do not exist', async () => {
 
         const counterGlobals = internals.counterGlobals;
         const originalValues = {};
@@ -136,7 +136,7 @@ describe('Leaks', () => {
             delete global[counterGlobal];
         });
 
-        const leaks = Lab.leaks.detect();
+        const leaks = await Lab.leaks.detect();
         expect(leaks.length).to.equal(0);
 
         for (const counterGlobal in originalValues) {
@@ -144,20 +144,20 @@ describe('Leaks', () => {
         }
     });
 
-    it('ignores WebAssembly global', () => {
+    it('ignores WebAssembly global', async () => {
 
         testedKeys.push('WebAssembly');
         global.WebAssembly = global.WebAssembly || 1;
 
-        const leaks = Lab.leaks.detect();
+        const leaks = await Lab.leaks.detect();
         expect(leaks.length).to.equal(0);
     });
 
-    it('identifies custom globals', () => {
+    it('identifies custom globals', async () => {
 
         testedKeys.push('abc');
         global.abc = 1;
-        const leaks = Lab.leaks.detect(['abc']);
+        const leaks = await Lab.leaks.detect(['abc']);
         expect(leaks.length).to.equal(0);
     });
 });


### PR DESCRIPTION
By using a worker, we are able to pretty efficiently get a fresh list of property names and symbols from node's global context.  I also updated the CI config so that it only tests node v12, v14, and v16.  The next major of lab will support v14, v16, and v18.

Resolves #1022 