### PR TITLE
Support node v18

### DIFF
--- a/lib/modules/coverage.js
+++ b/lib/modules/coverage.js
@@ -9,10 +9,10 @@ const Path = require('path');
 
 const ESLint = require('eslint');
 const ESLintParser = require('@babel/eslint-parser');
-const SourceMap = require('source-map');
 const SourceMapSupport = require('source-map-support');
 
 const Eslintrc = require('../linter/.eslintrc');
+const SourceMap = require('../source-map');
 const Transform = require('./transform');
 
 const internals = {

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -5,9 +5,9 @@ const Path = require('path');
 
 const Handlebars = require('handlebars');
 const Hoek = require('@hapi/hoek');
-const SourceMap = require('source-map');
 const SourceMapSupport = require('source-map-support');
 
+const SourceMap = require('../source-map');
 
 const internals = {};
 

--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const Utils = require('./utils');
+
+// An unfortunate quirk of source-maps is that it detects
+// whether it's a node or browser environment based on the
+// presence of fetch(), which is now a global in node v18.
+const stash = Utils.stashProperty(globalThis, 'fetch');
+
+module.exports = require('source-map');
+
+Utils.restoreProperty(globalThis, 'fetch', stash);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,3 +15,18 @@ exports.position = function (err) {
         column: parseInt(match[2], 10)
     };
 };
+
+exports.stashProperty = (obj, property) => {
+
+    const descriptor = Object.getOwnPropertyDescriptor(obj, property);
+    delete obj[property];
+
+    return descriptor;
+};
+
+exports.restoreProperty = (obj, property, descriptor) => {
+
+    if (descriptor) {
+        Object.defineProperty(obj, property, descriptor);
+    }
+};

--- a/test/utils.js
+++ b/test/utils.js
@@ -22,4 +22,64 @@ describe('Utils', () => {
             expect(Utils.position({ stack: '' })).to.equal({});
         });
     });
+
+    describe('stashProperty() and restoreProperty()', () => {
+
+        it('stashes and restores an existing property', () => {
+
+            const obj = { x: 1 };
+
+            expect(obj).to.contain('x');
+
+            const stash = Utils.stashProperty(obj, 'x');
+
+            expect(obj).to.not.contain('x');
+
+            Utils.restoreProperty(obj, 'x', stash);
+
+            expect(obj).to.contain('x');
+            expect(obj.x).to.equal(1);
+        });
+
+        it('stashes and restores a non-existing property', () => {
+
+            const obj = { x: 1 };
+
+            expect(obj).to.not.contain('y');
+
+            const stash = Utils.stashProperty(obj, 'y');
+
+            expect(obj).to.not.contain('y');
+
+            Utils.restoreProperty(obj, 'y', stash);
+
+            expect(obj).to.not.contain('y');
+        });
+
+        it('preserves descriptor', () => {
+
+            const obj = {};
+            Object.defineProperty(obj, 'x', {
+                value: 1,
+                enumerable: false,
+                configurable: true
+            });
+
+            expect(obj).to.contain('x');
+
+            const stash = Utils.stashProperty(obj, 'x');
+
+            expect(obj).to.not.contain('x');
+
+            Utils.restoreProperty(obj, 'x', stash);
+
+            expect(obj).to.contain('x');
+
+            expect(Object.getOwnPropertyDescriptor(obj, 'x')).to.contain({
+                value: 1,
+                enumerable: false,
+                configurable: true
+            });
+        });
+    });
 });


### PR DESCRIPTION
This brings node v18 support to lab v25.  Unfortunately this PR is a little ugly— there are two things going on here:
 - The source-map library doesn't function properly on node v18 because it thinks it's in a browser environment due to the existence of `fetch()` (see https://github.com/mozilla/source-map/issues/454).  To get around this I've implemented a hack to remove and then replace `fetch()` as carefully as possible while requiring the source-maps module.  Other options I considered were using source-maps beta version, or moving to the @jridgewell/trace-mapping module.  I didn't use the beta version both because it's a beta and because it hasn't been touched in years, so there's a chance it will never leave beta.  I didn't move to @jridgewell/trace-mapping because I wasn't able to assess whether we'd be able to use it for lab's HTML reporter, which uses a source-maps API that is not faithfully recreated in @jridgewell/trace-mapping.
 - ~~I added node v18 globals to leak detection.  These should be able to be removed once #1044 lands in the v25 branch.~~  I believe that we can also get rid of some other globals at that time that to my knowledge are no longer in any version of node such as the `DTRACE_*` globals.