### PR TITLE
Fix coverage ignore flag when ts comments are removed

### DIFF
--- a/lib/modules/typescript.js
+++ b/lib/modules/typescript.js
@@ -26,6 +26,7 @@ internals.transform = function (content, fileName) {
         options.inlineSourceMap = true;
         options.inlineSources = true;
         options.module = Typescript.ModuleKind.CommonJS;
+        options.removeComments = false;
         internals.configs.set(configFile, options);
     }
 

--- a/test/cli_typescript/api.ts
+++ b/test/cli_typescript/api.ts
@@ -4,3 +4,5 @@ export function add(a: number, b: number) {
 
     return a + b;
 }
+
+export const X = new (Date || Date)(); // $lab:coverage:ignore$

--- a/test/cli_typescript/tsconfig.json
+++ b/test/cli_typescript/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "target": "es2021",
         "module": "commonjs",
-        "moduleResolution": "node"
+        "moduleResolution": "node",
+        "removeComments": true
     }
 }


### PR DESCRIPTION
When the tsconfig is set to remove comments, it also removes coverage skipping comments. This overrides it for testing only.