### PR TITLE
Update target to ES2020 to match node 14+

### DIFF
--- a/lib/modules/types.js
+++ b/lib/modules/types.js
@@ -18,7 +18,7 @@ const internals = {
         jsx: Ts.JsxEmit.React,
         lib: ['lib.es2020.d.ts'],
         module: Ts.ModuleKind.CommonJS,
-        target: Ts.ScriptTarget.ES2019,
+        target: Ts.ScriptTarget.ES2020,
         moduleResolution: Ts.ModuleResolutionKind.NodeJs
     },
 


### PR DESCRIPTION
I updated the config to produce output with less transpiling.

See https://stackoverflow.com/a/61305579/248062 for details. Note that I use the commonjs variant, since we don't fully support ESM.