### PR TITLE
Upgrade dependences

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "dependencies": {
         "@babel/core": "^7.16.0",
         "@babel/eslint-parser": "^7.16.0",
-        "@hapi/bossy": "5.x.x",
+        "@hapi/bossy": "^6.0.0",
         "@hapi/eslint-plugin": "^5.1.0",
-        "@hapi/hoek": "9.x.x",
+        "@hapi/hoek": "^10.0.0",
         "diff": "^5.0.0",
         "eslint": "8.x.x",
         "find-rc": "4.x.x",
@@ -46,15 +46,15 @@
         }
     },
     "devDependencies": {
-        "@hapi/code": "8.x.x",
-        "@hapi/somever": "^3.0.1",
+        "@hapi/code": "^9.0.0",
+        "@hapi/somever": "^4.0.0",
         "@types/node": "^17.0.23",
         "cpr": "3.x.x",
         "lab-event-reporter": "1.x.x",
         "rimraf": "3.x.x",
         "semver": "7.x.x",
         "typescript": "^4.5.4",
-        "tsconfig-paths": "^3.14.1"
+        "tsconfig-paths": "^4.0.0"
     },
     "bin": {
         "lab": "./bin/lab"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "@babel/core": "^7.16.0",
         "@babel/eslint-parser": "^7.16.0",
         "@hapi/bossy": "^6.0.0",
-        "@hapi/eslint-plugin": "^5.1.0",
+        "@hapi/eslint-plugin": "^6.0.0",
         "@hapi/hoek": "^10.0.0",
         "diff": "^5.0.0",
         "eslint": "8.x.x",


### PR DESCRIPTION
Upgrades to hapi dependencies tested on node v14-v18 for lab v25.  Additional updates of some other dependencies.

If this looks good, this will be the last work to land in v25.0.0 👍 