### PR TITLE
Deal with `Symbol(undici.globalDispatcher.1)` in Node.js 18+

### DIFF
--- a/lib/modules/leaks.js
+++ b/lib/modules/leaks.js
@@ -118,6 +118,11 @@ internals.getNodeGlobals = async () => {
 };
 
 if (!WorkerThreads.isMainThread) {
+
+    // Accessing FormData does a lazy require of undici inside Node.js 18+, which in turn exposes
+    // the `Symbol(undici.globalDispatcher.1)`. In earlier Node.js versions this is a no-op.
+    typeof FormData;
+
     // When this module is used as a worker, it posts back global property names and symbols
     WorkerThreads.parentPort.postMessage({
         allowed: Object.getOwnPropertyNames(globalThis),

--- a/test/leaks.js
+++ b/test/leaks.js
@@ -153,6 +153,15 @@ describe('Leaks', () => {
         expect(leaks.length).to.equal(0);
     });
 
+    it('ignores undici global', async () => {
+
+        // trigger a lazy require of Undici, where supported, to expose a `Symbol(undici.globalDispatcher.1)`
+        typeof FormData;
+
+        const leaks = await Lab.leaks.detect();
+        expect(leaks.length).to.equal(0);
+    });
+
     it('identifies custom globals', async () => {
 
         testedKeys.push('abc');


### PR DESCRIPTION
Took a stab at it - fixes https://github.com/hapijs/lab/issues/1056.

Happy to re-do, if there's smarter options.