### PR TITLE
Always lint .ts

### DIFF
--- a/lib/linter/index.js
+++ b/lib/linter/index.js
@@ -33,6 +33,10 @@ exports.lint = async function () {
 
     if (!configuration.extensions) {
         configuration.extensions = ['.js', '.cjs', '.mjs'];
+
+        if (configuration.typescript) {
+            configuration.extensions.push('.ts');
+        }
     }
 
     let results;


### PR DESCRIPTION
Closes https://github.com/hapijs/lab/issues/1065

~~I took the simpler approach here - an alternative would be to only add `.ts` when `--typescript` is set, but I figure there's probably no harm in always doing this?~~

Had to hide this behind the `--typescript` flag, because otherwise it reports issues with `*.ts` files available in lab itself - and resolving those needs a new eslint config with typescript parser.