### PR TITLE
Make report an allow list

### DIFF
--- a/lib/modules/types.js
+++ b/lib/modules/types.js
@@ -30,18 +30,7 @@ const internals = {
     ],
 
     report: [
-        2304,                                       // Cannot find name
-        2345,                                       // Argument type is not assignable to parameter type
-        2339,                                       // Property does not exist on type
-        2540,                                       // Cannot assign to readonly property
-        2322,                                       // Type is not assignable to other type
-        2314,                                       // Generic type requires type arguments
-        2554,                                       // Expected arguments but got other
-        2559,                                       // Type T has no properties in common with type U
-        2769,                                       // No overload matches this call
-        2673,                                       // Constructor of class is private
-        2674,                                       // Constructor of class is protected
-        2820                                        // Type T is not assignable to type U. Did you mean V?
+        1005                                        // Syntax error
     ]
 };
 
@@ -162,7 +151,7 @@ internals.ignore = function (diagnostic, expectedErrors) {
         return true;
     }
 
-    if (!internals.report.includes(diagnostic.code)) {
+    if (internals.report.includes(diagnostic.code)) {
         return false;
     }
 


### PR DESCRIPTION
For some reason the "report" list, which is used limit the errors that can be inside `expect.error()`, is a deny list. This causes problems when upgrading typescript, which can report new error codes for an existing test case. Since the new error code is not a part of the deny list, it won't be handled by `expect.error()` checks, causing the expect to fail, even though it still errors.

This can be seen in `@hapi/hoek`, where updating typescript to v5.3.3, will cause the types check to fail:

```
	test/index.ts:35:38: Object literal may only specify known properties, and 'unknown' does not exist in type 'Options'.
	test/index.ts:58:30: Object literal may only specify known properties, and 'unknown' does not exist in type 'Options'.
	test/index.ts:74:49: Object literal may only specify known properties, and 'unknown' does not exist in type 'Options'.
	test/index.ts:183:40: Object literal may only specify known properties, and 'unknown' does not exist in type 'Options'.
	test/index.ts:201:50: Object literal may only specify known properties, and 'unknown' does not exist in type 'Options'.
	test/index.ts:35:0: Expected an error
	test/index.ts:58:0: Expected an error
	test/index.ts:74:0: Expected an error
	test/index.ts:183:0: Expected an error
	test/index.ts:201:0: Expected an error
```

We could add this new code to the list, but it will be a never ending a cat and mouse game. Additionally, there are likely many other codes that would make sense to be `expect.error()`-able.

The best solution seems to be to change it to an allow list. In this case there is only one code `1005`, which [is already tested for](https://github.com/hapijs/lab/blob/aa39557a97a9bc605807b14d7c4c10a9eb501ffa/test/types/errors/test/syntax.ts#L8-L9) in the ["identifies errors" test case](https://github.com/hapijs/lab/blob/aa39557a97a9bc605807b14d7c4c10a9eb501ffa/test/types.js#L60-L138).