### PR TITLE
fix: 🐛 place nice with commonjs

### DIFF
--- a/lib/modules/types.js
+++ b/lib/modules/types.js
@@ -19,7 +19,8 @@ const internals = {
         lib: ['lib.es2020.d.ts'],
         module: Ts.ModuleKind.CommonJS,
         target: Ts.ScriptTarget.ES2020,
-        moduleResolution: Ts.ModuleResolutionKind.NodeJs
+        moduleResolution: Ts.ModuleResolutionKind.NodeJs,
+        allowSyntheticDefaultImports: true
     },
 
     // Codes from https://github.com/microsoft/TypeScript/blob/master/src/compiler/diagnosticMessages.json

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@hapi/lab",
     "description": "Test utility",
-    "version": "25.2.0",
+    "version": "25.2.1",
     "repository": "git://github.com/hapijs/lab",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",


### PR DESCRIPTION
Current TS config doesn't allow one to use normal ESM imports because they don't have a default export. This config setup should allow it to play nice with modules that setup DTS files without a default exports (like a number of Hapi modules do)