### PR TITLE
fix: lint typescript files

### DIFF
--- a/lib/linter/index.js
+++ b/lib/linter/index.js
@@ -39,6 +39,10 @@ exports.lint = async function () {
         }
     }
 
+    if (configuration.typescript) {
+        delete configuration.typescript;
+    }
+
     let results;
     try {
         const eslint = new Eslint.ESLint(configuration);

--- a/lib/modules/lint.js
+++ b/lib/modules/lint.js
@@ -26,6 +26,10 @@ exports.lint = function (settings) {
 
         linterOptions.fix = settings['lint-fix'];
 
+        if (settings.typescript) {
+            linterOptions.typescript = true;
+        }
+
         const child = ChildProcess.fork(linterPath, [JSON.stringify(linterOptions)], { cwd: settings.lintingPath });
         child.once('message', (message) => {
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "@hapi/code": "^9.0.0",
         "@hapi/somever": "^4.0.0",
         "@types/node": "^18.11.17",
+        "@typescript-eslint/parser": "^5.62.0",
         "cpr": "3.x.x",
         "lab-event-reporter": "1.x.x",
         "semver": "7.x.x",

--- a/test/lint/eslint/typescript/.eslintrc.cjs
+++ b/test/lint/eslint/typescript/.eslintrc.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+    parser: '@typescript-eslint/parser'
+};

--- a/test/lint/eslint/typescript/fail.ts
+++ b/test/lint/eslint/typescript/fail.ts
@@ -1,0 +1,7 @@
+const internals = {};
+
+
+export const method = function (value) {
+
+	return value
+};

--- a/test/linters.js
+++ b/test/linters.js
@@ -118,6 +118,25 @@ describe('Linters - eslint', () => {
         ]);
     });
 
+    it('should lint typescript files in a folder', async () => {
+
+        const path = Path.join(__dirname, 'lint', 'eslint', 'typescript');
+        const result = await Linters.lint({ lintingPath: path, linter: 'eslint', typescript: true });
+
+        expect(result).to.include('lint');
+
+        const eslintResults = result.lint;
+        expect(eslintResults).to.have.length(2);
+
+        const checkedFile = eslintResults.find(({ filename }) => filename.endsWith('.ts'));
+        expect(checkedFile).to.include({ filename: Path.join(path, 'fail.ts') });
+        expect(checkedFile.errors).to.include([
+            { line: 1, severity: 'ERROR', message: `strict - Use the global form of 'use strict'.` },
+            { line: 6, severity: 'ERROR', message: 'indent - Expected indentation of 4 spaces but found 1 tab.' },
+            { line: 6, severity: 'ERROR', message: 'semi - Missing semicolon.' }
+        ]);
+    });
+
     it('displays success message if no issues found', async () => {
 
         const path = Path.join(__dirname, 'lint', 'eslint', 'clean');


### PR DESCRIPTION
It looks like https://github.com/hapijs/lab/pull/1069 was counting on the fact that lab's options were forwarded, but they're not. I guess this will potentially break some of our modules with existing typescript files in their tests.

Note: I had to stick to typescript-eslint/parser@5 because of node 14.