### PR TITLE
fix: coverage for arrow functions returning literals

### DIFF
--- a/lib/linter/index.js
+++ b/lib/linter/index.js
@@ -39,6 +39,10 @@ exports.lint = async function () {
         }
     }
 
+    if (configuration.typescript) {
+        delete configuration.typescript;
+    }
+
     let results;
     try {
         const eslint = new Eslint.ESLint(configuration);

--- a/lib/modules/coverage.js
+++ b/lib/modules/coverage.js
@@ -307,7 +307,7 @@ internals.instrument = function (filename, ctx) {
             node.set(`(global.__$$labCov._statement(\'${filename}\',${left},${line},${node.left.source()})${node.operator}global.__$$labCov._statement(\'${filename}\',${right},${line},${node.right.source()}))`);
         }
         else if (node.parent?.type === 'ArrowFunctionExpression' &&
-            node.type.includes('Expression')) {
+            (node.type.includes('Expression') || node.type === 'Literal')) {
 
             const id = addStatement(line, node, false);
 

--- a/lib/modules/lint.js
+++ b/lib/modules/lint.js
@@ -26,6 +26,10 @@ exports.lint = function (settings) {
 
         linterOptions.fix = settings['lint-fix'];
 
+        if (settings.typescript) {
+            linterOptions.typescript = true;
+        }
+
         const child = ChildProcess.fork(linterPath, [JSON.stringify(linterOptions)], { cwd: settings.lintingPath });
         child.once('message', (message) => {
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "@hapi/code": "^9.0.0",
         "@hapi/somever": "^4.0.0",
         "@types/node": "^18.11.17",
+        "@typescript-eslint/parser": "^5.62.0",
         "cpr": "3.x.x",
         "lab-event-reporter": "1.x.x",
         "semver": "7.x.x",

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -484,12 +484,13 @@ describe('Coverage', () => {
         results.push(Test.method11(5, 10));
         results.push(Test.method11(0, 10));
         results.push(Test.method11Partial(5, 10));
+        results.push(Test.method12());
 
         const cov = await Lab.coverage.analyze({ coveragePath: Path.join(__dirname, 'coverage/single-line-functions') });
         const source = cov.files[0].source;
         const missedLines = Object.keys(source).filter((lineNumber) => source[lineNumber].miss);
-        expect(results).to.equal([7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 5, 10, 5]);
-        expect(missedLines).to.equal(['12', '15', '21', '27', '30', '33', '39', '46', '50', '53', '56']);
+        expect(results).to.equal([7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 5, 10, 5, 42]);
+        expect(missedLines).to.equal(['12', '15', '21', '27', '30', '33', '39', '46', '50', '53', '56', '59']);
     });
 
     it('should measure missing coverage on trailing function declarations correctly', async () => {

--- a/test/coverage/single-line-functions.js
+++ b/test/coverage/single-line-functions.js
@@ -54,3 +54,6 @@ exports.method10NotCalled = (a, b) => exports.method9NotCalled(a, b);
 
 exports.method11 = (a, b) => a || b;
 exports.method11Partial = (a, b) => a || b;
+
+exports.method12 = () => 42;
+exports.method12NotCalled = () => 42;

--- a/test/lint/eslint/typescript/.eslintrc.cjs
+++ b/test/lint/eslint/typescript/.eslintrc.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+    parser: '@typescript-eslint/parser'
+};

--- a/test/lint/eslint/typescript/fail.ts
+++ b/test/lint/eslint/typescript/fail.ts
@@ -1,0 +1,7 @@
+const internals = {};
+
+
+export const method = function (value) {
+
+	return value
+};

--- a/test/linters.js
+++ b/test/linters.js
@@ -118,6 +118,25 @@ describe('Linters - eslint', () => {
         ]);
     });
 
+    it('should lint typescript files in a folder', async () => {
+
+        const path = Path.join(__dirname, 'lint', 'eslint', 'typescript');
+        const result = await Linters.lint({ lintingPath: path, linter: 'eslint', typescript: true });
+
+        expect(result).to.include('lint');
+
+        const eslintResults = result.lint;
+        expect(eslintResults).to.have.length(2);
+
+        const checkedFile = eslintResults.find(({ filename }) => filename.endsWith('.ts'));
+        expect(checkedFile).to.include({ filename: Path.join(path, 'fail.ts') });
+        expect(checkedFile.errors).to.include([
+            { line: 1, severity: 'ERROR', message: `strict - Use the global form of 'use strict'.` },
+            { line: 6, severity: 'ERROR', message: 'indent - Expected indentation of 4 spaces but found 1 tab.' },
+            { line: 6, severity: 'ERROR', message: 'semi - Missing semicolon.' }
+        ]);
+    });
+
     it('displays success message if no issues found', async () => {
 
         const path = Path.join(__dirname, 'lint', 'eslint', 'clean');


### PR DESCRIPTION
Arrow functions returning literal are declared as covered when they're not.