### PR TITLE
fix: guard parent access in `addTsEsmHook` for ESM-to-CJS sub-dependency resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@
 **/.idea
 
 !test/cli_coverage/node_modules
+!test/cli_typescript_esm_dep/node_modules
 test_runner
 test/cli/test/leaks.js

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -89,7 +89,7 @@ internals.addTsEsmHook = function () {
 
     Module._resolveFilename = function (request, parent, ...rest) {
 
-        if (request.endsWith('.js') && parent && parent.filename && (parent.filename.endsWith('.ts') || parent.filename.endsWith('.tsx'))) {
+        if (request.endsWith('.js') && parent && (parent.filename.endsWith('.ts') || parent.filename.endsWith('.tsx'))) {
             const target = Path.join(parent.path, request);
             const tsEquivalent = `${target.slice(0, -3)}.ts`;
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -89,7 +89,7 @@ internals.addTsEsmHook = function () {
 
     Module._resolveFilename = function (request, parent, ...rest) {
 
-        if (request.endsWith('.js') && (parent.filename.endsWith('.ts') || parent.filename.endsWith('.tsx'))) {
+        if (request.endsWith('.js') && parent && parent.filename && (parent.filename.endsWith('.ts') || parent.filename.endsWith('.tsx'))) {
             const target = Path.join(parent.path, request);
             const tsEquivalent = `${target.slice(0, -3)}.ts`;
 

--- a/test/cli_typescript_esm_dep/node_modules/cjs-helper/lib/utils.js
+++ b/test/cli_typescript_esm_dep/node_modules/cjs-helper/lib/utils.js
@@ -1,0 +1,6 @@
+'use strict';
+
+exports.double = function (n) {
+
+    return n * 2;
+};

--- a/test/cli_typescript_esm_dep/node_modules/cjs-helper/package.json
+++ b/test/cli_typescript_esm_dep/node_modules/cjs-helper/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "cjs-helper",
+    "version": "1.0.0"
+}

--- a/test/cli_typescript_esm_dep/node_modules/esm-dep/index.js
+++ b/test/cli_typescript_esm_dep/node_modules/esm-dep/index.js
@@ -1,0 +1,6 @@
+import { double } from 'cjs-helper/lib/utils.js';
+
+export function add(a, b) {
+
+    return double(a) - a + b;
+}

--- a/test/cli_typescript_esm_dep/node_modules/esm-dep/package.json
+++ b/test/cli_typescript_esm_dep/node_modules/esm-dep/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "esm-dep",
+    "version": "1.0.0",
+    "type": "module",
+    "exports": {
+        ".": "./index.js"
+    },
+    "dependencies": {
+        "cjs-helper": "1.0.0"
+    }
+}

--- a/test/cli_typescript_esm_dep/package.json
+++ b/test/cli_typescript_esm_dep/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }

--- a/test/cli_typescript_esm_dep/simple.ts
+++ b/test/cli_typescript_esm_dep/simple.ts
@@ -1,0 +1,15 @@
+import { expect } from '@hapi/code';
+import * as _Lab from '../../test_runner/index.js';
+
+import { add } from 'esm-dep';
+
+
+const { describe, it } = exports.lab = _Lab.script();
+
+describe('Test CLI', () => {
+
+    it('imports from an ESM dependency', () => {
+
+        expect(add(1, 1)).to.equal(2);
+    });
+});

--- a/test/cli_typescript_esm_dep/tsconfig.json
+++ b/test/cli_typescript_esm_dep/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "target": "es2021",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "removeComments": true
+    }
+}

--- a/test/typescript.js
+++ b/test/typescript.js
@@ -4,6 +4,7 @@ const Fs = require('fs');
 const Path = require('path');
 
 const Code = require('@hapi/code');
+const Somever = require('@hapi/somever');
 const _Lab = require('../test_runner');
 const RunCli = require('./run_cli');
 const Ts = require('typescript');
@@ -42,6 +43,15 @@ describe('TypeScript', () => {
 
         // Ensure scripts are run together, not independently
         expect(result.output.split('Test duration').length - 1).to.equal(1);
+    });
+
+    it('supports TypeScript with ESM dependencies', { skip: !Somever.match(process.version, '>=20') }, async () => {
+
+        process.chdir(Path.join(__dirname, 'cli_typescript_esm_dep'));
+        const result = await RunCli(['simple.ts', '-m', '2000', '--typescript']);
+        expect(result.errorOutput).to.equal('');
+        expect(result.code).to.equal(0);
+        expect(result.output).to.contain('1 tests complete');
     });
 
     it('handles errors', async () => {


### PR DESCRIPTION
**What:** Adds a null guard for `parent` in `internals.addTsEsmHook()` (`lib/cli.js`).


**Why:** When running TypeScript tests (`--typescript`) in an ESM project that imports from an ESM package with CJS sub-dependencies, the crash path is: `require.extensions['.ts']` → `Module._compile` → `loadESMFromCJS` → ESM translators → CJS sub-dependency resolution → `Module._resolveFilename` with `parent === undefined`. The current code accesses `parent.filename` unconditionally, causing `TypeError: Cannot read properties of undefined (reading 'filename')`.


**Fix:** Guard the `parent` access so that when `parent` is `undefined` (ESM-to-CJS transition context), the hook falls through to the original `_resolveFilename`, which handles the resolution natively.


**Test:** Added `test/cli_typescript_esm_dep/` fixture — a TypeScript ESM test that imports from an ESM package which has a CJS sub-dependency (two-layer structure required to trigger the crash). Without the fix, this crashes. With the fix, it passes.

**Ref:** fixes #1086 